### PR TITLE
Fixed #195 to be always 16 days diff from now

### DIFF
--- a/__tests__/components/ChallengeMaterial.test.js
+++ b/__tests__/components/ChallengeMaterial.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import dayjs from 'dayjs'
 import { render, fireEvent, wait } from '@testing-library/react'
 import ChallengeMaterial from '../../components/ChallengeMaterial'
 
@@ -61,7 +62,9 @@ describe('Curriculum challenge page', () => {
         challengeId: '105',
         reviewer: null,
         createdAt: '1586907809223',
-        updatedAt: '1586907825090'
+        updatedAt: dayjs()
+          .subtract(16, 'day')
+          .valueOf()
       },
       {
         id: '3501',
@@ -77,7 +80,9 @@ describe('Curriculum challenge page', () => {
           username: 'dan'
         },
         createdAt: '1586907809223',
-        updatedAt: '1586907825090'
+        updatedAt: dayjs()
+          .subtract(16, 'day')
+          .valueOf()
       }
     ],
     chatUrl: 'https://chat.c0d3.com/c0d3/channels/js0-foundations',


### PR DESCRIPTION
Closes #195 by adding a date that always be 16 day difference from today

I think a better solution would be to change this [line of code](https://github.com/garageScript/c0d3-app/blob/29ef35b0987af795be45a7fbc042ba6e8425e450/components/ChallengeMaterial.tsx#L211):
`Submitted {dayjs(parseInt(updatedAt)).fromNow()}` with an helper fn that will be more easy to test