### PR TITLE
fix review Challenges link on curriculum page

### DIFF
--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -65,7 +65,7 @@ export const Curriculum: React.FC<WithQueryProps> = ({ queryData }) => {
           description={lesson.description}
           currentState={lessonState}
           reviewUrl={`https://www.c0d3.com/review/${lesson.id}`}
-          challengesUrl={`https://www.c0d3.com/student/${lesson.id}`}
+          challengesUrl={`https://www.c0d3.com/curriculum/${lesson.id}`}
           docUrl={lesson.docUrl}
         />
       )


### PR DESCRIPTION
Changed `c0d3.com/student/` to `c0d3.com/curriculum` to fix
`view challenges button` for each lesson