### PR TITLE
Issue 246 card type

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -367,6 +367,46 @@ exports[`Storyshots Components/Card With Classes 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Card With Fail 1`] = `
+<div
+  className="row mt-5"
+>
+  <div
+    className="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
+  >
+    <div
+      className="card-body text-center pt-5 pb-5"
+    >
+      <svg
+        className="mb-4"
+        height="100px"
+        viewBox="0 0 180 180"
+        width="100px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M89 9a81 81 0 1 0 2 0zm1 38v58m0 25v1"
+          fill="none"
+          stroke="#721c24"
+          strokeLinecap="round"
+          strokeWidth="16"
+        />
+      </svg>
+      <h1
+        className="card-title h2 font-weight-bold mb-5"
+      >
+        Title of the card
+      </h1>
+      <p
+        className="card-text"
+      >
+        Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Card With Success 1`] = `
 <div
   className="row mt-5"

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,24 +1,35 @@
 import React from 'react'
 import { ReactComponent as Checked } from '../assets/images/checked.svg'
+import { ReactComponent as Fail } from '../public/curriculumAssets/icons/exclamation.svg'
 
 type Props = {
   children?: React.ReactNode
-  success?: boolean
+  type?: 'success' | 'fail'
   text?: string
   classes?: string
   title: string
 }
 
+const iconProps: { [type: string]: string } = {
+  className: 'mb-4',
+  width: '100px',
+  height: '100px'
+}
+
+const icons: { [type: string]: React.FC } = {
+  success: Checked,
+  fail: Fail
+}
+
 const Card: React.FC<Props> = props => {
   const classes = `${props.classes ||
     'col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0'}`
+  const Icon = props.type ? icons[props.type] : null
   return (
     <div className="row mt-5">
       <div className={`card shadow-sm ${classes}`}>
         <div className="card-body text-center pt-5 pb-5">
-          {props.success && (
-            <Checked className="mb-4" width="100px" height="100px" />
-          )}
+          {Icon && <Icon {...iconProps} />}
           <h1 className="card-title h2 font-weight-bold mb-5">{props.title}</h1>
           <p className="card-text">{props.text}</p>
           {props.children}

--- a/pages/confirm/[token].tsx
+++ b/pages/confirm/[token].tsx
@@ -15,7 +15,7 @@ const initialValues = {
 }
 
 const ConfirmSuccess: React.FC = () => (
-  <Card success title="Password has been set!">
+  <Card type="success" title="Password has been set!">
     <a className="btn btn-primary btn-lg mb-3" role="button" href="/curriculum">
       Continue to dashboard
     </a>

--- a/pages/forgotpassword.tsx
+++ b/pages/forgotpassword.tsx
@@ -20,7 +20,7 @@ export const ResetPassword: React.FC = () => {
   }
   if (data) {
     return (
-      <Card title="Password reset instructions sent" success={true}>
+      <Card title="Password reset instructions sent" type="success">
         <p>
           You will receive an email containing a link to reset your password.
         </p>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -43,7 +43,7 @@ const ErrorMessage: React.FC<ErrorDisplayProps> = ({ signupErrors }) => {
 
 const SignupSuccess: React.FC = () => (
   <Card
-    success
+    type="success"
     data-testid="signup-success"
     title="Account created successfully!"
   >

--- a/public/curriculumAssets/icons/exclamation.svg
+++ b/public/curriculumAssets/icons/exclamation.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180">
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 180 180">
 <path fill="none" stroke="#721c24" stroke-width="16" stroke-linecap="round" d="M89,9a81,81 0 1,0 2,0zm1,38v58m0,25v1"/>
 </svg>

--- a/stories/components/Card.stories.tsx
+++ b/stories/components/Card.stories.tsx
@@ -43,7 +43,15 @@ export const WithChildren: React.FC = () => (
 
 export const WithSuccess: React.FC = () => (
   <Card
-    success
+    type="success"
+    title="Title of the card"
+    text="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit..."
+  />
+)
+
+export const WithFail: React.FC = () => (
+  <Card
+    type="fail"
     title="Title of the card"
     text="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit..."
   />


### PR DESCRIPTION
Motivation:

- The resolution to issue #246 calls for a card with an error icon
- A purpose build ErrorCard component does not exist
- The existing Card component already supports a success icon and is easily modified to support a failure/error icon

Issue:

- Card component's success prop is used to display a large icon.
- success is boolean valued, so it can only accommodate two different icons or style variants.

Resolution:

- Replace Card's success prop with a string valued type prop in order to support more than two icons or style variants.
- Define two string values for type: success and fail.
- Add Fail SVG React Component
- Add icons map to simplify the selection of an icon based on the value of the types props

Other changes:

- Replace success prop with type prop throughout the codebase
- Add viewBox property to exclamation.svg to facilitate scaling throughout the application