### PR TITLE
close #250 - add www to the review challenges link

### DIFF
--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -358,7 +358,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
           <ChallengesCompletedCard
             imageSrc="icon-challenge-complete.jpg"
             chatUrl={chatUrl}
-            reviewUrl={`https://c0d3.com/review/${lessonId}`}
+            reviewUrl={`https://www.c0d3.com/review/${lessonId}`}
           />
         )}
       </div>

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -106,7 +106,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
             they have in the lesson and
             <a
               class="font-weight-bold mx-1"
-              href="https://c0d3.com/review/5"
+              href="https://www.c0d3.com/review/5"
               rel="noopener noreferrer"
               target="_blank"
             >


### PR DESCRIPTION
Currently, the review challenge submission link in the final card directs to an deprecated link. 
The correction redirects the user to the appropriate URL by fixing the link.