### PR TITLE
[Alerts] Fix brief Alert render

### DIFF
--- a/components/AlertsDisplay.test.js
+++ b/components/AlertsDisplay.test.js
@@ -19,20 +19,27 @@ describe('Alerts Display Component', () => {
     }
   ]
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetAllMocks()
+  })
+
   test('Should dismiss alerts based on local storage', () => {
     jest
-      .spyOn(window.localStorage.__proto__, 'getItem')
+      .spyOn(window.Storage.prototype, 'getItem')
       .mockReturnValueOnce(JSON.stringify({ 1: true }))
+
     const { getAllByRole } = render(
       <AlertsDisplay alerts={alerts} page="curriculum" />
     )
-    act(() => {
-      const displayedAlerts = getAllByRole('alert')
-      expect(displayedAlerts.length).toEqual(1)
-    })
+
+    const displayedAlerts = getAllByRole('alert')
+    expect(displayedAlerts.length).toEqual(1)
   })
 
   test('Should dismiss alert for curriculum page', () => {
+    jest.spyOn(window.Storage.prototype, 'getItem').mockReturnValueOnce(null)
+
     const { getAllByRole } = render(
       <AlertsDisplay alerts={alerts} page="curriculum" />
     )

--- a/components/AlertsDisplay.tsx
+++ b/components/AlertsDisplay.tsx
@@ -9,11 +9,14 @@ type Props = {
 
 const AlertsDisplay: React.FC<Props> = ({ alerts, page }) => {
   const [dismissedAlerts, onDismiss] = useState<DismissedAlerts>({})
+  const [loading, setLoading] = useState<boolean>(true)
+
   useEffect(() => {
     const localDismissedAlerts = localStorage.getItem('dismissedAlerts')
     if (localDismissedAlerts) {
       onDismiss(JSON.parse(localDismissedAlerts))
     }
+    setLoading(false)
   }, [])
 
   const dismissAlert = (id: string) => {
@@ -26,6 +29,8 @@ const AlertsDisplay: React.FC<Props> = ({ alerts, page }) => {
       return newDismissedAlerts
     })
   }
+
+  if (loading) return null
 
   const widthClass = page === 'curriculum' ? 'col-12' : ''
   return (


### PR DESCRIPTION
Added loading state to Alerts so they don't sometimes render briefly before being set to dismissed.