### PR TITLE
Fix font difference between Firefox and Chrome

### DIFF
--- a/scss/index.scss
+++ b/scss/index.scss
@@ -18,6 +18,10 @@ $green: #00cf92 !default;
 @import "../public/PTMono-Regular.ttf";
 
 // Global CSS
+body{
+  font-optical-sizing: none;
+}
+
 .outline-danger{
   border: 1px solid rgba(220,53,69, 1);
   &:focus{

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -19,7 +19,10 @@ $green: #00cf92 !default;
 
 // Global CSS
 body{
-  font-optical-sizing: none;
+  /* This fix the font difference between browsers
+   * https://github.com/garageScript/c0d3-app/pull/134
+   */
+  font-optical-sizing: none; 
 }
 
 .outline-danger{


### PR DESCRIPTION
This font difference created a UI bug with Firefox

<img width="755" alt="Screen Shot 2020-04-15 at 10 54 52 PM" src="https://user-images.githubusercontent.com/25457563/79419773-5192eb80-7f6c-11ea-935c-eb032b199dd0.png">

First I discover that Roboto font do not work well with Firefox. [Reddit source](https://www.reddit.com/r/firefox/comments/71pgin/why_doesnt_firefox_use_roboto_font_in_pages_like/)
Then I tried to understand why the font was much bigger on Firefox and after some search I found this [font-optical-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/font-optical-sizing) will fix it.
