### PR TITLE
close #248 - lesson card should take users to the correct url

### DIFF
--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -358,7 +358,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
           <ChallengesCompletedCard
             imageSrc="icon-challenge-complete.jpg"
             chatUrl={chatUrl}
-            reviewUrl={`https://c0d3.com/teacher/${lessonId}`}
+            reviewUrl={`https://c0d3.com/review/${lessonId}`}
           />
         )}
       </div>

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -155,8 +155,8 @@ export const ChallengeQuestionCard: React.FC<ChallengeQuestionCardProps> = ({
     const oldValue: String[] = []
     const newValue: String[] = []
 
-    hunks.forEach((hunk) => {
-      hunk.changes.forEach((change) => {
+    hunks.forEach(hunk => {
+      hunk.changes.forEach(change => {
         if (change.isDelete) oldValue.push(change.content)
         else if (change.isInsert) newValue.push(change.content)
         else {
@@ -228,9 +228,7 @@ export const ChallengeQuestionCard: React.FC<ChallengeQuestionCardProps> = ({
   )
 }
 
-export const ChallengesCompletedCard: React.FC<ChallengesCompletedCardProps> = (
-  props
-) => {
+export const ChallengesCompletedCard: React.FC<ChallengesCompletedCardProps> = props => {
   return (
     <div className="card text-center shadow-sm">
       <div className="card-body">
@@ -322,7 +320,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
       return challenge.status !== 'passed'
     }) || finalChallenge
   const challengeTitleCards: React.ReactElement[] = challengesWithSubmissionData.map(
-    (challenge) => {
+    challenge => {
       return (
         <ChallengeTitleCard
           key={challenge.id}

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -155,8 +155,8 @@ export const ChallengeQuestionCard: React.FC<ChallengeQuestionCardProps> = ({
     const oldValue: String[] = []
     const newValue: String[] = []
 
-    hunks.forEach(hunk => {
-      hunk.changes.forEach(change => {
+    hunks.forEach((hunk) => {
+      hunk.changes.forEach((change) => {
         if (change.isDelete) oldValue.push(change.content)
         else if (change.isInsert) newValue.push(change.content)
         else {
@@ -228,7 +228,9 @@ export const ChallengeQuestionCard: React.FC<ChallengeQuestionCardProps> = ({
   )
 }
 
-export const ChallengesCompletedCard: React.FC<ChallengesCompletedCardProps> = props => {
+export const ChallengesCompletedCard: React.FC<ChallengesCompletedCardProps> = (
+  props
+) => {
   return (
     <div className="card text-center shadow-sm">
       <div className="card-body">
@@ -320,7 +322,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
       return challenge.status !== 'passed'
     }) || finalChallenge
   const challengeTitleCards: React.ReactElement[] = challengesWithSubmissionData.map(
-    challenge => {
+    (challenge) => {
       return (
         <ChallengeTitleCard
           key={challenge.id}
@@ -358,7 +360,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
           <ChallengesCompletedCard
             imageSrc="icon-challenge-complete.jpg"
             chatUrl={chatUrl}
-            reviewUrl={`https:/c0d3.com/teacher/${lessonId}`}
+            reviewUrl={`https://c0d3.com/teacher/${lessonId}`}
           />
         )}
       </div>

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -106,7 +106,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
             they have in the lesson and
             <a
               class="font-weight-bold mx-1"
-              href="https:/c0d3.com/teacher/5"
+              href="https://c0d3.com/teacher/5"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -106,7 +106,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
             they have in the lesson and
             <a
               class="font-weight-bold mx-1"
-              href="https://c0d3.com/teacher/5"
+              href="https://c0d3.com/review/5"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
Currently, when a user clicks on the link to go review challenge submissions once they have completed all of the challenges for a section, they are brought to a 404 error for page not found. 
<img width="808" alt="image" src="https://user-images.githubusercontent.com/20160586/83933111-a7109b00-a75a-11ea-8641-b5611165f935.png">

The correction redirects the user to the appropriate URL by fixing the link.