### PR TITLE
closes #311 - Redesign look of write/preview buttons of MdInput

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2315,46 +2315,28 @@ exports[`Storyshots Components/MdInput Basic 1`] = `
     }
   }
 >
-  <div
+  <button
+    className="btn"
+    onClick={[Function]}
     style={
       Object {
-        "backgroundColor": "rgba(0, 0, 0, 0.2)",
-        "borderRadius": "0.25rem",
-        "display": "inline-block",
+        "color": "#292929",
       }
     }
   >
-    <button
-      className="btn"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "#292929",
-        }
-      }
-    >
-      Write
-    </button>
-  </div>
-  <div
+    Write
+  </button>
+  <button
+    className="btn"
+    onClick={[Function]}
     style={
       Object {
-        "display": "inline-block",
+        "color": "#8e8e8e",
       }
     }
   >
-    <button
-      className="btn"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "#292929",
-        }
-      }
-    >
-      Preview
-    </button>
-  </div>
+    Preview
+  </button>
   <textarea
     data-testid="textbox"
     onChange={[Function]}
@@ -2378,46 +2360,28 @@ exports[`Storyshots Components/MdInput White 1`] = `
     }
   }
 >
-  <div
+  <button
+    className="btn"
+    onClick={[Function]}
     style={
       Object {
-        "backgroundColor": "rgba(0, 0, 0, 0.2)",
-        "borderRadius": "0.25rem",
-        "display": "inline-block",
+        "color": "#292929",
       }
     }
   >
-    <button
-      className="btn"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "#292929",
-        }
-      }
-    >
-      Write
-    </button>
-  </div>
-  <div
+    Write
+  </button>
+  <button
+    className="btn"
+    onClick={[Function]}
     style={
       Object {
-        "display": "inline-block",
+        "color": "#8e8e8e",
       }
     }
   >
-    <button
-      className="btn"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "#292929",
-        }
-      }
-    >
-      Preview
-    </button>
-  </div>
+    Preview
+  </button>
   <textarea
     data-testid="textbox"
     onChange={[Function]}
@@ -2442,46 +2406,28 @@ exports[`Storyshots Components/MdInput With Submission Buttons 1`] = `
       }
     }
   >
-    <div
+    <button
+      className="btn"
+      onClick={[Function]}
       style={
         Object {
-          "backgroundColor": "rgba(0, 0, 0, 0.2)",
-          "borderRadius": "0.25rem",
-          "display": "inline-block",
+          "color": "#292929",
         }
       }
     >
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#292929",
-          }
-        }
-      >
-        Write
-      </button>
-    </div>
-    <div
+      Write
+    </button>
+    <button
+      className="btn"
+      onClick={[Function]}
       style={
         Object {
-          "display": "inline-block",
+          "color": "#8e8e8e",
         }
       }
     >
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#292929",
-          }
-        }
-      >
-        Preview
-      </button>
-    </div>
+      Preview
+    </button>
     <textarea
       data-testid="textbox"
       onChange={[Function]}

--- a/components/MdInput.tsx
+++ b/components/MdInput.tsx
@@ -3,28 +3,16 @@ import Markdown from 'markdown-to-jsx'
 import { Button } from './theme/Button'
 import noop from '../helpers/noop'
 
-// style for both Markdown and textarea
-const style = {
+// style for textarea
+const textBoxStyle = {
   padding: '1rem',
   width: '100%'
 }
 
-// style only for Markdowwn
+// style for Markdown
 const MdStyle = {
-  display: 'block',
-  marginTop: 0
-}
-
-// style only for Buttons
-const btnStyle = {
-  display: 'inline-block'
-}
-
-// styling to turn button background grey
-const selectedBtnStyle = {
-  ...btnStyle,
-  backgroundColor: 'rgba(0, 0, 0, 0.2)',
-  borderRadius: '0.25rem'
+  ...textBoxStyle,
+  display: 'block'
 }
 
 type MdInputProps = {
@@ -46,7 +34,7 @@ export const MdInput: React.FC<MdInputProps> = ({
   }
 
   const displayOption = preview ? (
-    <Markdown data-testid="markdown" style={{ ...style, ...MdStyle }}>
+    <Markdown data-testid="markdown" style={MdStyle}>
       {commentValue}
     </Markdown>
   ) : (
@@ -54,23 +42,22 @@ export const MdInput: React.FC<MdInputProps> = ({
       value={commentValue}
       onChange={handleChange}
       placeholder="Type something..."
-      style={style}
+      style={textBoxStyle}
       data-testid="textbox"
     />
   )
 
-  // makes previewBtn or writeBtn background grey, depending on mode chosen
-  const writeBtnStyle = preview ? btnStyle : selectedBtnStyle
-  const previewBtnStyle = preview ? selectedBtnStyle : btnStyle
+  const previewBtnColor = preview ? 'black' : 'lightgrey'
+  const writeBtnColor = preview ? 'lightgrey' : 'black'
 
   return (
     <div style={{ backgroundColor: bgColor }}>
-      <div style={writeBtnStyle}>
-        <Button onClick={() => setPreview(false)}>Write</Button>
-      </div>
-      <div style={previewBtnStyle}>
-        <Button onClick={() => setPreview(true)}>Preview</Button>
-      </div>
+      <Button color={writeBtnColor} onClick={() => setPreview(false)}>
+        Write
+      </Button>
+      <Button color={previewBtnColor} onClick={() => setPreview(true)}>
+        Preview
+      </Button>
       {displayOption}
     </div>
   )

--- a/components/__snapshots__/MdInput.test.js.snap
+++ b/components/__snapshots__/MdInput.test.js.snap
@@ -3,26 +3,18 @@
 exports[`MdInput Component Should render text onto textbox when user types 1`] = `
 <div>
   <div>
-    <div
-      style="display: inline-block; background-color: rgba(0, 0, 0, 0.2); border-radius: 0.25rem;"
+    <button
+      class="btn"
+      style="color: rgb(41, 41, 41);"
     >
-      <button
-        class="btn"
-        style="color: rgb(41, 41, 41);"
-      >
-        Write
-      </button>
-    </div>
-    <div
-      style="display: inline-block;"
+      Write
+    </button>
+    <button
+      class="btn"
+      style="color: rgb(142, 142, 142);"
     >
-      <button
-        class="btn"
-        style="color: rgb(41, 41, 41);"
-      >
-        Preview
-      </button>
-    </div>
+      Preview
+    </button>
     <textarea
       data-testid="textbox"
       placeholder="Type something..."
@@ -37,29 +29,21 @@ exports[`MdInput Component Should render text onto textbox when user types 1`] =
 exports[`MdInput Component Should switch to Preview mode when user clicks Preview button 1`] = `
 <div>
   <div>
-    <div
-      style="display: inline-block;"
+    <button
+      class="btn"
+      style="color: rgb(142, 142, 142);"
     >
-      <button
-        class="btn"
-        style="color: rgb(41, 41, 41);"
-      >
-        Write
-      </button>
-    </div>
-    <div
-      style="display: inline-block; background-color: rgba(0, 0, 0, 0.2); border-radius: 0.25rem;"
+      Write
+    </button>
+    <button
+      class="btn"
+      style="color: rgb(41, 41, 41);"
     >
-      <button
-        class="btn"
-        style="color: rgb(41, 41, 41);"
-      >
-        Preview
-      </button>
-    </div>
+      Preview
+    </button>
     <span
       data-testid="markdown"
-      style="padding: 1rem; width: 100%; display: block; margin-top: 0px;"
+      style="padding: 1rem; width: 100%; display: block;"
     />
   </div>
 </div>
@@ -68,26 +52,18 @@ exports[`MdInput Component Should switch to Preview mode when user clicks Previe
 exports[`MdInput Component Should switch to Write mode when user clicks Write button 1`] = `
 <div>
   <div>
-    <div
-      style="display: inline-block; background-color: rgba(0, 0, 0, 0.2); border-radius: 0.25rem;"
+    <button
+      class="btn"
+      style="color: rgb(41, 41, 41);"
     >
-      <button
-        class="btn"
-        style="color: rgb(41, 41, 41);"
-      >
-        Write
-      </button>
-    </div>
-    <div
-      style="display: inline-block;"
+      Write
+    </button>
+    <button
+      class="btn"
+      style="color: rgb(142, 142, 142);"
     >
-      <button
-        class="btn"
-        style="color: rgb(41, 41, 41);"
-      >
-        Preview
-      </button>
-    </div>
+      Preview
+    </button>
     <textarea
       data-testid="textbox"
       placeholder="Type something..."


### PR DESCRIPTION
This PR redesigns the look of the write and preview buttons of MdInput.
Originally, the buttons had no background, or a grey background depending on the mode chosen.
This does not have a smooth flow with the rest of the reviewCard component which has a white background.

I removed the grey background, and instead made the text color of the buttons different depending on the mode chosen.
Here is how it looks like when a person is in `write` mode.

<img width="326" alt="Screen Shot 2020-07-10 at 1 34 17 PM" src="https://user-images.githubusercontent.com/45890848/87201808-30644180-c2b4-11ea-8fdb-7b0929cd6864.png">
