### PR TITLE
Display Error Card with Token Reset Link for Expired Tokens (Resolves Issue #264)

### DIFF
--- a/__tests__/pages/__snapshots__/reset.test.js.snap
+++ b/__tests__/pages/__snapshots__/reset.test.js.snap
@@ -93,63 +93,35 @@ exports[`ResetPassword Page Should render alert on error 1`] = `
         <div
           class="card-body text-center pt-5 pb-5"
         >
+          <svg
+            class="mb-4"
+            height="100px"
+            viewBox="0 0 180 180"
+            width="100px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M89 9a81 81 0 1 0 2 0zm1 38v58m0 25v1"
+              fill="none"
+              stroke="#721c24"
+              stroke-linecap="round"
+              stroke-width="16"
+            />
+          </svg>
           <h1
             class="card-title h2 font-weight-bold mb-5"
           >
-            Enter new password
+            Link has expired.
           </h1>
           <p
             class="card-text"
           />
-          <div
-            class="alert d-flex justify-content-between mt-3 alert-danger"
-            role="alert"
+          <a
+            class="btn btn-primary"
+            href="/forgotpassword"
           >
-            <div>
-              <img
-                class="mr-3 alert-icon"
-                src="/curriculumAssets/icons/exclamation.svg"
-              />
-              Link has expired. Request a new password reset 
-            </div>
-          </div>
-          <p
-            class="mb-4"
-          >
-            Your password should contain minimum 6 characters.
-          </p>
-          <form
-            action="#"
-            data-testid="form"
-          >
-            <div
-              class="form-group"
-            >
-              <input
-                class="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="password"
-                name="password"
-                placeholder="Enter new password"
-                type="password"
-                value="fake reset password"
-              />
-              <input
-                class="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="confirmPassword"
-                name="confirmPassword"
-                placeholder="Re-enter new password"
-                type="password"
-                value="fake reset password"
-              />
-              <button
-                class="btn btn-primary btn-lg btn-block mb-3"
-                data-testid="submit"
-                type="submit"
-              >
-                Reset Password
-              </button>
-            </div>
-          </form>
+            Request a new password reset
+          </a>
         </div>
       </div>
     </div>

--- a/__tests__/pages/reset.test.js
+++ b/__tests__/pages/reset.test.js
@@ -136,9 +136,8 @@ describe('ResetPassword Page', () => {
     })
 
     await wait(() => {
-      expect(
-        getByText('Link has expired. Request a new password reset')
-      ).toBeTruthy()
+      expect(getByText('Link has expired.')).toBeTruthy()
+      expect(getByText('Request a new password reset')).toBeTruthy()
       expect(container).toMatchSnapshot()
     })
   })

--- a/pages/confirm/[token].tsx
+++ b/pages/confirm/[token].tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import { Formik, Form, Field } from 'formik'
 import { useMutation } from '@apollo/react-hooks'
 import UPDATE_PASSWORD from '../../graphql/queries/updatePassword'
-import Alert from '../../components/Alert'
+import NavLink from '../../components/NavLink'
 import Input from '../../components/Input'
 import { confirmPasswordValidation } from '../../helpers/formValidation'
 import Layout from '../../components/Layout'
@@ -19,6 +19,14 @@ const ConfirmSuccess: React.FC = () => (
     <a className="btn btn-primary btn-lg mb-3" role="button" href="/curriculum">
       Continue to dashboard
     </a>
+  </Card>
+)
+
+const ExpiredToken: React.FC = () => (
+  <Card type="fail" title="Link has expired.">
+    <NavLink path="/forgotpassword" className="btn btn-primary">
+      Request a new password reset
+    </NavLink>
   </Card>
 )
 
@@ -40,16 +48,10 @@ export const ResetPassword: React.FC = () => {
     return <ConfirmSuccess />
   }
 
+  if (error) return <ExpiredToken />
+
   return (
     <Card title="Enter new password">
-      {error && (
-        <Alert
-          alert={{
-            text: 'Link has expired. Request a new password reset',
-            type: 'urgent'
-          }}
-        />
-      )}
       <p className="mb-4">Your password should contain minimum 6 characters.</p>
       <Formik
         validateOnBlur


### PR DESCRIPTION
- Display error card with link to request new reset token when existing token is expired
- Update tests and snapshot
- Resolve issue #246 