### PR TITLE
Resolves #302: Fix Broken Asynchronous Tests

### DIFF
--- a/helpers/controllers/userInfoController.test.js
+++ b/helpers/controllers/userInfoController.test.js
@@ -5,11 +5,11 @@ import { userInfo } from './userInfoController'
 const { User, UserLesson, Submission } = db
 describe('userInfo controller tests', () => {
   test('should return error of invalid username if no username is passed in', async () => {
-    expect(userInfo({}, {})).rejects.toEqual('Invalid username')
+    await expect(userInfo({}, {})).rejects.toThrow('Invalid username')
   })
   test('should return error if User.findOne returns invalid user object', async () => {
     User.findOne = jest.fn()
-    expect(userInfo({}, { username: 'testing2020' })).rejects.toEqual(
+    await expect(userInfo({}, { username: 'testing2020' })).rejects.toThrow(
       'Invalid user object'
     )
   })


### PR DESCRIPTION
#### Issues

Tests in `userInfoController.test.js` that are designed to match error messages  from promise rejections:

- Do not wait for promises to settle
- Match on string values instead of error messages 

As a result of the first issue, unhandled promise rejection errors are thrown when the tests are executed. In absence of the first issue, the second issue (the matcher) would cause the tests to fail.

#### Resolution

- Use `await` keyword to wait for settled promise
- Replace `toEqual` with `toThrow` to match error message instead of string value

#### Notes

- Resolves #302 
- [`rejects` matcher documentation](https://jestjs.io/docs/en/expect.html#rejects)
- [`toThrow` matcher documentation](https://jestjs.io/docs/en/expect.html#tothrowerror)