### PR TITLE
closes #320 Update alerts to check for admin rights

### DIFF
--- a/helpers/controllers/alertController.test.js
+++ b/helpers/controllers/alertController.test.js
@@ -43,7 +43,7 @@ describe('Alert controller tests', () => {
       )
     ).resolves.toEqual({ success: true })
   })
-  test('Should add alert - throw error if missing parameters', async () => {
+  test('Should throw error if missing parameters', async () => {
     expect(
       addAlert({}, { url: 'https://google.com' }, ctx)
     ).rejects.toThrowError('Missing alert parameters')
@@ -52,7 +52,7 @@ describe('Alert controller tests', () => {
   test('Should remove alert', async () => {
     expect(removeAlert({}, { id: 5 }, ctx)).resolves.toEqual({ success: true })
   })
-  test('Should remove alert - throw error if no id provided', async () => {
+  test('Should throw error if no id provided when removing alert', async () => {
     db.Alert.destroy = jest.fn().mockRejectedValueOnce('No alert id provided')
     expect(removeAlert({}, {}, ctx)).rejects.toThrowError(
       'No alert id provided'

--- a/helpers/controllers/alertController.test.js
+++ b/helpers/controllers/alertController.test.js
@@ -5,9 +5,15 @@ import { addAlert, removeAlert } from './alertController'
 
 describe('Alert controller tests', () => {
   const ctx = {
-    req: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), session: {} }
+    req: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      session: {},
+      user: { isAdmin: 'true' }
+    }
   }
-  test('Add alert', async () => {
+  test('Should add alert', async () => {
     expect(
       addAlert(
         {},
@@ -22,7 +28,7 @@ describe('Alert controller tests', () => {
       )
     ).resolves.toEqual({ success: true })
   })
-  test('Add alert with url and caption', async () => {
+  test('Should add alert with url and caption', async () => {
     expect(
       addAlert(
         {},
@@ -37,19 +43,31 @@ describe('Alert controller tests', () => {
       )
     ).resolves.toEqual({ success: true })
   })
-  test('Add alert - throw error if missing parameters', async () => {
+  test('Should add alert - throw error if missing parameters', async () => {
     expect(
       addAlert({}, { url: 'https://google.com' }, ctx)
     ).rejects.toThrowError('Missing alert parameters')
   })
 
-  test('Remove alert', async () => {
+  test('Should remove alert', async () => {
     expect(removeAlert({}, { id: 5 }, ctx)).resolves.toEqual({ success: true })
   })
-  test('Remove alert - throw error if no id provided', async () => {
+  test('Should remove alert - throw error if no id provided', async () => {
     db.Alert.destroy = jest.fn().mockRejectedValueOnce('No alert id provided')
     expect(removeAlert({}, {}, ctx)).rejects.toThrowError(
       'No alert id provided'
     )
+  })
+  test('Should throw Error when user is not an admin when adding Alert', async () => {
+    ctx.req.user.isAdmin = 'false'
+    expect(
+      addAlert({}, { url: 'https://google.com' }, ctx)
+    ).rejects.toThrowError('User is not an admin')
+  })
+  test('Should throw Error when user is not an admin when removing Alert', async () => {
+    ctx.req.user.isAdmin = 'false'
+    expect(
+      removeAlert({}, { url: 'https://google.com' }, ctx)
+    ).rejects.toThrowError('User is not an admin')
   })
 })

--- a/helpers/controllers/alertController.ts
+++ b/helpers/controllers/alertController.ts
@@ -1,6 +1,7 @@
 import db from '../dbload'
 import { LoggedRequest } from '../../@types/helpers'
 
+import _ from 'lodash'
 const { Alert } = db
 
 type AlertData = {
@@ -16,7 +17,11 @@ export const addAlert = async (
   ctx: { req: LoggedRequest }
 ) => {
   const { req } = ctx
+  const isAdmin = _.get(req, 'user.isAdmin', false)
   try {
+    if (isAdmin === 'false') {
+      throw new Error('User is not an admin')
+    }
     const { text, type, url, urlCaption } = arg
     if (!text || !type) {
       throw new Error('Missing alert parameters')
@@ -37,7 +42,11 @@ export const removeAlert = async (
   ctx: { req: LoggedRequest }
 ) => {
   const { req } = ctx
+  const isAdmin = _.get(req, 'user.isAdmin', false)
   try {
+    if (isAdmin === 'false') {
+      throw new Error('User is not an admin')
+    }
     const { id } = arg
     await Alert.destroy({ where: { id } })
     return {

--- a/helpers/controllers/alertController.ts
+++ b/helpers/controllers/alertController.ts
@@ -1,6 +1,8 @@
 import db from '../dbload'
 import { LoggedRequest } from '../../@types/helpers'
 import _ from 'lodash'
+import { isAdmin } from '../isAdmin'
+
 const { Alert } = db
 
 type AlertData = {
@@ -16,9 +18,8 @@ export const addAlert = async (
   ctx: { req: LoggedRequest }
 ) => {
   const { req } = ctx
-  const isAdmin = _.get(req, 'user.isAdmin', false)
   try {
-    if (isAdmin === 'false') {
+    if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
     const { text, type, url, urlCaption } = arg
@@ -41,9 +42,8 @@ export const removeAlert = async (
   ctx: { req: LoggedRequest }
 ) => {
   const { req } = ctx
-  const isAdmin = _.get(req, 'user.isAdmin', false)
   try {
-    if (isAdmin === 'false') {
+    if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
     const { id } = arg

--- a/helpers/controllers/alertController.ts
+++ b/helpers/controllers/alertController.ts
@@ -1,6 +1,5 @@
 import db from '../dbload'
 import { LoggedRequest } from '../../@types/helpers'
-
 import _ from 'lodash'
 const { Alert } = db
 

--- a/helpers/isAdmin.ts
+++ b/helpers/isAdmin.ts
@@ -1,0 +1,6 @@
+import { LoggedRequest } from '../@types/helpers'
+import _ from 'lodash'
+
+export const isAdmin = (req: LoggedRequest) => {
+  return _.get(req, 'user.isAdmin', false) === 'true'
+}


### PR DESCRIPTION
Our resolvers for Graphql mutations `addAlert` and `removeAlert` do not check if the user is an admin or not. This is a security flaw because  non-admins can attack the site by sending out alerts continuously

This PR aims to solve this issue by checking to make sure the user is an admin before adding or removing any alerts. A helper function `isAdmin` is also created.