### PR TITLE
[Refactor] Migrate Curriculum page to new GraphQL types

### DIFF
--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Curriculum Page Should render Error on error 1`] = `
+<div>
+  <h1>
+    Error
+  </h1>
+</div>
+`;
+
+exports[`Curriculum Page Should render Loading Spinner when loading 1`] = `
+<div>
+  <div
+    class="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
+    style="min-height: 100vh;"
+  >
+    <h1
+      class="text-white font-weight-bold display-3"
+      style="font-family: 'PT Mono', sans-serif;"
+    >
+      C0D3
+    </h1>
+    <div
+      class="spinner-border text-white"
+      role="status"
+    >
+      <h1
+        class="sr-only"
+      >
+        Loading...
+      </h1>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Curriculum Page Should render No Data when no session 1`] = `
+<div>
+  <h1>
+    Bad Data
+  </h1>
+</div>
+`;
+
 exports[`Curriculum Page Should render with basic dummy data 1`] = `
 <div>
   <nav

--- a/__tests__/pages/curriculum.test.js
+++ b/__tests__/pages/curriculum.test.js
@@ -7,6 +7,71 @@ import dummyLessonData from '../../__dummy__/lessonData'
 import dummySessionData from '../../__dummy__/sessionData'
 
 describe('Curriculum Page', () => {
+  test('Should render Loading Spinner when loading', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            lessons: dummyLessonData,
+            session: dummySessionData,
+            alerts: []
+          }
+        }
+      }
+    ]
+
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Curriculum />
+      </MockedProvider>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Should render Error on error', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        error: new Error('error')
+      }
+    ]
+
+    const { container, debug } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Curriculum />
+      </MockedProvider>
+    )
+
+    await wait()
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Should render No Data when no session', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            lessons: dummyLessonData,
+            session: null,
+            alerts: []
+          }
+        }
+      }
+    ]
+
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Curriculum />
+      </MockedProvider>
+    )
+
+    await wait()
+    expect(container).toMatchSnapshot()
+  })
+
   test('Should render with basic dummy data', async () => {
     const mocks = [
       {

--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import NavLink from './NavLink'
-import { AlertData } from '../@types/alerts'
+import { GetAppQuery } from '../graphql/'
+import _ from 'lodash'
 import '../scss/alerts.scss'
 
+const alerts: GetAppQuery['alerts'] = []
+
 type Props = {
-  alert: AlertData
+  alert?: typeof alerts[0]
   text?: string
   instructionsUrl?: string
   icon?: string
@@ -19,8 +22,8 @@ const alertIconMap: { [type: string]: string } = {
 }
 
 const Alert: React.FC<Props> = ({ alert, onDismiss }) => {
-  const { text, type, url, urlCaption, id } = alert
-  const icon = alertIconMap[type]
+  const { text, type, url, urlCaption, id } = _.defaultTo(alert, {})
+  const icon = alertIconMap[_.defaultTo(type, '-1')]
   const textColor = type === 'urgent' ? 'text-danger' : 'text-white'
   const alertClasses =
     type === 'urgent' ? 'alert-danger' : `bg-primary ${textColor}`

--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -1,13 +1,11 @@
 import React from 'react'
 import NavLink from './NavLink'
-import { GetAppQuery } from '../graphql/'
+import { Alert as AlertType } from '../graphql/'
 import _ from 'lodash'
 import '../scss/alerts.scss'
 
-const alerts: GetAppQuery['alerts'] = []
-
 type Props = {
-  alert?: typeof alerts[0]
+  alert: AlertType
   text?: string
   instructionsUrl?: string
   icon?: string
@@ -22,7 +20,7 @@ const alertIconMap: { [type: string]: string } = {
 }
 
 const Alert: React.FC<Props> = ({ alert, onDismiss }) => {
-  const { text, type, url, urlCaption, id } = _.defaultTo(alert, {})
+  const { text, type, url, urlCaption, id } = alert
   const icon = alertIconMap[_.defaultTo(type, '-1')]
   const textColor = type === 'urgent' ? 'text-danger' : 'text-white'
   const alertClasses =

--- a/components/AlertsDisplay.test.js
+++ b/components/AlertsDisplay.test.js
@@ -24,6 +24,12 @@ describe('Alerts Display Component', () => {
     jest.resetAllMocks()
   })
 
+  test('Should render properly when no props are passed in', () => {
+    const { container } = render(<AlertsDisplay />)
+
+    expect(container).toMatchSnapshot()
+  })
+
   test('Should dismiss alerts based on local storage', () => {
     jest
       .spyOn(window.Storage.prototype, 'getItem')

--- a/components/AlertsDisplay.tsx
+++ b/components/AlertsDisplay.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import Alert from './Alert'
-import { AlertData, DismissedAlerts } from '../@types/alerts'
+import { DismissedAlerts } from '../@types/alerts'
+import { GetAppQuery } from '../graphql/'
+import _ from 'lodash'
 
 type Props = {
-  alerts: AlertData[]
+  alerts?: GetAppQuery['alerts']
   page?: string
 }
 
@@ -35,10 +37,14 @@ const AlertsDisplay: React.FC<Props> = ({ alerts, page }) => {
   const widthClass = page === 'curriculum' ? 'col-12' : ''
   return (
     <div className={`alerts-container ${widthClass}`}>
-      {alerts
-        .filter(alert => !dismissedAlerts[alert.id as string])
-        .map(alert => (
-          <Alert key={alert.id} alert={alert} onDismiss={dismissAlert} />
+      {_.defaultTo(alerts, [])
+        .filter(alert => !dismissedAlerts[_.defaultTo(alert?.id, '-1')])
+        .map((alert, i) => (
+          <Alert
+            key={_.defaultTo(alert?.id, i)}
+            alert={alert}
+            onDismiss={dismissAlert}
+          />
         ))}
     </div>
   )

--- a/components/AlertsDisplay.tsx
+++ b/components/AlertsDisplay.tsx
@@ -1,15 +1,15 @@
 import React, { useState, useEffect } from 'react'
 import Alert from './Alert'
 import { DismissedAlerts } from '../@types/alerts'
-import { GetAppQuery } from '../graphql/'
+import { Alert as AlertType } from '../graphql/'
 import _ from 'lodash'
 
 type Props = {
-  alerts?: GetAppQuery['alerts']
+  alerts?: AlertType[]
   page?: string
 }
 
-const AlertsDisplay: React.FC<Props> = ({ alerts, page }) => {
+const AlertsDisplay: React.FC<Props> = ({ alerts = [], page }) => {
   const [dismissedAlerts, onDismiss] = useState<DismissedAlerts>({})
   const [loading, setLoading] = useState<boolean>(true)
 
@@ -37,14 +37,10 @@ const AlertsDisplay: React.FC<Props> = ({ alerts, page }) => {
   const widthClass = page === 'curriculum' ? 'col-12' : ''
   return (
     <div className={`alerts-container ${widthClass}`}>
-      {_.defaultTo(alerts, [])
-        .filter(alert => !dismissedAlerts[_.defaultTo(alert?.id, '-1')])
-        .map((alert, i) => (
-          <Alert
-            key={_.defaultTo(alert?.id, i)}
-            alert={alert}
-            onDismiss={dismissAlert}
-          />
+      {alerts
+        .filter(alert => !dismissedAlerts[alert.id])
+        .map(alert => (
+          <Alert key={alert.id} alert={alert} onDismiss={dismissAlert} />
         ))}
     </div>
   )

--- a/components/__snapshots__/AlertsDisplay.test.js.snap
+++ b/components/__snapshots__/AlertsDisplay.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alerts Display Component Should render properly when no props are passed in 1`] = `
+<div>
+  <div
+    class="alerts-container "
+  />
+</div>
+`;

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -144,7 +144,7 @@ export type MutationRejectSubmissionArgs = {
 
 export type Query = {
   __typename?: 'Query'
-  lessons?: Maybe<Array<Maybe<Lesson>>>
+  lessons: Array<Lesson>
   session?: Maybe<Session>
   userInfo?: Maybe<Session>
   isTokenValid: Scalars['Boolean']
@@ -168,7 +168,7 @@ export type Session = {
   __typename?: 'Session'
   user?: Maybe<User>
   submissions?: Maybe<Array<Maybe<Submission>>>
-  lessonStatus?: Maybe<Array<Maybe<UserLesson>>>
+  lessonStatus: Array<UserLesson>
 }
 
 export type Submission = {
@@ -248,33 +248,29 @@ export type AddAlertMutation = { __typename?: 'Mutation' } & {
 export type GetAppQueryVariables = Exact<{ [key: string]: never }>
 
 export type GetAppQuery = { __typename?: 'Query' } & {
-  lessons?: Maybe<
-    Array<
-      Maybe<
-        { __typename?: 'Lesson' } & Pick<
-          Lesson,
-          | 'id'
-          | 'title'
-          | 'description'
-          | 'docUrl'
-          | 'githubUrl'
-          | 'videoUrl'
-          | 'order'
-          | 'chatUrl'
-        > & {
-            challenges?: Maybe<
-              Array<
-                Maybe<
-                  { __typename?: 'Challenge' } & Pick<
-                    Challenge,
-                    'id' | 'title' | 'description' | 'order'
-                  >
-                >
+  lessons: Array<
+    { __typename?: 'Lesson' } & Pick<
+      Lesson,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'docUrl'
+      | 'githubUrl'
+      | 'videoUrl'
+      | 'order'
+      | 'chatUrl'
+    > & {
+        challenges?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Challenge' } & Pick<
+                Challenge,
+                'id' | 'title' | 'description' | 'order'
               >
             >
-          }
-      >
-    >
+          >
+        >
+      }
   >
   session?: Maybe<
     { __typename?: 'Session' } & {
@@ -305,14 +301,10 @@ export type GetAppQuery = { __typename?: 'Query' } & {
           >
         >
       >
-      lessonStatus?: Maybe<
-        Array<
-          Maybe<
-            { __typename?: 'UserLesson' } & Pick<
-              UserLesson,
-              'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
-            >
-          >
+      lessonStatus: Array<
+        { __typename?: 'UserLesson' } & Pick<
+          UserLesson,
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
         >
       >
     }
@@ -437,33 +429,29 @@ export type UserInfoQueryVariables = Exact<{
 }>
 
 export type UserInfoQuery = { __typename?: 'Query' } & {
-  lessons?: Maybe<
-    Array<
-      Maybe<
-        { __typename?: 'Lesson' } & Pick<
-          Lesson,
-          | 'id'
-          | 'title'
-          | 'description'
-          | 'docUrl'
-          | 'githubUrl'
-          | 'videoUrl'
-          | 'order'
-          | 'chatUrl'
-        > & {
-            challenges?: Maybe<
-              Array<
-                Maybe<
-                  { __typename?: 'Challenge' } & Pick<
-                    Challenge,
-                    'id' | 'title' | 'description' | 'order'
-                  >
-                >
+  lessons: Array<
+    { __typename?: 'Lesson' } & Pick<
+      Lesson,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'docUrl'
+      | 'githubUrl'
+      | 'videoUrl'
+      | 'order'
+      | 'chatUrl'
+    > & {
+        challenges?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Challenge' } & Pick<
+                Challenge,
+                'id' | 'title' | 'description' | 'order'
               >
             >
-          }
-      >
-    >
+          >
+        >
+      }
   >
   userInfo?: Maybe<
     { __typename?: 'Session' } & {
@@ -494,14 +482,10 @@ export type UserInfoQuery = { __typename?: 'Query' } & {
           >
         >
       >
-      lessonStatus?: Maybe<
-        Array<
-          Maybe<
-            { __typename?: 'UserLesson' } & Pick<
-              UserLesson,
-              'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
-            >
-          >
+      lessonStatus: Array<
+        { __typename?: 'UserLesson' } & Pick<
+          UserLesson,
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
         >
       >
     }
@@ -818,11 +802,7 @@ export type QueryResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
 > = {
-  lessons?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
-    ParentType,
-    ContextType
-  >
+  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>
   session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>
   userInfo?: Resolver<
     Maybe<ResolversTypes['Session']>,
@@ -860,7 +840,7 @@ export type SessionResolvers<
     ContextType
   >
   lessonStatus?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['UserLesson']>>>,
+    Array<ResolversTypes['UserLesson']>,
     ParentType,
     ContextType
   >

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -29,7 +29,7 @@ export type Scalars = {
 
 export type Alert = {
   __typename?: 'Alert'
-  id?: Maybe<Scalars['String']>
+  id: Scalars['String']
   text?: Maybe<Scalars['String']>
   type?: Maybe<Scalars['String']>
   url?: Maybe<Scalars['String']>
@@ -149,7 +149,7 @@ export type Query = {
   userInfo?: Maybe<Session>
   isTokenValid: Scalars['Boolean']
   submissions?: Maybe<Array<Maybe<Submission>>>
-  alerts?: Maybe<Array<Maybe<Alert>>>
+  alerts: Array<Alert>
 }
 
 export type QueryUserInfoArgs = {
@@ -309,14 +309,10 @@ export type GetAppQuery = { __typename?: 'Query' } & {
       >
     }
   >
-  alerts?: Maybe<
-    Array<
-      Maybe<
-        { __typename?: 'Alert' } & Pick<
-          Alert,
-          'id' | 'text' | 'type' | 'url' | 'urlCaption'
-        >
-      >
+  alerts: Array<
+    { __typename?: 'Alert' } & Pick<
+      Alert,
+      'id' | 'text' | 'type' | 'url' | 'urlCaption'
     >
   >
 }
@@ -650,7 +646,7 @@ export type AlertResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']
 > = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
@@ -822,11 +818,7 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QuerySubmissionsArgs, 'lessonId'>
   >
-  alerts?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Alert']>>>,
-    ParentType,
-    ContextType
-  >
+  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>
 }
 
 export type SessionResolvers<

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -7,7 +7,7 @@ export default gql`
     userInfo(username: String!): Session
     isTokenValid(cliToken: String!): Boolean!
     submissions(lessonId: String!): [Submission]
-    alerts: [Alert]
+    alerts: [Alert!]!
   }
 
   type TokenResponse {
@@ -123,7 +123,7 @@ export default gql`
     order: Int
   }
   type Alert {
-    id: String
+    id: String!
     text: String
     type: String
     url: String

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -2,7 +2,7 @@ import { gql } from 'apollo-boost'
 
 export default gql`
   type Query {
-    lessons: [Lesson]
+    lessons: [Lesson!]!
     session: Session
     userInfo(username: String!): Session
     isTokenValid(cliToken: String!): Boolean!
@@ -87,7 +87,7 @@ export default gql`
   type Session {
     user: User
     submissions: [Submission]
-    lessonStatus: [UserLesson]
+    lessonStatus: [UserLesson!]!
   }
 
   type UserLesson {

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -31,7 +31,7 @@ export const Curriculum: React.FC<GetAppProps> = ({ data }) => {
   }
 
   const lessonInProgressIdx = _.cond([
-    [_.isEqualWith.bind(null, -1), _.constant(0)],
+    [_.isEqual.bind(null, -1), _.constant(0)],
     [_.constant(true), (output: number) => output]
   ])(
     lessons.findIndex(lesson => {

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -4,20 +4,18 @@ import LessonCard from '../components/LessonCard'
 import ProgressCard from '../components/ProgressCard'
 import AnnouncementCard from '../components/AnnouncementCard'
 import AdditionalResources from '../components/AdditionalResources'
-import { Lesson, LessonStatus } from '../@types/lesson'
-import { AppData } from '../@types/app'
-import GET_APP from '../graphql/queries/getApp'
-import withQueryLoader, { QueryDataProps } from '../containers/withQueryLoader'
 import AlertsDisplay from '../components/AlertsDisplay'
+import LoadingSpinner from '../components/LoadingSpinner'
+import { withGetApp, GetAppProps } from '../graphql/'
 import _ from 'lodash'
 
-type LessonStatusMap = {
-  [id: string]: LessonStatus
-}
+export const Curriculum: React.FC<GetAppProps> = ({ data }) => {
+  let { loading, error, alerts, lessons, session } = data
 
-export const Curriculum: React.FC<QueryDataProps<AppData>> = ({
-  queryData
-}) => {
+  if (loading) return <LoadingSpinner />
+  if (error) return <h1>Error</h1>
+  if (!session || !lessons || !alerts) return <h1>Bad Data</h1>
+
   const announcements = [
     'To make space for other students on our servers, your account will be deleted after 30 days of inactivity.',
     'Take each lesson challenge seriously and do them over and over again until you can solve them. With the exception End to End, all challenges are questions and exercises taken from real interviews.',
@@ -25,55 +23,56 @@ export const Curriculum: React.FC<QueryDataProps<AppData>> = ({
     'After completing Foundations of JavaScript, Variables & Functions, Array, Objects, End to End, HTML/CSS/JavaScript, React/GraphQL/SocketIO, you will be technically ready to contribute to our codebase.'
   ]
 
-  const { lessons, session, alerts } = queryData
-  const lessonStatus: LessonStatus[] = _.get(session, 'lessonStatus', [])
-  const lessonStatusMap: LessonStatusMap = lessonStatus.reduce(
-    (map: LessonStatusMap, lessonStatus: LessonStatus) => {
-      map[lessonStatus.lessonId] = lessonStatus
-      return map
-    },
-    {}
+  const { lessonStatus } = session
+  const lessonStatusMap: { [id: string]: typeof lessonStatus[0] } = {}
+  for (const status of lessonStatus) {
+    const lessonId = _.get(status, 'lessonId', '-1') as string
+    lessonStatusMap[lessonId] = status
+  }
+
+  const lessonInProgressIdx = _.cond([
+    [_.isEqualWith.bind(null, -1), _.constant(0)],
+    [_.constant(true), (output: number) => output]
+  ])(
+    lessons.findIndex(lesson => {
+      const lessonId = _.get(lesson, 'id', '-1') as string
+      return !lessonStatusMap[lessonId]?.isPassed
+    })
   )
-
-  const lessonsWithStatus: Lesson[] = lessons.map((lesson: Lesson) => {
-    lesson.lessonStatus = lessonStatusMap[lesson.id] || {
-      isEnrolled: null,
-      isTeaching: null,
-      lessonId: lesson.id
-    }
-    return lesson
-  })
-
-  const lessonInProgressIdx =
-    lessonsWithStatus.findIndex(lesson => !lesson.lessonStatus.isPassed) || 0
 
   // Progress Percentage should be calculated from lessons 0-6 because thats our current standard of finishing the curriculum.
-  const progressPercentage = Math.floor((lessonInProgressIdx * 100) / 7)
-  const lessonsToRender: React.ReactElement[] = lessonsWithStatus.map(
-    (lesson, idx) => {
-      let lessonState = ''
-      if (idx === lessonInProgressIdx) {
-        lessonState = 'inProgress'
-      }
-      if (lesson.lessonStatus.isPassed) {
-        lessonState = 'completed'
-      }
-      return (
-        <LessonCard
-          key={lesson.id}
-          lessonId={lesson.id}
-          coverImg={`js-${idx}-cover.svg`}
-          title={lesson.title}
-          challengeCount={lesson.challenges.length}
-          description={lesson.description}
-          currentState={lessonState}
-          reviewUrl={`/review/${lesson.id}`}
-          challengesUrl={`/curriculum/${lesson.id}`}
-          docUrl={lesson.docUrl}
-        />
-      )
-    }
+  const TOTAL_LESSONS = 7
+  const progressPercentage = Math.floor(
+    (lessonInProgressIdx * 100) / TOTAL_LESSONS
   )
+  const lessonsToRender: React.ReactElement[] = lessons.map((lesson, idx) => {
+    const id = _.get(lesson, 'id', idx) as number
+    const status = lessonStatusMap[id]
+    let lessonState = ''
+    if (idx === lessonInProgressIdx) {
+      lessonState = 'inProgress'
+    }
+    if (status?.isPassed) {
+      lessonState = 'completed'
+    }
+    const title = _.get(lesson, 'title', '') as string
+    const challengeCount = _.get(lesson, 'challenges.length', 0) as number
+    const description = _.get(lesson, 'description', '') as string
+    return (
+      <LessonCard
+        key={id}
+        lessonId={id}
+        coverImg={`js-${idx}-cover.svg`}
+        title={title}
+        challengeCount={challengeCount}
+        description={description}
+        currentState={lessonState}
+        reviewUrl={`/review/${id}`}
+        challengesUrl={`/curriculum/${id}`}
+        docUrl={lesson?.docUrl || ''}
+      />
+    )
+  })
   return (
     <Layout>
       <div className="row">
@@ -89,9 +88,4 @@ export const Curriculum: React.FC<QueryDataProps<AppData>> = ({
   )
 }
 
-export default withQueryLoader<AppData>(
-  {
-    query: GET_APP
-  },
-  Curriculum
-)
+export default withGetApp()(Curriculum)

--- a/pages/curriculum/[lesson].tsx
+++ b/pages/curriculum/[lesson].tsx
@@ -39,7 +39,8 @@ const Challenges: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
                 lessonId={currentlessonId}
                 isPassed={isPassed}
               />
-              {alerts && <AlertsDisplay alerts={alerts} />}
+              {/* Casting alerts as any until type is migrated */}
+              {alerts && <AlertsDisplay alerts={alerts as any} />}
               <ChallengeMaterial
                 challenges={currentLesson.challenges}
                 userSubmissions={userSubmissions}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -21,7 +21,10 @@ const ErrorMessages: React.FC<ErrorDisplayProps> = ({ loginErrors }) => {
   const errorMessages = loginErrors.map((message, idx) => {
     const formattedMessage = message.split(':')[1]
     return (
-      <Alert key={idx} alert={{ text: formattedMessage, type: 'urgent' }} />
+      <Alert
+        key={idx}
+        alert={{ id: '-1', text: formattedMessage, type: 'urgent' }}
+      />
     )
   })
   return <>{errorMessages}</>

--- a/stories/components/Alert.stories.tsx
+++ b/stories/components/Alert.stories.tsx
@@ -21,6 +21,7 @@ export const Info: React.FC = () => (
 export const Urgent: React.FC = () => (
   <Alert
     alert={{
+      id: '-1',
       text: 'Invalid password',
       type: 'urgent'
     }}


### PR DESCRIPTION
Switch over old custom GraphQL HOC with new generated typed HOC in curriculum page component.

Works on #291 