### PR TITLE
closes #256 - update review and challenge links

### DIFF
--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -64,8 +64,8 @@ export const Curriculum: React.FC<WithQueryProps> = ({ queryData }) => {
           challengeCount={lesson.challenges.length}
           description={lesson.description}
           currentState={lessonState}
-          reviewUrl={`https://c0d3.com/teacher/${lesson.id}`}
-          challengesUrl={`https://c0d3.com/student/${lesson.id}`}
+          reviewUrl={`https://www.c0d3.com/review/${lesson.id}`}
+          challengesUrl={`https://www.c0d3.com/curriculum/${lesson.id}`}
           docUrl={lesson.docUrl}
         />
       )


### PR DESCRIPTION
Currently, the curriculum page is redirecting to outdated links:
1. 'Review Submissions':
    teacher route is deprecated -> review route
2. 'View Challenges':
    student route is deprecated -> curriculum route
<br />

The correction on the curriculum page now uses:
1. the review route for reviewing submissions
2. the curriculum route for viewing challenges
