### PR TITLE
Update createSubmission to notify next lesson channel

### DIFF
--- a/helpers/controllers/submissionController.test.js
+++ b/helpers/controllers/submissionController.test.js
@@ -5,6 +5,7 @@ jest.mock('mailgun-js')
 import db from '../dbload'
 import fetch from 'node-fetch'
 import resolvers from '../../graphql/resolvers'
+import { publicChannelMessage, getUserByEmail } from '../mattermost'
 
 const { Mutation } = resolvers
 const { Lesson, Submission, User, Challenge } = db
@@ -23,29 +24,119 @@ describe('Submissions', () => {
     lessonId: 'fakeLessonId'
   }
 
-  test('createSubmission should return submission', async () => {
-    const submission = { ...args, update: jest.fn() }
-    User.findByPk = jest
-      .fn()
-      .mockResolvedValue({ username: 'username', id: 'userId' })
-    Submission.findOrCreate = jest.fn().mockResolvedValue([submission])
-    Challenge.findByPk = jest.fn().mockReturnValue({ title: 'title' })
-    Lesson.findByPk = jest.fn().mockReturnValue({
-      chatUrl: 'https://fake/url/channels/js1-variablesfunction',
-      id: 'fakeId'
+  describe('createSubmission', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
     })
-    fetch.mockResolvedValue({
-      status: 200,
-      json: () => Promise.resolve({ id: 'fakeId' })
-    })
-    const result = await Mutation.createSubmission(null, args)
-    expect(result).toEqual(submission)
-  })
 
-  test('createSubmission should throw error Invalid args', async () => {
-    await expect(Mutation.createSubmission(null, null)).rejects.toThrow(
-      'Invalid args'
-    )
+    test('should return submission', async () => {
+      const submission = { ...args, update: jest.fn() }
+      const username = 'fake user'
+      const challengeTitle = 'fake challenge title'
+      const lessonId = '1337'
+
+      // mock the current user
+      User.findByPk = jest.fn().mockResolvedValue({ username, id: 'userId' })
+
+      // mock the submission
+      Submission.findOrCreate = jest.fn().mockResolvedValue([submission])
+
+      // mock the challenge that is associated with the submission
+      Challenge.findByPk = jest.fn().mockReturnValue({ title: challengeTitle })
+
+      // mock the current lesson that is associated with the submission
+      Lesson.findByPk = jest.fn().mockReturnValue({
+        chatUrl: 'https://fake/url/channels/js1-variablesfunction',
+        id: lessonId,
+        order: 1
+      })
+
+      // mock the next lesson
+      Lesson.findOne = jest.fn().mockReturnValue(null)
+
+      // mock mattermost getUserByEmail
+      getUserByEmail.mockReturnValue(username)
+
+      const res = await Mutation.createSubmission(null, args)
+      expect(res).toEqual(submission)
+    })
+
+    test('should notify next lesson channel when there is a next lesson', async () => {
+      const submission = { ...args, update: jest.fn() }
+      const username = 'fake user'
+      const channelName = 'js2-arrays'
+      const challengeTitle = 'fake challenge title'
+      const lessonId = '1337'
+
+      // mock the current user
+      User.findByPk = jest.fn().mockResolvedValue({ username, id: 'userId' })
+
+      // mock the submission
+      Submission.findOrCreate = jest.fn().mockResolvedValue([submission])
+
+      // mock the challenge that is associated with the submission
+      Challenge.findByPk = jest.fn().mockReturnValue({ title: challengeTitle })
+
+      // mock the current lesson that is associated with the submission
+      Lesson.findByPk = jest.fn().mockReturnValue({
+        chatUrl: 'https://fake/url/channels/js1-variablesfunction',
+        id: lessonId,
+        order: 1
+      })
+
+      // mock the next lesson
+      Lesson.findOne = jest.fn().mockReturnValue({
+        chatUrl: `https://fake/url/channels/${channelName}`,
+        order: 2
+      })
+
+      // mock mattermost getUserByEmail
+      getUserByEmail.mockReturnValue(username)
+
+      await Mutation.createSubmission(null, args)
+      expect(publicChannelMessage).toHaveBeenCalledWith(
+        channelName,
+        `@${username} has submitted a solution **_${challengeTitle}_**. Click [here](<https://www.c0d3.com/review/${lessonId}>) to review the code.`
+      )
+    })
+
+    test('should not notify any channel when there is no next lesson', async () => {
+      const submission = { ...args, update: jest.fn() }
+      const username = 'fake user'
+      const challengeTitle = 'fake challenge title'
+      const lessonId = '1337'
+
+      // mock the current user
+      User.findByPk = jest.fn().mockResolvedValue({ username, id: 'userId' })
+
+      // mock the submission
+      Submission.findOrCreate = jest.fn().mockResolvedValue([submission])
+
+      // mock the challenge that is associated with the submission
+      Challenge.findByPk = jest.fn().mockReturnValue({ title: challengeTitle })
+
+      // mock the current lesson that is associated with the submission
+      Lesson.findByPk = jest.fn().mockReturnValue({
+        chatUrl: 'https://fake/url/channels/js1-variablesfunction',
+        id: lessonId,
+        order: 1
+      })
+
+      // mock the next lesson
+      Lesson.findOne = jest.fn().mockReturnValue(null)
+
+      // mock mattermost getUserByEmail
+      getUserByEmail.mockReturnValue(username)
+
+      await Mutation.createSubmission(null, args)
+      expect(publicChannelMessage).not.toHaveBeenCalled()
+    })
+
+    test('should throw error Invalid args', async () => {
+      await expect(Mutation.createSubmission(null, null)).rejects.toThrow(
+        'Invalid args'
+      )
+    })
   })
 
   test('acceptSubmission should call updateSubmission', async () => {

--- a/helpers/controllers/submissionController.ts
+++ b/helpers/controllers/submissionController.ts
@@ -32,15 +32,27 @@ export const createSubmission = async (
     const [submission] = await Submission.findOrCreate({
       where: { lessonId, challengeId, userId }
     })
+
     await submission.update({ diff, status: 'open', viewCount: 0 })
-    const [lesson, challenge] = await Promise.all([
+
+    const [currentLesson, challenge] = await Promise.all([
       Lesson.findByPk(lessonId),
       Challenge.findByPk(challengeId)
     ])
-    const lessonName = lesson.chatUrl.split('/').pop()
-    const username = await getUserByEmail(email)
-    const message = `@${username} has submitted a solution **_${challenge.title}_**. Click [here](<https://www.c0d3.com/review/${lesson.id}>) to review the code.`
-    publicChannelMessage(lessonName, message)
+
+    // query nextLesson based off order property of currentLesson
+    const nextLesson = await Lesson.findOne({
+      where: { order: currentLesson.order + 1 }
+    })
+
+    // if no Lesson was found nextLesson is null
+    if (nextLesson) {
+      const nextLessonChannelName = nextLesson.chatUrl.split('/').pop()
+      const username = await getUserByEmail(email)
+      const message = `@${username} has submitted a solution **_${challenge.title}_**. Click [here](<https://www.c0d3.com/review/${currentLesson.id}>) to review the code.`
+      publicChannelMessage(nextLessonChannelName, message)
+    }
+
     return submission
   } catch (error) {
     throw new Error(error)


### PR DESCRIPTION
- Have createSubmission resolver notify next lesson channel in mattermost
- Update tests for createSubmission

*Note: Need to update backend data **chatUrl** property on lessons to point to that lesson's chatUrl instead of the next lesson's **chatUrl***