### PR TITLE
Signup Schema: Require Lowercase Alpha-Characters for Email Field (Resolves #244)

### DIFF
--- a/helpers/formValidation.tsx
+++ b/helpers/formValidation.tsx
@@ -7,6 +7,8 @@ const REGEX_ALPHANUMERICS_AND_SPACE = /^[a-zA-Z0-9_\s]*$/
 
 const signupValidation = Yup.object({
   email: Yup.string()
+    .strict(true)
+    .lowercase('Alpha characters must be lowercase')
     .email('Invalid email address')
     .required('Required'),
   username: Yup.string()


### PR DESCRIPTION
#### Issue

- sentry.io reports an error in a downstream service when email address and usernames contains uppercase alpha-characters

#### Resolution

- Update signup form schema to require lowercase alpha-characters for email field

#### Notes

- Resolves #244
- Schemas for signup and login already require lowercase alpha-characters