### PR TITLE
fixed incorrectly typed HTML entity (&lsquo;) on forgot password page

### DIFF
--- a/pages/forgotpassword.tsx
+++ b/pages/forgotpassword.tsx
@@ -42,7 +42,7 @@ export const ResetPassword: React.FC = () => {
   return (
     <Card title="Reset your password">
       <p className="mb-5">
-        Type in your email or username below and we`&lsquo`ll send you an email
+        Type in your email or username below and we`&lsquo;`ll send you an email
         with instructions on how to reset your password
       </p>
       <Formik


### PR DESCRIPTION
HTML entity for left single quote needs a semi-colon at the end, updated code to reflect this need.