### PR TITLE
closes #327 - Creation of graphql resolvers needed for admin page

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -1,53 +1,41 @@
-import {
-  GraphQLResolveInfo,
-  GraphQLScalarType,
-  GraphQLScalarTypeConfig
-} from 'graphql'
-import gql from 'graphql-tag'
-import * as ApolloReactCommon from '@apollo/react-common'
-import * as React from 'react'
-import * as ApolloReactComponents from '@apollo/react-components'
-import * as ApolloReactHoc from '@apollo/react-hoc'
-import * as ApolloReactHooks from '@apollo/react-hooks'
-export type Maybe<T> = T | null
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] }
-export type RequireFields<T, K extends keyof T> = {
-  [X in Exclude<keyof T, K>]?: T[X]
-} &
-  { [P in K]-?: NonNullable<T[P]> }
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import gql from 'graphql-tag';
+import * as ApolloReactCommon from '@apollo/react-common';
+import * as React from 'react';
+import * as ApolloReactComponents from '@apollo/react-components';
+import * as ApolloReactHoc from '@apollo/react-hoc';
+import * as ApolloReactHooks from '@apollo/react-hooks';
+export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string
-  String: string
-  Boolean: boolean
-  Int: number
-  Float: number
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any
-}
+  Upload: any;
+};
 
 export type Alert = {
-  __typename?: 'Alert'
-  id: Scalars['String']
-  text?: Maybe<Scalars['String']>
-  type?: Maybe<Scalars['String']>
-  url?: Maybe<Scalars['String']>
-  urlCaption?: Maybe<Scalars['String']>
-}
-
-export type AlertResponse = {
-  __typename?: 'AlertResponse'
-  success?: Maybe<Scalars['Boolean']>
-}
+  __typename?: 'Alert';
+  id: Scalars['String'];
+  text?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+  urlCaption?: Maybe<Scalars['String']>;
+};
 
 export type AuthResponse = {
-  __typename?: 'AuthResponse'
-  success?: Maybe<Scalars['Boolean']>
-  username?: Maybe<Scalars['String']>
-  error?: Maybe<Scalars['String']>
-  cliToken?: Maybe<Scalars['String']>
-}
+  __typename?: 'AuthResponse';
+  success?: Maybe<Scalars['Boolean']>;
+  username?: Maybe<Scalars['String']>;
+  error?: Maybe<Scalars['String']>;
+  cliToken?: Maybe<Scalars['String']>;
+};
 
 export enum CacheControlScope {
   Public = 'PUBLIC',
@@ -55,971 +43,741 @@ export enum CacheControlScope {
 }
 
 export type Challenge = {
-  __typename?: 'Challenge'
-  id?: Maybe<Scalars['String']>
-  description?: Maybe<Scalars['String']>
-  lessonId?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
-}
+  __typename?: 'Challenge';
+  id?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  lessonId?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+};
 
 export type Lesson = {
-  __typename?: 'Lesson'
-  id?: Maybe<Scalars['String']>
-  description?: Maybe<Scalars['String']>
-  docUrl?: Maybe<Scalars['String']>
-  githubUrl?: Maybe<Scalars['String']>
-  videoUrl?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
-  title?: Maybe<Scalars['String']>
-  challenges?: Maybe<Array<Maybe<Challenge>>>
-  users?: Maybe<Array<Maybe<User>>>
-  currentUser?: Maybe<User>
-  chatUrl?: Maybe<Scalars['String']>
-}
+  __typename?: 'Lesson';
+  id?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  docUrl?: Maybe<Scalars['String']>;
+  githubUrl?: Maybe<Scalars['String']>;
+  videoUrl?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  title?: Maybe<Scalars['String']>;
+  challenges?: Maybe<Array<Maybe<Challenge>>>;
+  users?: Maybe<Array<Maybe<User>>>;
+  currentUser?: Maybe<User>;
+  chatUrl?: Maybe<Scalars['String']>;
+};
 
 export type Mutation = {
-  __typename?: 'Mutation'
-  login?: Maybe<AuthResponse>
-  logout?: Maybe<AuthResponse>
-  reqPwReset?: Maybe<TokenResponse>
-  changePw?: Maybe<AuthResponse>
-  signup?: Maybe<AuthResponse>
-  addAlert?: Maybe<AlertResponse>
-  removeAlert?: Maybe<AlertResponse>
-  createSubmission?: Maybe<Submission>
-  acceptSubmission?: Maybe<Submission>
-  rejectSubmission?: Maybe<Submission>
-}
+  __typename?: 'Mutation';
+  login?: Maybe<AuthResponse>;
+  logout?: Maybe<AuthResponse>;
+  reqPwReset?: Maybe<TokenResponse>;
+  changePw?: Maybe<AuthResponse>;
+  changeAdminRights?: Maybe<SuccessResponse>;
+  signup?: Maybe<AuthResponse>;
+  addAlert?: Maybe<SuccessResponse>;
+  removeAlert?: Maybe<SuccessResponse>;
+  createSubmission?: Maybe<Submission>;
+  acceptSubmission?: Maybe<Submission>;
+  rejectSubmission?: Maybe<Submission>;
+  createLesson?: Maybe<SuccessResponse>;
+  updateLesson?: Maybe<SuccessResponse>;
+  createChallenge?: Maybe<SuccessResponse>;
+  updateChallenge?: Maybe<SuccessResponse>;
+};
+
 
 export type MutationLoginArgs = {
-  username: Scalars['String']
-  password: Scalars['String']
-}
+  username: Scalars['String'];
+  password: Scalars['String'];
+};
+
 
 export type MutationReqPwResetArgs = {
-  userOrEmail: Scalars['String']
-}
+  userOrEmail: Scalars['String'];
+};
+
 
 export type MutationChangePwArgs = {
-  token: Scalars['String']
-  password: Scalars['String']
-}
+  token: Scalars['String'];
+  password: Scalars['String'];
+};
+
+
+export type MutationChangeAdminRightsArgs = {
+  username: Scalars['String'];
+  status: Scalars['String'];
+};
+
 
 export type MutationSignupArgs = {
-  firstName: Scalars['String']
-  lastName: Scalars['String']
-  email: Scalars['String']
-  username: Scalars['String']
-  password?: Maybe<Scalars['String']>
-}
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  email: Scalars['String'];
+  username: Scalars['String'];
+  password?: Maybe<Scalars['String']>;
+};
+
 
 export type MutationAddAlertArgs = {
-  text: Scalars['String']
-  type: Scalars['String']
-  url?: Maybe<Scalars['String']>
-  urlCaption?: Maybe<Scalars['String']>
-}
+  text: Scalars['String'];
+  type: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
+  urlCaption?: Maybe<Scalars['String']>;
+};
+
 
 export type MutationRemoveAlertArgs = {
-  id: Scalars['String']
-}
+  id: Scalars['String'];
+};
+
 
 export type MutationCreateSubmissionArgs = {
-  lessonId: Scalars['String']
-  challengeId: Scalars['String']
-  cliToken: Scalars['String']
-  diff: Scalars['String']
-}
+  lessonId: Scalars['String'];
+  challengeId: Scalars['String'];
+  cliToken: Scalars['String'];
+  diff: Scalars['String'];
+};
+
 
 export type MutationAcceptSubmissionArgs = {
-  id: Scalars['String']
-  comment: Scalars['String']
-}
+  id: Scalars['String'];
+  comment: Scalars['String'];
+};
+
 
 export type MutationRejectSubmissionArgs = {
-  id: Scalars['String']
-  comment: Scalars['String']
-}
+  id: Scalars['String'];
+  comment: Scalars['String'];
+};
+
+
+export type MutationCreateLessonArgs = {
+  description: Scalars['String'];
+  docUrl?: Maybe<Scalars['String']>;
+  githubUrl?: Maybe<Scalars['String']>;
+  videoUrl?: Maybe<Scalars['String']>;
+  title: Scalars['String'];
+  chatUrl?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+  order: Scalars['Int'];
+};
+
+
+export type MutationUpdateLessonArgs = {
+  id: Scalars['Int'];
+  description?: Maybe<Scalars['String']>;
+  docUrl?: Maybe<Scalars['String']>;
+  githubUrl?: Maybe<Scalars['String']>;
+  videoUrl?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  chatUrl?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+};
+
+
+export type MutationCreateChallengeArgs = {
+  lessonId: Scalars['Int'];
+  id: Scalars['Int'];
+  order: Scalars['Int'];
+  description?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationUpdateChallengeArgs = {
+  lessonId: Scalars['Int'];
+  id: Scalars['Int'];
+  order: Scalars['Int'];
+  description?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
 
 export type Query = {
-  __typename?: 'Query'
-  lessons: Array<Lesson>
-  session?: Maybe<Session>
-  userInfo?: Maybe<Session>
-  isTokenValid: Scalars['Boolean']
-  submissions?: Maybe<Array<Maybe<Submission>>>
-  alerts: Array<Alert>
-}
+  __typename?: 'Query';
+  lessons: Array<Lesson>;
+  session?: Maybe<Session>;
+  allUsers?: Maybe<Array<Maybe<User>>>;
+  userInfo?: Maybe<Session>;
+  isTokenValid: Scalars['Boolean'];
+  submissions?: Maybe<Array<Maybe<Submission>>>;
+  alerts: Array<Alert>;
+};
+
 
 export type QueryUserInfoArgs = {
-  username: Scalars['String']
-}
+  username: Scalars['String'];
+};
+
 
 export type QueryIsTokenValidArgs = {
-  cliToken: Scalars['String']
-}
+  cliToken: Scalars['String'];
+};
+
 
 export type QuerySubmissionsArgs = {
-  lessonId: Scalars['String']
-}
+  lessonId: Scalars['String'];
+};
 
 export type Session = {
-  __typename?: 'Session'
-  user?: Maybe<User>
-  submissions?: Maybe<Array<Maybe<Submission>>>
-  lessonStatus: Array<UserLesson>
-}
+  __typename?: 'Session';
+  user?: Maybe<User>;
+  submissions?: Maybe<Array<Maybe<Submission>>>;
+  lessonStatus: Array<UserLesson>;
+};
 
 export type Submission = {
-  __typename?: 'Submission'
-  id?: Maybe<Scalars['String']>
-  status?: Maybe<Scalars['String']>
-  mrUrl?: Maybe<Scalars['String']>
-  diff?: Maybe<Scalars['String']>
-  viewCount?: Maybe<Scalars['Int']>
-  comment?: Maybe<Scalars['String']>
-  userId?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
-  lessonId?: Maybe<Scalars['String']>
-  challengeId?: Maybe<Scalars['String']>
-  challenge?: Maybe<Challenge>
-  reviewer?: Maybe<User>
-  user?: Maybe<User>
-  reviewerId?: Maybe<Scalars['String']>
-  createdAt?: Maybe<Scalars['String']>
-  updatedAt?: Maybe<Scalars['String']>
-}
+  __typename?: 'Submission';
+  id?: Maybe<Scalars['String']>;
+  status?: Maybe<Scalars['String']>;
+  mrUrl?: Maybe<Scalars['String']>;
+  diff?: Maybe<Scalars['String']>;
+  viewCount?: Maybe<Scalars['Int']>;
+  comment?: Maybe<Scalars['String']>;
+  userId?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  lessonId?: Maybe<Scalars['String']>;
+  challengeId?: Maybe<Scalars['String']>;
+  challenge?: Maybe<Challenge>;
+  reviewer?: Maybe<User>;
+  user?: Maybe<User>;
+  reviewerId?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['String']>;
+};
+
+export type SuccessResponse = {
+  __typename?: 'SuccessResponse';
+  success?: Maybe<Scalars['Boolean']>;
+};
 
 export type TokenResponse = {
-  __typename?: 'TokenResponse'
-  success?: Maybe<Scalars['Boolean']>
-  token?: Maybe<Scalars['String']>
-}
+  __typename?: 'TokenResponse';
+  success?: Maybe<Scalars['Boolean']>;
+  token?: Maybe<Scalars['String']>;
+};
+
 
 export type User = {
-  __typename?: 'User'
-  id?: Maybe<Scalars['String']>
-  username?: Maybe<Scalars['String']>
-  userLesson?: Maybe<UserLesson>
-  email?: Maybe<Scalars['String']>
-  name?: Maybe<Scalars['String']>
-  isAdmin?: Maybe<Scalars['String']>
-  cliToken?: Maybe<Scalars['String']>
-}
+  __typename?: 'User';
+  id?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+  userLesson?: Maybe<UserLesson>;
+  email?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  isAdmin?: Maybe<Scalars['String']>;
+  cliToken?: Maybe<Scalars['String']>;
+};
 
 export type UserLesson = {
-  __typename?: 'UserLesson'
-  id?: Maybe<Scalars['String']>
-  userId?: Maybe<Scalars['String']>
-  lessonId?: Maybe<Scalars['String']>
-  isPassed?: Maybe<Scalars['String']>
-  isTeaching?: Maybe<Scalars['String']>
-  isEnrolled?: Maybe<Scalars['String']>
-  starGiven?: Maybe<User>
-  starComment?: Maybe<Scalars['String']>
-}
+  __typename?: 'UserLesson';
+  id?: Maybe<Scalars['String']>;
+  userId?: Maybe<Scalars['String']>;
+  lessonId?: Maybe<Scalars['String']>;
+  isPassed?: Maybe<Scalars['String']>;
+  isTeaching?: Maybe<Scalars['String']>;
+  isEnrolled?: Maybe<Scalars['String']>;
+  starGiven?: Maybe<User>;
+  starComment?: Maybe<Scalars['String']>;
+};
 
 export type AcceptSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String']
-  comment: Scalars['String']
-}>
+  submissionId: Scalars['String'];
+  comment: Scalars['String'];
+}>;
 
-export type AcceptSubmissionMutation = { __typename?: 'Mutation' } & {
-  acceptSubmission?: Maybe<
-    { __typename?: 'Submission' } & Pick<
-      Submission,
-      'id' | 'comment' | 'status'
-    >
-  >
-}
+
+export type AcceptSubmissionMutation = (
+  { __typename?: 'Mutation' }
+  & { acceptSubmission?: Maybe<(
+    { __typename?: 'Submission' }
+    & Pick<Submission, 'id' | 'comment' | 'status'>
+  )> }
+);
 
 export type AddAlertMutationVariables = Exact<{
-  text: Scalars['String']
-  type: Scalars['String']
-}>
+  text: Scalars['String'];
+  type: Scalars['String'];
+}>;
 
-export type AddAlertMutation = { __typename?: 'Mutation' } & {
-  addAlert?: Maybe<
-    { __typename?: 'AlertResponse' } & Pick<AlertResponse, 'success'>
-  >
-}
 
-export type GetAppQueryVariables = Exact<{ [key: string]: never }>
+export type AddAlertMutation = (
+  { __typename?: 'Mutation' }
+  & { addAlert?: Maybe<(
+    { __typename?: 'SuccessResponse' }
+    & Pick<SuccessResponse, 'success'>
+  )> }
+);
 
-export type GetAppQuery = { __typename?: 'Query' } & {
-  lessons: Array<
-    { __typename?: 'Lesson' } & Pick<
-      Lesson,
-      | 'id'
-      | 'title'
-      | 'description'
-      | 'docUrl'
-      | 'githubUrl'
-      | 'videoUrl'
-      | 'order'
-      | 'chatUrl'
-    > & {
-        challenges?: Maybe<
-          Array<
-            Maybe<
-              { __typename?: 'Challenge' } & Pick<
-                Challenge,
-                'id' | 'title' | 'description' | 'order'
-              >
-            >
-          >
-        >
-      }
-  >
-  session?: Maybe<
-    { __typename?: 'Session' } & {
-      user?: Maybe<
-        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
-      >
-      submissions?: Maybe<
-        Array<
-          Maybe<
-            { __typename?: 'Submission' } & Pick<
-              Submission,
-              | 'id'
-              | 'status'
-              | 'mrUrl'
-              | 'diff'
-              | 'viewCount'
-              | 'comment'
-              | 'order'
-              | 'challengeId'
-              | 'lessonId'
-              | 'createdAt'
-              | 'updatedAt'
-            > & {
-                reviewer?: Maybe<
-                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
-                >
-              }
-          >
-        >
-      >
-      lessonStatus: Array<
-        { __typename?: 'UserLesson' } & Pick<
-          UserLesson,
-          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
-        >
-      >
-    }
-  >
-  alerts: Array<
-    { __typename?: 'Alert' } & Pick<
-      Alert,
-      'id' | 'text' | 'type' | 'url' | 'urlCaption'
-    >
-  >
-}
+export type GetAppQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAppQuery = (
+  { __typename?: 'Query' }
+  & { lessons: Array<(
+    { __typename?: 'Lesson' }
+    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
+    & { challenges?: Maybe<Array<Maybe<(
+      { __typename?: 'Challenge' }
+      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
+    )>>> }
+  )>, session?: Maybe<(
+    { __typename?: 'Session' }
+    & { user?: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'username' | 'name'>
+    )>, submissions?: Maybe<Array<Maybe<(
+      { __typename?: 'Submission' }
+      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
+      & { reviewer?: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'id' | 'username'>
+      )> }
+    )>>>, lessonStatus: Array<(
+      { __typename?: 'UserLesson' }
+      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
+    )> }
+  )>, alerts: Array<(
+    { __typename?: 'Alert' }
+    & Pick<Alert, 'id' | 'text' | 'type' | 'url' | 'urlCaption'>
+  )> }
+);
 
 export type SubmissionsQueryVariables = Exact<{
-  lessonId: Scalars['String']
-}>
+  lessonId: Scalars['String'];
+}>;
 
-export type SubmissionsQuery = { __typename?: 'Query' } & {
-  submissions?: Maybe<
-    Array<
-      Maybe<
-        { __typename?: 'Submission' } & Pick<
-          Submission,
-          | 'id'
-          | 'status'
-          | 'diff'
-          | 'comment'
-          | 'challengeId'
-          | 'createdAt'
-          | 'updatedAt'
-        > & {
-            user?: Maybe<
-              { __typename?: 'User' } & Pick<User, 'id' | 'username'>
-            >
-          }
-      >
-    >
-  >
-}
+
+export type SubmissionsQuery = (
+  { __typename?: 'Query' }
+  & { submissions?: Maybe<Array<Maybe<(
+    { __typename?: 'Submission' }
+    & Pick<Submission, 'id' | 'status' | 'diff' | 'comment' | 'challengeId' | 'createdAt' | 'updatedAt'>
+    & { user?: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'username'>
+    )> }
+  )>>> }
+);
 
 export type LoginMutationVariables = Exact<{
-  username: Scalars['String']
-  password: Scalars['String']
-}>
+  username: Scalars['String'];
+  password: Scalars['String'];
+}>;
 
-export type LoginMutation = { __typename?: 'Mutation' } & {
-  login?: Maybe<
-    { __typename?: 'AuthResponse' } & Pick<
-      AuthResponse,
-      'success' | 'username' | 'cliToken' | 'error'
-    >
-  >
-}
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never }>
+export type LoginMutation = (
+  { __typename?: 'Mutation' }
+  & { login?: Maybe<(
+    { __typename?: 'AuthResponse' }
+    & Pick<AuthResponse, 'success' | 'username' | 'cliToken' | 'error'>
+  )> }
+);
 
-export type LogoutMutation = { __typename?: 'Mutation' } & {
-  logout?: Maybe<
-    { __typename?: 'AuthResponse' } & Pick<
-      AuthResponse,
-      'success' | 'username' | 'error'
-    >
-  >
-}
+export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LogoutMutation = (
+  { __typename?: 'Mutation' }
+  & { logout?: Maybe<(
+    { __typename?: 'AuthResponse' }
+    & Pick<AuthResponse, 'success' | 'username' | 'error'>
+  )> }
+);
 
 export type RejectSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String']
-  comment: Scalars['String']
-}>
+  submissionId: Scalars['String'];
+  comment: Scalars['String'];
+}>;
 
-export type RejectSubmissionMutation = { __typename?: 'Mutation' } & {
-  rejectSubmission?: Maybe<
-    { __typename?: 'Submission' } & Pick<
-      Submission,
-      'id' | 'comment' | 'status'
-    >
-  >
-}
+
+export type RejectSubmissionMutation = (
+  { __typename?: 'Mutation' }
+  & { rejectSubmission?: Maybe<(
+    { __typename?: 'Submission' }
+    & Pick<Submission, 'id' | 'comment' | 'status'>
+  )> }
+);
 
 export type ReqPwResetMutationVariables = Exact<{
-  userOrEmail: Scalars['String']
-}>
+  userOrEmail: Scalars['String'];
+}>;
 
-export type ReqPwResetMutation = { __typename?: 'Mutation' } & {
-  reqPwReset?: Maybe<
-    { __typename?: 'TokenResponse' } & Pick<TokenResponse, 'success' | 'token'>
-  >
-}
+
+export type ReqPwResetMutation = (
+  { __typename?: 'Mutation' }
+  & { reqPwReset?: Maybe<(
+    { __typename?: 'TokenResponse' }
+    & Pick<TokenResponse, 'success' | 'token'>
+  )> }
+);
 
 export type SignupMutationVariables = Exact<{
-  firstName: Scalars['String']
-  lastName: Scalars['String']
-  email: Scalars['String']
-  username: Scalars['String']
-}>
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  email: Scalars['String'];
+  username: Scalars['String'];
+}>;
 
-export type SignupMutation = { __typename?: 'Mutation' } & {
-  signup?: Maybe<
-    { __typename?: 'AuthResponse' } & Pick<
-      AuthResponse,
-      'success' | 'username' | 'error'
-    >
-  >
-}
+
+export type SignupMutation = (
+  { __typename?: 'Mutation' }
+  & { signup?: Maybe<(
+    { __typename?: 'AuthResponse' }
+    & Pick<AuthResponse, 'success' | 'username' | 'error'>
+  )> }
+);
 
 export type ChangePwMutationVariables = Exact<{
-  token: Scalars['String']
-  password: Scalars['String']
-}>
+  token: Scalars['String'];
+  password: Scalars['String'];
+}>;
 
-export type ChangePwMutation = { __typename?: 'Mutation' } & {
-  changePw?: Maybe<
-    { __typename?: 'AuthResponse' } & Pick<AuthResponse, 'success'>
-  >
-}
+
+export type ChangePwMutation = (
+  { __typename?: 'Mutation' }
+  & { changePw?: Maybe<(
+    { __typename?: 'AuthResponse' }
+    & Pick<AuthResponse, 'success'>
+  )> }
+);
 
 export type UserInfoQueryVariables = Exact<{
-  username: Scalars['String']
-}>
+  username: Scalars['String'];
+}>;
 
-export type UserInfoQuery = { __typename?: 'Query' } & {
-  lessons: Array<
-    { __typename?: 'Lesson' } & Pick<
-      Lesson,
-      | 'id'
-      | 'title'
-      | 'description'
-      | 'docUrl'
-      | 'githubUrl'
-      | 'videoUrl'
-      | 'order'
-      | 'chatUrl'
-    > & {
-        challenges?: Maybe<
-          Array<
-            Maybe<
-              { __typename?: 'Challenge' } & Pick<
-                Challenge,
-                'id' | 'title' | 'description' | 'order'
-              >
-            >
-          >
-        >
-      }
-  >
-  userInfo?: Maybe<
-    { __typename?: 'Session' } & {
-      user?: Maybe<
-        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
-      >
-      submissions?: Maybe<
-        Array<
-          Maybe<
-            { __typename?: 'Submission' } & Pick<
-              Submission,
-              | 'id'
-              | 'status'
-              | 'mrUrl'
-              | 'diff'
-              | 'viewCount'
-              | 'comment'
-              | 'order'
-              | 'challengeId'
-              | 'lessonId'
-              | 'createdAt'
-              | 'updatedAt'
-            > & {
-                reviewer?: Maybe<
-                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
-                >
-              }
-          >
-        >
-      >
-      lessonStatus: Array<
-        { __typename?: 'UserLesson' } & Pick<
-          UserLesson,
-          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
-        >
-      >
-    }
-  >
-}
 
-export type ResolverTypeWrapper<T> = Promise<T> | T
+export type UserInfoQuery = (
+  { __typename?: 'Query' }
+  & { lessons: Array<(
+    { __typename?: 'Lesson' }
+    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
+    & { challenges?: Maybe<Array<Maybe<(
+      { __typename?: 'Challenge' }
+      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
+    )>>> }
+  )>, userInfo?: Maybe<(
+    { __typename?: 'Session' }
+    & { user?: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'username' | 'name'>
+    )>, submissions?: Maybe<Array<Maybe<(
+      { __typename?: 'Submission' }
+      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
+      & { reviewer?: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'id' | 'username'>
+      )> }
+    )>>>, lessonStatus: Array<(
+      { __typename?: 'UserLesson' }
+      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
+    )> }
+  )> }
+);
+
+
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  fragment: string
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
-}
+  fragment: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
 
 export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  selectionSet: string
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
-}
-export type StitchingResolver<TResult, TParent, TContext, TArgs> =
-  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
-  | NewStitchingResolver<TResult, TParent, TContext, TArgs>
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
-  | StitchingResolver<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => Promise<TResult> | TResult
+) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>
+) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> {
-  subscribe: SubscriptionSubscribeFn<
-    { [key in TKey]: TResult },
-    TParent,
-    TContext,
-    TArgs
-  >
-  resolve?: SubscriptionResolveFn<
-    TResult,
-    { [key in TKey]: TResult },
-    TContext,
-    TArgs
-  >
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>
-  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> =
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
-  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<
-  TResult,
-  TKey extends string,
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> =
-  | ((
-      ...args: any[]
-    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
-  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
   info: GraphQLResolveInfo
-) => Maybe<TTypes> | Promise<Maybe<TTypes>>
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}> = (
-  obj: T,
-  info: GraphQLResolveInfo
-) => boolean | Promise<boolean>
+export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
-export type NextResolverFn<T> = () => Promise<T>
+export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<
-  TResult = {},
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> = (
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>
+) => TResult | Promise<TResult>;
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Query: ResolverTypeWrapper<{}>
-  Lesson: ResolverTypeWrapper<Lesson>
-  String: ResolverTypeWrapper<Scalars['String']>
-  Int: ResolverTypeWrapper<Scalars['Int']>
-  Challenge: ResolverTypeWrapper<Challenge>
-  User: ResolverTypeWrapper<User>
-  UserLesson: ResolverTypeWrapper<UserLesson>
-  Session: ResolverTypeWrapper<Session>
-  Submission: ResolverTypeWrapper<Submission>
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>
-  Alert: ResolverTypeWrapper<Alert>
-  Mutation: ResolverTypeWrapper<{}>
-  AuthResponse: ResolverTypeWrapper<AuthResponse>
-  TokenResponse: ResolverTypeWrapper<TokenResponse>
-  AlertResponse: ResolverTypeWrapper<AlertResponse>
-  CacheControlScope: CacheControlScope
-  Upload: ResolverTypeWrapper<Scalars['Upload']>
-}
+  Query: ResolverTypeWrapper<{}>;
+  Lesson: ResolverTypeWrapper<Lesson>;
+  String: ResolverTypeWrapper<Scalars['String']>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  Challenge: ResolverTypeWrapper<Challenge>;
+  User: ResolverTypeWrapper<User>;
+  UserLesson: ResolverTypeWrapper<UserLesson>;
+  Session: ResolverTypeWrapper<Session>;
+  Submission: ResolverTypeWrapper<Submission>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  Alert: ResolverTypeWrapper<Alert>;
+  Mutation: ResolverTypeWrapper<{}>;
+  AuthResponse: ResolverTypeWrapper<AuthResponse>;
+  TokenResponse: ResolverTypeWrapper<TokenResponse>;
+  SuccessResponse: ResolverTypeWrapper<SuccessResponse>;
+  CacheControlScope: CacheControlScope;
+  Upload: ResolverTypeWrapper<Scalars['Upload']>;
+};
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Query: {}
-  Lesson: Lesson
-  String: Scalars['String']
-  Int: Scalars['Int']
-  Challenge: Challenge
-  User: User
-  UserLesson: UserLesson
-  Session: Session
-  Submission: Submission
-  Boolean: Scalars['Boolean']
-  Alert: Alert
-  Mutation: {}
-  AuthResponse: AuthResponse
-  TokenResponse: TokenResponse
-  AlertResponse: AlertResponse
-  Upload: Scalars['Upload']
+  Query: {};
+  Lesson: Lesson;
+  String: Scalars['String'];
+  Int: Scalars['Int'];
+  Challenge: Challenge;
+  User: User;
+  UserLesson: UserLesson;
+  Session: Session;
+  Submission: Submission;
+  Boolean: Scalars['Boolean'];
+  Alert: Alert;
+  Mutation: {};
+  AuthResponse: AuthResponse;
+  TokenResponse: TokenResponse;
+  SuccessResponse: SuccessResponse;
+  Upload: Scalars['Upload'];
+};
+
+export type AlertResolvers<ContextType = any, ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']> = {
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  urlCaption?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type AuthResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type ChallengeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type LessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  challenges?: Resolver<Maybe<Array<Maybe<ResolversTypes['Challenge']>>>, ParentType, ContextType>;
+  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
+  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  login?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationLoginArgs, 'username' | 'password'>>;
+  logout?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType>;
+  reqPwReset?: Resolver<Maybe<ResolversTypes['TokenResponse']>, ParentType, ContextType, RequireFields<MutationReqPwResetArgs, 'userOrEmail'>>;
+  changePw?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationChangePwArgs, 'token' | 'password'>>;
+  changeAdminRights?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationChangeAdminRightsArgs, 'username' | 'status'>>;
+  signup?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationSignupArgs, 'firstName' | 'lastName' | 'email' | 'username'>>;
+  addAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationAddAlertArgs, 'text' | 'type'>>;
+  removeAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationRemoveAlertArgs, 'id'>>;
+  createSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationCreateSubmissionArgs, 'lessonId' | 'challengeId' | 'cliToken' | 'diff'>>;
+  acceptSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>>;
+  rejectSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>>;
+  createLesson?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'id' | 'order'>>;
+  updateLesson?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationUpdateLessonArgs, 'id'>>;
+  createChallenge?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'id' | 'order'>>;
+  updateChallenge?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id' | 'order'>>;
+};
+
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>;
+  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>;
+  allUsers?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
+  userInfo?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType, RequireFields<QueryUserInfoArgs, 'username'>>;
+  isTokenValid?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<QueryIsTokenValidArgs, 'cliToken'>>;
+  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType, RequireFields<QuerySubmissionsArgs, 'lessonId'>>;
+  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>;
+};
+
+export type SessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']> = {
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType>;
+  lessonStatus?: Resolver<Array<ResolversTypes['UserLesson']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  challengeId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  challenge?: Resolver<Maybe<ResolversTypes['Challenge']>, ParentType, ContextType>;
+  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  reviewerId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type SuccessResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type TokenResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export interface UploadScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
+  name: 'Upload';
 }
 
-export type AlertResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']
-> = {
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
-  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  urlCaption?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
+export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  userLesson?: Resolver<Maybe<ResolversTypes['UserLesson']>, ParentType, ContextType>;
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
 
-export type AlertResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['AlertResponse'] = ResolversParentTypes['AlertResponse']
-> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type AuthResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']
-> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type ChallengeResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  description?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type LessonResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  description?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  challenges?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Challenge']>>>,
-    ParentType,
-    ContextType
-  >
-  users?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['User']>>>,
-    ParentType,
-    ContextType
-  >
-  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type MutationResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
-> = {
-  login?: Resolver<
-    Maybe<ResolversTypes['AuthResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationLoginArgs, 'username' | 'password'>
-  >
-  logout?: Resolver<
-    Maybe<ResolversTypes['AuthResponse']>,
-    ParentType,
-    ContextType
-  >
-  reqPwReset?: Resolver<
-    Maybe<ResolversTypes['TokenResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationReqPwResetArgs, 'userOrEmail'>
-  >
-  changePw?: Resolver<
-    Maybe<ResolversTypes['AuthResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationChangePwArgs, 'token' | 'password'>
-  >
-  signup?: Resolver<
-    Maybe<ResolversTypes['AuthResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<
-      MutationSignupArgs,
-      'firstName' | 'lastName' | 'email' | 'username'
-    >
-  >
-  addAlert?: Resolver<
-    Maybe<ResolversTypes['AlertResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationAddAlertArgs, 'text' | 'type'>
-  >
-  removeAlert?: Resolver<
-    Maybe<ResolversTypes['AlertResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationRemoveAlertArgs, 'id'>
-  >
-  createSubmission?: Resolver<
-    Maybe<ResolversTypes['Submission']>,
-    ParentType,
-    ContextType,
-    RequireFields<
-      MutationCreateSubmissionArgs,
-      'lessonId' | 'challengeId' | 'cliToken' | 'diff'
-    >
-  >
-  acceptSubmission?: Resolver<
-    Maybe<ResolversTypes['Submission']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>
-  >
-  rejectSubmission?: Resolver<
-    Maybe<ResolversTypes['Submission']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>
-  >
-}
-
-export type QueryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
-> = {
-  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>
-  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>
-  userInfo?: Resolver<
-    Maybe<ResolversTypes['Session']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryUserInfoArgs, 'username'>
-  >
-  isTokenValid?: Resolver<
-    ResolversTypes['Boolean'],
-    ParentType,
-    ContextType,
-    RequireFields<QueryIsTokenValidArgs, 'cliToken'>
-  >
-  submissions?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
-    ParentType,
-    ContextType,
-    RequireFields<QuerySubmissionsArgs, 'lessonId'>
-  >
-  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>
-}
-
-export type SessionResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']
-> = {
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  submissions?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
-    ParentType,
-    ContextType
-  >
-  lessonStatus?: Resolver<
-    Array<ResolversTypes['UserLesson']>,
-    ParentType,
-    ContextType
-  >
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type SubmissionResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  challengeId?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  challenge?: Resolver<
-    Maybe<ResolversTypes['Challenge']>,
-    ParentType,
-    ContextType
-  >
-  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  reviewerId?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type TokenResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']
-> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
-  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export interface UploadScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
-  name: 'Upload'
-}
-
-export type UserResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  userLesson?: Resolver<
-    Maybe<ResolversTypes['UserLesson']>,
-    ParentType,
-    ContextType
-  >
-  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type UserLessonResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  isTeaching?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  isEnrolled?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  starGiven?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  starComment?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
+export type UserLessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isTeaching?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isEnrolled?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  starGiven?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  starComment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
 
 export type Resolvers<ContextType = any> = {
-  Alert?: AlertResolvers<ContextType>
-  AlertResponse?: AlertResponseResolvers<ContextType>
-  AuthResponse?: AuthResponseResolvers<ContextType>
-  Challenge?: ChallengeResolvers<ContextType>
-  Lesson?: LessonResolvers<ContextType>
-  Mutation?: MutationResolvers<ContextType>
-  Query?: QueryResolvers<ContextType>
-  Session?: SessionResolvers<ContextType>
-  Submission?: SubmissionResolvers<ContextType>
-  TokenResponse?: TokenResponseResolvers<ContextType>
-  Upload?: GraphQLScalarType
-  User?: UserResolvers<ContextType>
-  UserLesson?: UserLessonResolvers<ContextType>
-}
+  Alert?: AlertResolvers<ContextType>;
+  AuthResponse?: AuthResponseResolvers<ContextType>;
+  Challenge?: ChallengeResolvers<ContextType>;
+  Lesson?: LessonResolvers<ContextType>;
+  Mutation?: MutationResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+  Session?: SessionResolvers<ContextType>;
+  Submission?: SubmissionResolvers<ContextType>;
+  SuccessResponse?: SuccessResponseResolvers<ContextType>;
+  TokenResponse?: TokenResponseResolvers<ContextType>;
+  Upload?: GraphQLScalarType;
+  User?: UserResolvers<ContextType>;
+  UserLesson?: UserLessonResolvers<ContextType>;
+};
+
 
 /**
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
  */
-export type IResolvers<ContextType = any> = Resolvers<ContextType>
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;
+
 
 export const AcceptSubmissionDocument = gql`
-  mutation acceptSubmission($submissionId: String!, $comment: String!) {
-    acceptSubmission(id: $submissionId, comment: $comment) {
-      id
-      comment
-      status
-    }
+    mutation acceptSubmission($submissionId: String!, $comment: String!) {
+  acceptSubmission(id: $submissionId, comment: $comment) {
+    id
+    comment
+    status
   }
-`
-export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<
-  AcceptSubmissionMutation,
-  AcceptSubmissionMutationVariables
->
-export type AcceptSubmissionComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >,
-  'mutation'
->
-
-export const AcceptSubmissionComponent = (
-  props: AcceptSubmissionComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >
-    mutation={AcceptSubmissionDocument}
-    {...props}
-  />
-)
-
-export type AcceptSubmissionProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >
-} &
-  TChildProps
-export function withAcceptSubmission<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables,
-    AcceptSubmissionProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables,
-    AcceptSubmissionProps<TChildProps, TDataName>
-  >(AcceptSubmissionDocument, {
-    alias: 'acceptSubmission',
-    ...operationOptions
-  })
 }
+    `;
+export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
+export type AcceptSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>, 'mutation'>;
+
+    export const AcceptSubmissionComponent = (props: AcceptSubmissionComponentProps) => (
+      <ApolloReactComponents.Mutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables> mutation={AcceptSubmissionDocument} {...props} />
+    );
+    
+export type AcceptSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>
+    } & TChildProps;
+export function withAcceptSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  AcceptSubmissionMutation,
+  AcceptSubmissionMutationVariables,
+  AcceptSubmissionProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, AcceptSubmissionMutation, AcceptSubmissionMutationVariables, AcceptSubmissionProps<TChildProps, TDataName>>(AcceptSubmissionDocument, {
+      alias: 'acceptSubmission',
+      ...operationOptions
+    });
+};
 
 /**
  * __useAcceptSubmissionMutation__
@@ -1039,85 +797,39 @@ export function withAcceptSubmission<
  *   },
  * });
  */
-export function useAcceptSubmissionMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >(AcceptSubmissionDocument, baseOptions)
-}
-export type AcceptSubmissionMutationHookResult = ReturnType<
-  typeof useAcceptSubmissionMutation
->
-export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<
-  AcceptSubmissionMutation
->
-export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  AcceptSubmissionMutation,
-  AcceptSubmissionMutationVariables
->
+export function useAcceptSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>) {
+        return ApolloReactHooks.useMutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>(AcceptSubmissionDocument, baseOptions);
+      }
+export type AcceptSubmissionMutationHookResult = ReturnType<typeof useAcceptSubmissionMutation>;
+export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<AcceptSubmissionMutation>;
+export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
 export const AddAlertDocument = gql`
-  mutation addAlert($text: String!, $type: String!) {
-    addAlert(text: $text, type: $type) {
-      success
-    }
+    mutation addAlert($text: String!, $type: String!) {
+  addAlert(text: $text, type: $type) {
+    success
   }
-`
-export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<
-  AddAlertMutation,
-  AddAlertMutationVariables
->
-export type AddAlertComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >,
-  'mutation'
->
-
-export const AddAlertComponent = (props: AddAlertComponentProps) => (
-  <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables>
-    mutation={AddAlertDocument}
-    {...props}
-  />
-)
-
-export type AddAlertProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >
-} &
-  TChildProps
-export function withAddAlert<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    AddAlertMutation,
-    AddAlertMutationVariables,
-    AddAlertProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    AddAlertMutation,
-    AddAlertMutationVariables,
-    AddAlertProps<TChildProps, TDataName>
-  >(AddAlertDocument, {
-    alias: 'addAlert',
-    ...operationOptions
-  })
 }
+    `;
+export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>;
+export type AddAlertComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AddAlertMutation, AddAlertMutationVariables>, 'mutation'>;
+
+    export const AddAlertComponent = (props: AddAlertComponentProps) => (
+      <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables> mutation={AddAlertDocument} {...props} />
+    );
+    
+export type AddAlertProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>
+    } & TChildProps;
+export function withAddAlert<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  AddAlertMutation,
+  AddAlertMutationVariables,
+  AddAlertProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, AddAlertMutation, AddAlertMutationVariables, AddAlertProps<TChildProps, TDataName>>(AddAlertDocument, {
+      alias: 'addAlert',
+      ...operationOptions
+    });
+};
 
 /**
  * __useAddAlertMutation__
@@ -1137,126 +849,88 @@ export function withAddAlert<
  *   },
  * });
  */
-export function useAddAlertMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >(AddAlertDocument, baseOptions)
-}
-export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>
-export type AddAlertMutationResult = ApolloReactCommon.MutationResult<
-  AddAlertMutation
->
-export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  AddAlertMutation,
-  AddAlertMutationVariables
->
+export function useAddAlertMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AddAlertMutation, AddAlertMutationVariables>) {
+        return ApolloReactHooks.useMutation<AddAlertMutation, AddAlertMutationVariables>(AddAlertDocument, baseOptions);
+      }
+export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>;
+export type AddAlertMutationResult = ApolloReactCommon.MutationResult<AddAlertMutation>;
+export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<AddAlertMutation, AddAlertMutationVariables>;
 export const GetAppDocument = gql`
-  query getApp {
-    lessons {
+    query getApp {
+  lessons {
+    id
+    title
+    description
+    docUrl
+    githubUrl
+    videoUrl
+    order
+    challenges {
       id
       title
       description
-      docUrl
-      githubUrl
-      videoUrl
       order
-      challenges {
-        id
-        title
-        description
-        order
-      }
-      chatUrl
     }
-    session {
-      user {
+    chatUrl
+  }
+  session {
+    user {
+      id
+      username
+      name
+    }
+    submissions {
+      id
+      status
+      mrUrl
+      diff
+      viewCount
+      comment
+      order
+      challengeId
+      lessonId
+      reviewer {
         id
         username
-        name
       }
-      submissions {
-        id
-        status
-        mrUrl
-        diff
-        viewCount
-        comment
-        order
-        challengeId
-        lessonId
-        reviewer {
-          id
-          username
-        }
-        createdAt
-        updatedAt
-      }
-      lessonStatus {
-        lessonId
-        isPassed
-        isTeaching
-        isEnrolled
-      }
+      createdAt
+      updatedAt
     }
-    alerts {
-      id
-      text
-      type
-      url
-      urlCaption
+    lessonStatus {
+      lessonId
+      isPassed
+      isTeaching
+      isEnrolled
     }
   }
-`
-export type GetAppComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >,
-  'query'
->
-
-export const GetAppComponent = (props: GetAppComponentProps) => (
-  <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables>
-    query={GetAppDocument}
-    {...props}
-  />
-)
-
-export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactHoc.DataValue<
-    GetAppQuery,
-    GetAppQueryVariables
-  >
-} &
-  TChildProps
-export function withGetApp<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'data'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    GetAppQuery,
-    GetAppQueryVariables,
-    GetAppProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withQuery<
-    TProps,
-    GetAppQuery,
-    GetAppQueryVariables,
-    GetAppProps<TChildProps, TDataName>
-  >(GetAppDocument, {
-    alias: 'getApp',
-    ...operationOptions
-  })
+  alerts {
+    id
+    text
+    type
+    url
+    urlCaption
+  }
 }
+    `;
+export type GetAppComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<GetAppQuery, GetAppQueryVariables>, 'query'>;
+
+    export const GetAppComponent = (props: GetAppComponentProps) => (
+      <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables> query={GetAppDocument} {...props} />
+    );
+    
+export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
+      [key in TDataName]: ApolloReactHoc.DataValue<GetAppQuery, GetAppQueryVariables>
+    } & TChildProps;
+export function withGetApp<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  GetAppQuery,
+  GetAppQueryVariables,
+  GetAppProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withQuery<TProps, GetAppQuery, GetAppQueryVariables, GetAppProps<TChildProps, TDataName>>(GetAppDocument, {
+      alias: 'getApp',
+      ...operationOptions
+    });
+};
 
 /**
  * __useGetAppQuery__
@@ -1273,99 +947,51 @@ export function withGetApp<
  *   },
  * });
  */
-export function useGetAppQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(
-    GetAppDocument,
-    baseOptions
-  )
-}
-export function useGetAppLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(
-    GetAppDocument,
-    baseOptions
-  )
-}
-export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>
-export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>
-export type GetAppQueryResult = ApolloReactCommon.QueryResult<
-  GetAppQuery,
-  GetAppQueryVariables
->
-export const SubmissionsDocument = gql`
-  query submissions($lessonId: String!) {
-    submissions(lessonId: $lessonId) {
-      id
-      status
-      diff
-      comment
-      challengeId
-      user {
-        id
-        username
+export function useGetAppQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
       }
-      createdAt
-      updatedAt
+export function useGetAppLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
+        }
+export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>;
+export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>;
+export type GetAppQueryResult = ApolloReactCommon.QueryResult<GetAppQuery, GetAppQueryVariables>;
+export const SubmissionsDocument = gql`
+    query submissions($lessonId: String!) {
+  submissions(lessonId: $lessonId) {
+    id
+    status
+    diff
+    comment
+    challengeId
+    user {
+      id
+      username
     }
+    createdAt
+    updatedAt
   }
-`
-export type SubmissionsComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >,
-  'query'
-> &
-  ({ variables: SubmissionsQueryVariables; skip?: boolean } | { skip: boolean })
-
-export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
-  <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables>
-    query={SubmissionsDocument}
-    {...props}
-  />
-)
-
-export type SubmissionsProps<
-  TChildProps = {},
-  TDataName extends string = 'data'
-> = {
-  [key in TDataName]: ApolloReactHoc.DataValue<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >
-} &
-  TChildProps
-export function withSubmissions<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'data'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    SubmissionsQuery,
-    SubmissionsQueryVariables,
-    SubmissionsProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withQuery<
-    TProps,
-    SubmissionsQuery,
-    SubmissionsQueryVariables,
-    SubmissionsProps<TChildProps, TDataName>
-  >(SubmissionsDocument, {
-    alias: 'submissions',
-    ...operationOptions
-  })
 }
+    `;
+export type SubmissionsComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<SubmissionsQuery, SubmissionsQueryVariables>, 'query'> & ({ variables: SubmissionsQueryVariables; skip?: boolean; } | { skip: boolean; });
+
+    export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
+      <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables> query={SubmissionsDocument} {...props} />
+    );
+    
+export type SubmissionsProps<TChildProps = {}, TDataName extends string = 'data'> = {
+      [key in TDataName]: ApolloReactHoc.DataValue<SubmissionsQuery, SubmissionsQueryVariables>
+    } & TChildProps;
+export function withSubmissions<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  SubmissionsQuery,
+  SubmissionsQueryVariables,
+  SubmissionsProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withQuery<TProps, SubmissionsQuery, SubmissionsQueryVariables, SubmissionsProps<TChildProps, TDataName>>(SubmissionsDocument, {
+      alias: 'submissions',
+      ...operationOptions
+    });
+};
 
 /**
  * __useSubmissionsQuery__
@@ -1383,97 +1009,45 @@ export function withSubmissions<
  *   },
  * });
  */
-export function useSubmissionsQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(
-    SubmissionsDocument,
-    baseOptions
-  )
-}
-export function useSubmissionsLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >(SubmissionsDocument, baseOptions)
-}
-export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>
-export type SubmissionsLazyQueryHookResult = ReturnType<
-  typeof useSubmissionsLazyQuery
->
-export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<
-  SubmissionsQuery,
-  SubmissionsQueryVariables
->
+export function useSubmissionsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
+        return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
+      }
+export function useSubmissionsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
+        }
+export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>;
+export type SubmissionsLazyQueryHookResult = ReturnType<typeof useSubmissionsLazyQuery>;
+export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<SubmissionsQuery, SubmissionsQueryVariables>;
 export const LoginDocument = gql`
-  mutation login($username: String!, $password: String!) {
-    login(username: $username, password: $password) {
-      success
-      username
-      cliToken
-      error
-    }
+    mutation login($username: String!, $password: String!) {
+  login(username: $username, password: $password) {
+    success
+    username
+    cliToken
+    error
   }
-`
-export type LoginMutationFn = ApolloReactCommon.MutationFunction<
-  LoginMutation,
-  LoginMutationVariables
->
-export type LoginComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    LoginMutation,
-    LoginMutationVariables
-  >,
-  'mutation'
->
-
-export const LoginComponent = (props: LoginComponentProps) => (
-  <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables>
-    mutation={LoginDocument}
-    {...props}
-  />
-)
-
-export type LoginProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    LoginMutation,
-    LoginMutationVariables
-  >
-} &
-  TChildProps
-export function withLogin<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    LoginMutation,
-    LoginMutationVariables,
-    LoginProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    LoginMutation,
-    LoginMutationVariables,
-    LoginProps<TChildProps, TDataName>
-  >(LoginDocument, {
-    alias: 'login',
-    ...operationOptions
-  })
 }
+    `;
+export type LoginMutationFn = ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>;
+export type LoginComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LoginMutation, LoginMutationVariables>, 'mutation'>;
+
+    export const LoginComponent = (props: LoginComponentProps) => (
+      <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables> mutation={LoginDocument} {...props} />
+    );
+    
+export type LoginProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>
+    } & TChildProps;
+export function withLogin<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  LoginMutation,
+  LoginMutationVariables,
+  LoginProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, LoginMutation, LoginMutationVariables, LoginProps<TChildProps, TDataName>>(LoginDocument, {
+      alias: 'login',
+      ...operationOptions
+    });
+};
 
 /**
  * __useLoginMutation__
@@ -1493,85 +1067,41 @@ export function withLogin<
  *   },
  * });
  */
-export function useLoginMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    LoginMutation,
-    LoginMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(
-    LoginDocument,
-    baseOptions
-  )
-}
-export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>
-export type LoginMutationResult = ApolloReactCommon.MutationResult<
-  LoginMutation
->
-export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  LoginMutation,
-  LoginMutationVariables
->
+export function useLoginMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
+        return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, baseOptions);
+      }
+export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
+export type LoginMutationResult = ApolloReactCommon.MutationResult<LoginMutation>;
+export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
 export const LogoutDocument = gql`
-  mutation logout {
-    logout {
-      success
-      username
-      error
-    }
+    mutation logout {
+  logout {
+    success
+    username
+    error
   }
-`
-export type LogoutMutationFn = ApolloReactCommon.MutationFunction<
-  LogoutMutation,
-  LogoutMutationVariables
->
-export type LogoutComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    LogoutMutation,
-    LogoutMutationVariables
-  >,
-  'mutation'
->
-
-export const LogoutComponent = (props: LogoutComponentProps) => (
-  <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables>
-    mutation={LogoutDocument}
-    {...props}
-  />
-)
-
-export type LogoutProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    LogoutMutation,
-    LogoutMutationVariables
-  >
-} &
-  TChildProps
-export function withLogout<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    LogoutMutation,
-    LogoutMutationVariables,
-    LogoutProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    LogoutMutation,
-    LogoutMutationVariables,
-    LogoutProps<TChildProps, TDataName>
-  >(LogoutDocument, {
-    alias: 'logout',
-    ...operationOptions
-  })
 }
+    `;
+export type LogoutMutationFn = ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>;
+export type LogoutComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LogoutMutation, LogoutMutationVariables>, 'mutation'>;
+
+    export const LogoutComponent = (props: LogoutComponentProps) => (
+      <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables> mutation={LogoutDocument} {...props} />
+    );
+    
+export type LogoutProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>
+    } & TChildProps;
+export function withLogout<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  LogoutMutation,
+  LogoutMutationVariables,
+  LogoutProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, LogoutMutation, LogoutMutationVariables, LogoutProps<TChildProps, TDataName>>(LogoutDocument, {
+      alias: 'logout',
+      ...operationOptions
+    });
+};
 
 /**
  * __useLogoutMutation__
@@ -1589,90 +1119,41 @@ export function withLogout<
  *   },
  * });
  */
-export function useLogoutMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    LogoutMutation,
-    LogoutMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(
-    LogoutDocument,
-    baseOptions
-  )
-}
-export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>
-export type LogoutMutationResult = ApolloReactCommon.MutationResult<
-  LogoutMutation
->
-export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  LogoutMutation,
-  LogoutMutationVariables
->
+export function useLogoutMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
+        return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, baseOptions);
+      }
+export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
+export type LogoutMutationResult = ApolloReactCommon.MutationResult<LogoutMutation>;
+export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<LogoutMutation, LogoutMutationVariables>;
 export const RejectSubmissionDocument = gql`
-  mutation rejectSubmission($submissionId: String!, $comment: String!) {
-    rejectSubmission(id: $submissionId, comment: $comment) {
-      id
-      comment
-      status
-    }
+    mutation rejectSubmission($submissionId: String!, $comment: String!) {
+  rejectSubmission(id: $submissionId, comment: $comment) {
+    id
+    comment
+    status
   }
-`
-export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<
-  RejectSubmissionMutation,
-  RejectSubmissionMutationVariables
->
-export type RejectSubmissionComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >,
-  'mutation'
->
-
-export const RejectSubmissionComponent = (
-  props: RejectSubmissionComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >
-    mutation={RejectSubmissionDocument}
-    {...props}
-  />
-)
-
-export type RejectSubmissionProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >
-} &
-  TChildProps
-export function withRejectSubmission<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables,
-    RejectSubmissionProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables,
-    RejectSubmissionProps<TChildProps, TDataName>
-  >(RejectSubmissionDocument, {
-    alias: 'rejectSubmission',
-    ...operationOptions
-  })
 }
+    `;
+export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
+export type RejectSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>, 'mutation'>;
+
+    export const RejectSubmissionComponent = (props: RejectSubmissionComponentProps) => (
+      <ApolloReactComponents.Mutation<RejectSubmissionMutation, RejectSubmissionMutationVariables> mutation={RejectSubmissionDocument} {...props} />
+    );
+    
+export type RejectSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>
+    } & TChildProps;
+export function withRejectSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  RejectSubmissionMutation,
+  RejectSubmissionMutationVariables,
+  RejectSubmissionProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, RejectSubmissionMutation, RejectSubmissionMutationVariables, RejectSubmissionProps<TChildProps, TDataName>>(RejectSubmissionDocument, {
+      alias: 'rejectSubmission',
+      ...operationOptions
+    });
+};
 
 /**
  * __useRejectSubmissionMutation__
@@ -1692,89 +1173,40 @@ export function withRejectSubmission<
  *   },
  * });
  */
-export function useRejectSubmissionMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >(RejectSubmissionDocument, baseOptions)
-}
-export type RejectSubmissionMutationHookResult = ReturnType<
-  typeof useRejectSubmissionMutation
->
-export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<
-  RejectSubmissionMutation
->
-export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  RejectSubmissionMutation,
-  RejectSubmissionMutationVariables
->
+export function useRejectSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>) {
+        return ApolloReactHooks.useMutation<RejectSubmissionMutation, RejectSubmissionMutationVariables>(RejectSubmissionDocument, baseOptions);
+      }
+export type RejectSubmissionMutationHookResult = ReturnType<typeof useRejectSubmissionMutation>;
+export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<RejectSubmissionMutation>;
+export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
 export const ReqPwResetDocument = gql`
-  mutation reqPwReset($userOrEmail: String!) {
-    reqPwReset(userOrEmail: $userOrEmail) {
-      success
-      token
-    }
+    mutation reqPwReset($userOrEmail: String!) {
+  reqPwReset(userOrEmail: $userOrEmail) {
+    success
+    token
   }
-`
-export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<
-  ReqPwResetMutation,
-  ReqPwResetMutationVariables
->
-export type ReqPwResetComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >,
-  'mutation'
->
-
-export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
-  <ApolloReactComponents.Mutation<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >
-    mutation={ReqPwResetDocument}
-    {...props}
-  />
-)
-
-export type ReqPwResetProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >
-} &
-  TChildProps
-export function withReqPwReset<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables,
-    ReqPwResetProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables,
-    ReqPwResetProps<TChildProps, TDataName>
-  >(ReqPwResetDocument, {
-    alias: 'reqPwReset',
-    ...operationOptions
-  })
 }
+    `;
+export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>;
+export type ReqPwResetComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ReqPwResetMutation, ReqPwResetMutationVariables>, 'mutation'>;
+
+    export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
+      <ApolloReactComponents.Mutation<ReqPwResetMutation, ReqPwResetMutationVariables> mutation={ReqPwResetDocument} {...props} />
+    );
+    
+export type ReqPwResetProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>
+    } & TChildProps;
+export function withReqPwReset<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  ReqPwResetMutation,
+  ReqPwResetMutationVariables,
+  ReqPwResetProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, ReqPwResetMutation, ReqPwResetMutationVariables, ReqPwResetProps<TChildProps, TDataName>>(ReqPwResetDocument, {
+      alias: 'reqPwReset',
+      ...operationOptions
+    });
+};
 
 /**
  * __useReqPwResetMutation__
@@ -1793,97 +1225,41 @@ export function withReqPwReset<
  *   },
  * });
  */
-export function useReqPwResetMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >(ReqPwResetDocument, baseOptions)
-}
-export type ReqPwResetMutationHookResult = ReturnType<
-  typeof useReqPwResetMutation
->
-export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<
-  ReqPwResetMutation
->
-export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  ReqPwResetMutation,
-  ReqPwResetMutationVariables
->
+export function useReqPwResetMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ReqPwResetMutation, ReqPwResetMutationVariables>) {
+        return ApolloReactHooks.useMutation<ReqPwResetMutation, ReqPwResetMutationVariables>(ReqPwResetDocument, baseOptions);
+      }
+export type ReqPwResetMutationHookResult = ReturnType<typeof useReqPwResetMutation>;
+export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<ReqPwResetMutation>;
+export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<ReqPwResetMutation, ReqPwResetMutationVariables>;
 export const SignupDocument = gql`
-  mutation signup(
-    $firstName: String!
-    $lastName: String!
-    $email: String!
-    $username: String!
-  ) {
-    signup(
-      firstName: $firstName
-      lastName: $lastName
-      email: $email
-      username: $username
-    ) {
-      success
-      username
-      error
-    }
+    mutation signup($firstName: String!, $lastName: String!, $email: String!, $username: String!) {
+  signup(firstName: $firstName, lastName: $lastName, email: $email, username: $username) {
+    success
+    username
+    error
   }
-`
-export type SignupMutationFn = ApolloReactCommon.MutationFunction<
-  SignupMutation,
-  SignupMutationVariables
->
-export type SignupComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    SignupMutation,
-    SignupMutationVariables
-  >,
-  'mutation'
->
-
-export const SignupComponent = (props: SignupComponentProps) => (
-  <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables>
-    mutation={SignupDocument}
-    {...props}
-  />
-)
-
-export type SignupProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    SignupMutation,
-    SignupMutationVariables
-  >
-} &
-  TChildProps
-export function withSignup<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    SignupMutation,
-    SignupMutationVariables,
-    SignupProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    SignupMutation,
-    SignupMutationVariables,
-    SignupProps<TChildProps, TDataName>
-  >(SignupDocument, {
-    alias: 'signup',
-    ...operationOptions
-  })
 }
+    `;
+export type SignupMutationFn = ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>;
+export type SignupComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<SignupMutation, SignupMutationVariables>, 'mutation'>;
+
+    export const SignupComponent = (props: SignupComponentProps) => (
+      <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables> mutation={SignupDocument} {...props} />
+    );
+    
+export type SignupProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>
+    } & TChildProps;
+export function withSignup<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  SignupMutation,
+  SignupMutationVariables,
+  SignupProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, SignupMutation, SignupMutationVariables, SignupProps<TChildProps, TDataName>>(SignupDocument, {
+      alias: 'signup',
+      ...operationOptions
+    });
+};
 
 /**
  * __useSignupMutation__
@@ -1905,83 +1281,39 @@ export function withSignup<
  *   },
  * });
  */
-export function useSignupMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    SignupMutation,
-    SignupMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(
-    SignupDocument,
-    baseOptions
-  )
-}
-export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>
-export type SignupMutationResult = ApolloReactCommon.MutationResult<
-  SignupMutation
->
-export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  SignupMutation,
-  SignupMutationVariables
->
+export function useSignupMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SignupMutation, SignupMutationVariables>) {
+        return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(SignupDocument, baseOptions);
+      }
+export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>;
+export type SignupMutationResult = ApolloReactCommon.MutationResult<SignupMutation>;
+export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<SignupMutation, SignupMutationVariables>;
 export const ChangePwDocument = gql`
-  mutation changePw($token: String!, $password: String!) {
-    changePw(token: $token, password: $password) {
-      success
-    }
+    mutation changePw($token: String!, $password: String!) {
+  changePw(token: $token, password: $password) {
+    success
   }
-`
-export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<
-  ChangePwMutation,
-  ChangePwMutationVariables
->
-export type ChangePwComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >,
-  'mutation'
->
-
-export const ChangePwComponent = (props: ChangePwComponentProps) => (
-  <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables>
-    mutation={ChangePwDocument}
-    {...props}
-  />
-)
-
-export type ChangePwProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >
-} &
-  TChildProps
-export function withChangePw<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    ChangePwMutation,
-    ChangePwMutationVariables,
-    ChangePwProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    ChangePwMutation,
-    ChangePwMutationVariables,
-    ChangePwProps<TChildProps, TDataName>
-  >(ChangePwDocument, {
-    alias: 'changePw',
-    ...operationOptions
-  })
 }
+    `;
+export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>;
+export type ChangePwComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ChangePwMutation, ChangePwMutationVariables>, 'mutation'>;
+
+    export const ChangePwComponent = (props: ChangePwComponentProps) => (
+      <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables> mutation={ChangePwDocument} {...props} />
+    );
+    
+export type ChangePwProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>
+    } & TChildProps;
+export function withChangePw<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  ChangePwMutation,
+  ChangePwMutationVariables,
+  ChangePwProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, ChangePwMutation, ChangePwMutationVariables, ChangePwProps<TChildProps, TDataName>>(ChangePwDocument, {
+      alias: 'changePw',
+      ...operationOptions
+    });
+};
 
 /**
  * __useChangePwMutation__
@@ -2001,123 +1333,81 @@ export function withChangePw<
  *   },
  * });
  */
-export function useChangePwMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >(ChangePwDocument, baseOptions)
-}
-export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>
-export type ChangePwMutationResult = ApolloReactCommon.MutationResult<
-  ChangePwMutation
->
-export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  ChangePwMutation,
-  ChangePwMutationVariables
->
+export function useChangePwMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ChangePwMutation, ChangePwMutationVariables>) {
+        return ApolloReactHooks.useMutation<ChangePwMutation, ChangePwMutationVariables>(ChangePwDocument, baseOptions);
+      }
+export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>;
+export type ChangePwMutationResult = ApolloReactCommon.MutationResult<ChangePwMutation>;
+export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<ChangePwMutation, ChangePwMutationVariables>;
 export const UserInfoDocument = gql`
-  query userInfo($username: String!) {
-    lessons {
+    query userInfo($username: String!) {
+  lessons {
+    id
+    title
+    description
+    docUrl
+    githubUrl
+    videoUrl
+    order
+    challenges {
       id
       title
       description
-      docUrl
-      githubUrl
-      videoUrl
       order
-      challenges {
-        id
-        title
-        description
-        order
-      }
-      chatUrl
     }
-    userInfo(username: $username) {
-      user {
+    chatUrl
+  }
+  userInfo(username: $username) {
+    user {
+      id
+      username
+      name
+    }
+    submissions {
+      id
+      status
+      mrUrl
+      diff
+      viewCount
+      comment
+      order
+      challengeId
+      lessonId
+      reviewer {
         id
         username
-        name
       }
-      submissions {
-        id
-        status
-        mrUrl
-        diff
-        viewCount
-        comment
-        order
-        challengeId
-        lessonId
-        reviewer {
-          id
-          username
-        }
-        createdAt
-        updatedAt
-      }
-      lessonStatus {
-        lessonId
-        isPassed
-        isTeaching
-        isEnrolled
-      }
+      createdAt
+      updatedAt
+    }
+    lessonStatus {
+      lessonId
+      isPassed
+      isTeaching
+      isEnrolled
     }
   }
-`
-export type UserInfoComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >,
-  'query'
-> &
-  ({ variables: UserInfoQueryVariables; skip?: boolean } | { skip: boolean })
-
-export const UserInfoComponent = (props: UserInfoComponentProps) => (
-  <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables>
-    query={UserInfoDocument}
-    {...props}
-  />
-)
-
-export type UserInfoProps<
-  TChildProps = {},
-  TDataName extends string = 'data'
-> = {
-  [key in TDataName]: ApolloReactHoc.DataValue<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >
-} &
-  TChildProps
-export function withUserInfo<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'data'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    UserInfoQuery,
-    UserInfoQueryVariables,
-    UserInfoProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withQuery<
-    TProps,
-    UserInfoQuery,
-    UserInfoQueryVariables,
-    UserInfoProps<TChildProps, TDataName>
-  >(UserInfoDocument, {
-    alias: 'userInfo',
-    ...operationOptions
-  })
 }
+    `;
+export type UserInfoComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<UserInfoQuery, UserInfoQueryVariables>, 'query'> & ({ variables: UserInfoQueryVariables; skip?: boolean; } | { skip: boolean; });
+
+    export const UserInfoComponent = (props: UserInfoComponentProps) => (
+      <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables> query={UserInfoDocument} {...props} />
+    );
+    
+export type UserInfoProps<TChildProps = {}, TDataName extends string = 'data'> = {
+      [key in TDataName]: ApolloReactHoc.DataValue<UserInfoQuery, UserInfoQueryVariables>
+    } & TChildProps;
+export function withUserInfo<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  UserInfoQuery,
+  UserInfoQueryVariables,
+  UserInfoProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withQuery<TProps, UserInfoQuery, UserInfoQueryVariables, UserInfoProps<TChildProps, TDataName>>(UserInfoDocument, {
+      alias: 'userInfo',
+      ...operationOptions
+    });
+};
 
 /**
  * __useUserInfoQuery__
@@ -2135,33 +1425,12 @@ export function withUserInfo<
  *   },
  * });
  */
-export function useUserInfoQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(
-    UserInfoDocument,
-    baseOptions
-  )
-}
-export function useUserInfoLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(
-    UserInfoDocument,
-    baseOptions
-  )
-}
-export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>
-export type UserInfoLazyQueryHookResult = ReturnType<
-  typeof useUserInfoLazyQuery
->
-export type UserInfoQueryResult = ApolloReactCommon.QueryResult<
-  UserInfoQuery,
-  UserInfoQueryVariables
->
+export function useUserInfoQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
+        return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
+      }
+export function useUserInfoLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
+        }
+export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>;
+export type UserInfoLazyQueryHookResult = ReturnType<typeof useUserInfoLazyQuery>;
+export type UserInfoQueryResult = ApolloReactCommon.QueryResult<UserInfoQuery, UserInfoQueryVariables>;

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -107,7 +107,7 @@ export type MutationChangePwArgs = {
 }
 
 export type MutationChangeAdminRightsArgs = {
-  username: Scalars['String']
+  id: Scalars['Int']
   status: Scalars['String']
 }
 
@@ -154,7 +154,6 @@ export type MutationCreateLessonArgs = {
   videoUrl?: Maybe<Scalars['String']>
   title: Scalars['String']
   chatUrl?: Maybe<Scalars['String']>
-  id: Scalars['Int']
   order: Scalars['Int']
 }
 
@@ -171,7 +170,6 @@ export type MutationUpdateLessonArgs = {
 
 export type MutationCreateChallengeArgs = {
   lessonId: Scalars['Int']
-  id: Scalars['Int']
   order: Scalars['Int']
   description?: Maybe<Scalars['String']>
   title?: Maybe<Scalars['String']>
@@ -798,7 +796,7 @@ export type MutationResolvers<
     Maybe<ResolversTypes['SuccessResponse']>,
     ParentType,
     ContextType,
-    RequireFields<MutationChangeAdminRightsArgs, 'username' | 'status'>
+    RequireFields<MutationChangeAdminRightsArgs, 'id' | 'status'>
   >
   signup?: Resolver<
     Maybe<ResolversTypes['AuthResponse']>,
@@ -846,10 +844,7 @@ export type MutationResolvers<
     Maybe<ResolversTypes['SuccessResponse']>,
     ParentType,
     ContextType,
-    RequireFields<
-      MutationCreateLessonArgs,
-      'description' | 'title' | 'id' | 'order'
-    >
+    RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>
   >
   updateLesson?: Resolver<
     Maybe<ResolversTypes['SuccessResponse']>,
@@ -861,7 +856,7 @@ export type MutationResolvers<
     Maybe<ResolversTypes['SuccessResponse']>,
     ParentType,
     ContextType,
-    RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'id' | 'order'>
+    RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'order'>
   >
   updateChallenge?: Resolver<
     Maybe<ResolversTypes['SuccessResponse']>,

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -1,41 +1,48 @@
-import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
-import gql from 'graphql-tag';
-import * as ApolloReactCommon from '@apollo/react-common';
-import * as React from 'react';
-import * as ApolloReactComponents from '@apollo/react-components';
-import * as ApolloReactHoc from '@apollo/react-hoc';
-import * as ApolloReactHooks from '@apollo/react-hooks';
-export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
-export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig
+} from 'graphql'
+import gql from 'graphql-tag'
+import * as ApolloReactCommon from '@apollo/react-common'
+import * as React from 'react'
+import * as ApolloReactComponents from '@apollo/react-components'
+import * as ApolloReactHoc from '@apollo/react-hoc'
+import * as ApolloReactHooks from '@apollo/react-hooks'
+export type Maybe<T> = T | null
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] }
+export type RequireFields<T, K extends keyof T> = {
+  [X in Exclude<keyof T, K>]?: T[X]
+} &
+  { [P in K]-?: NonNullable<T[P]> }
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: string
+  String: string
+  Boolean: boolean
+  Int: number
+  Float: number
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
-};
+  Upload: any
+}
 
 export type Alert = {
-  __typename?: 'Alert';
-  id: Scalars['String'];
-  text?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
-  urlCaption?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Alert'
+  id: Scalars['String']
+  text?: Maybe<Scalars['String']>
+  type?: Maybe<Scalars['String']>
+  url?: Maybe<Scalars['String']>
+  urlCaption?: Maybe<Scalars['String']>
+}
 
 export type AuthResponse = {
-  __typename?: 'AuthResponse';
-  success?: Maybe<Scalars['Boolean']>;
-  username?: Maybe<Scalars['String']>;
-  error?: Maybe<Scalars['String']>;
-  cliToken?: Maybe<Scalars['String']>;
-};
+  __typename?: 'AuthResponse'
+  success?: Maybe<Scalars['Boolean']>
+  username?: Maybe<Scalars['String']>
+  error?: Maybe<Scalars['String']>
+  cliToken?: Maybe<Scalars['String']>
+}
 
 export enum CacheControlScope {
   Public = 'PUBLIC',
@@ -43,741 +50,1063 @@ export enum CacheControlScope {
 }
 
 export type Challenge = {
-  __typename?: 'Challenge';
-  id?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  lessonId?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-};
+  __typename?: 'Challenge'
+  id?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>
+  lessonId?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+}
 
 export type Lesson = {
-  __typename?: 'Lesson';
-  id?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  title?: Maybe<Scalars['String']>;
-  challenges?: Maybe<Array<Maybe<Challenge>>>;
-  users?: Maybe<Array<Maybe<User>>>;
-  currentUser?: Maybe<User>;
-  chatUrl?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Lesson'
+  id?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+  title?: Maybe<Scalars['String']>
+  challenges?: Maybe<Array<Maybe<Challenge>>>
+  users?: Maybe<Array<Maybe<User>>>
+  currentUser?: Maybe<User>
+  chatUrl?: Maybe<Scalars['String']>
+}
 
 export type Mutation = {
-  __typename?: 'Mutation';
-  login?: Maybe<AuthResponse>;
-  logout?: Maybe<AuthResponse>;
-  reqPwReset?: Maybe<TokenResponse>;
-  changePw?: Maybe<AuthResponse>;
-  changeAdminRights?: Maybe<SuccessResponse>;
-  signup?: Maybe<AuthResponse>;
-  addAlert?: Maybe<SuccessResponse>;
-  removeAlert?: Maybe<SuccessResponse>;
-  createSubmission?: Maybe<Submission>;
-  acceptSubmission?: Maybe<Submission>;
-  rejectSubmission?: Maybe<Submission>;
-  createLesson?: Maybe<SuccessResponse>;
-  updateLesson?: Maybe<SuccessResponse>;
-  createChallenge?: Maybe<SuccessResponse>;
-  updateChallenge?: Maybe<SuccessResponse>;
-};
-
+  __typename?: 'Mutation'
+  login?: Maybe<AuthResponse>
+  logout?: Maybe<AuthResponse>
+  reqPwReset?: Maybe<TokenResponse>
+  changePw?: Maybe<AuthResponse>
+  changeAdminRights?: Maybe<SuccessResponse>
+  signup?: Maybe<AuthResponse>
+  addAlert?: Maybe<SuccessResponse>
+  removeAlert?: Maybe<SuccessResponse>
+  createSubmission?: Maybe<Submission>
+  acceptSubmission?: Maybe<Submission>
+  rejectSubmission?: Maybe<Submission>
+  createLesson?: Maybe<SuccessResponse>
+  updateLesson?: Maybe<SuccessResponse>
+  createChallenge?: Maybe<SuccessResponse>
+  updateChallenge?: Maybe<SuccessResponse>
+}
 
 export type MutationLoginArgs = {
-  username: Scalars['String'];
-  password: Scalars['String'];
-};
-
+  username: Scalars['String']
+  password: Scalars['String']
+}
 
 export type MutationReqPwResetArgs = {
-  userOrEmail: Scalars['String'];
-};
-
+  userOrEmail: Scalars['String']
+}
 
 export type MutationChangePwArgs = {
-  token: Scalars['String'];
-  password: Scalars['String'];
-};
-
+  token: Scalars['String']
+  password: Scalars['String']
+}
 
 export type MutationChangeAdminRightsArgs = {
-  username: Scalars['String'];
-  status: Scalars['String'];
-};
-
+  username: Scalars['String']
+  status: Scalars['String']
+}
 
 export type MutationSignupArgs = {
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  email: Scalars['String'];
-  username: Scalars['String'];
-  password?: Maybe<Scalars['String']>;
-};
-
+  firstName: Scalars['String']
+  lastName: Scalars['String']
+  email: Scalars['String']
+  username: Scalars['String']
+  password?: Maybe<Scalars['String']>
+}
 
 export type MutationAddAlertArgs = {
-  text: Scalars['String'];
-  type: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
-  urlCaption?: Maybe<Scalars['String']>;
-};
-
+  text: Scalars['String']
+  type: Scalars['String']
+  url?: Maybe<Scalars['String']>
+  urlCaption?: Maybe<Scalars['String']>
+}
 
 export type MutationRemoveAlertArgs = {
-  id: Scalars['String'];
-};
-
+  id: Scalars['String']
+}
 
 export type MutationCreateSubmissionArgs = {
-  lessonId: Scalars['String'];
-  challengeId: Scalars['String'];
-  cliToken: Scalars['String'];
-  diff: Scalars['String'];
-};
-
+  lessonId: Scalars['String']
+  challengeId: Scalars['String']
+  cliToken: Scalars['String']
+  diff: Scalars['String']
+}
 
 export type MutationAcceptSubmissionArgs = {
-  id: Scalars['String'];
-  comment: Scalars['String'];
-};
-
+  id: Scalars['String']
+  comment: Scalars['String']
+}
 
 export type MutationRejectSubmissionArgs = {
-  id: Scalars['String'];
-  comment: Scalars['String'];
-};
-
+  id: Scalars['String']
+  comment: Scalars['String']
+}
 
 export type MutationCreateLessonArgs = {
-  description: Scalars['String'];
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
-  chatUrl?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
-  order: Scalars['Int'];
-};
-
+  description: Scalars['String']
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  title: Scalars['String']
+  chatUrl?: Maybe<Scalars['String']>
+  id: Scalars['Int']
+  order: Scalars['Int']
+}
 
 export type MutationUpdateLessonArgs = {
-  id: Scalars['Int'];
-  description?: Maybe<Scalars['String']>;
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  chatUrl?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-};
-
+  id: Scalars['Int']
+  description?: Maybe<Scalars['String']>
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+  chatUrl?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+}
 
 export type MutationCreateChallengeArgs = {
-  lessonId: Scalars['Int'];
-  id: Scalars['Int'];
-  order: Scalars['Int'];
-  description?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-};
-
+  lessonId: Scalars['Int']
+  id: Scalars['Int']
+  order: Scalars['Int']
+  description?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+}
 
 export type MutationUpdateChallengeArgs = {
-  lessonId: Scalars['Int'];
-  id: Scalars['Int'];
-  order: Scalars['Int'];
-  description?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-};
+  lessonId: Scalars['Int']
+  id: Scalars['Int']
+  order: Scalars['Int']
+  description?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+}
 
 export type Query = {
-  __typename?: 'Query';
-  lessons: Array<Lesson>;
-  session?: Maybe<Session>;
-  allUsers?: Maybe<Array<Maybe<User>>>;
-  userInfo?: Maybe<Session>;
-  isTokenValid: Scalars['Boolean'];
-  submissions?: Maybe<Array<Maybe<Submission>>>;
-  alerts: Array<Alert>;
-};
-
+  __typename?: 'Query'
+  lessons: Array<Lesson>
+  session?: Maybe<Session>
+  allUsers?: Maybe<Array<Maybe<User>>>
+  userInfo?: Maybe<Session>
+  isTokenValid: Scalars['Boolean']
+  submissions?: Maybe<Array<Maybe<Submission>>>
+  alerts: Array<Alert>
+}
 
 export type QueryUserInfoArgs = {
-  username: Scalars['String'];
-};
-
+  username: Scalars['String']
+}
 
 export type QueryIsTokenValidArgs = {
-  cliToken: Scalars['String'];
-};
-
+  cliToken: Scalars['String']
+}
 
 export type QuerySubmissionsArgs = {
-  lessonId: Scalars['String'];
-};
+  lessonId: Scalars['String']
+}
 
 export type Session = {
-  __typename?: 'Session';
-  user?: Maybe<User>;
-  submissions?: Maybe<Array<Maybe<Submission>>>;
-  lessonStatus: Array<UserLesson>;
-};
+  __typename?: 'Session'
+  user?: Maybe<User>
+  submissions?: Maybe<Array<Maybe<Submission>>>
+  lessonStatus: Array<UserLesson>
+}
 
 export type Submission = {
-  __typename?: 'Submission';
-  id?: Maybe<Scalars['String']>;
-  status?: Maybe<Scalars['String']>;
-  mrUrl?: Maybe<Scalars['String']>;
-  diff?: Maybe<Scalars['String']>;
-  viewCount?: Maybe<Scalars['Int']>;
-  comment?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  lessonId?: Maybe<Scalars['String']>;
-  challengeId?: Maybe<Scalars['String']>;
-  challenge?: Maybe<Challenge>;
-  reviewer?: Maybe<User>;
-  user?: Maybe<User>;
-  reviewerId?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Submission'
+  id?: Maybe<Scalars['String']>
+  status?: Maybe<Scalars['String']>
+  mrUrl?: Maybe<Scalars['String']>
+  diff?: Maybe<Scalars['String']>
+  viewCount?: Maybe<Scalars['Int']>
+  comment?: Maybe<Scalars['String']>
+  userId?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+  lessonId?: Maybe<Scalars['String']>
+  challengeId?: Maybe<Scalars['String']>
+  challenge?: Maybe<Challenge>
+  reviewer?: Maybe<User>
+  user?: Maybe<User>
+  reviewerId?: Maybe<Scalars['String']>
+  createdAt?: Maybe<Scalars['String']>
+  updatedAt?: Maybe<Scalars['String']>
+}
 
 export type SuccessResponse = {
-  __typename?: 'SuccessResponse';
-  success?: Maybe<Scalars['Boolean']>;
-};
+  __typename?: 'SuccessResponse'
+  success?: Maybe<Scalars['Boolean']>
+}
 
 export type TokenResponse = {
-  __typename?: 'TokenResponse';
-  success?: Maybe<Scalars['Boolean']>;
-  token?: Maybe<Scalars['String']>;
-};
-
+  __typename?: 'TokenResponse'
+  success?: Maybe<Scalars['Boolean']>
+  token?: Maybe<Scalars['String']>
+}
 
 export type User = {
-  __typename?: 'User';
-  id?: Maybe<Scalars['String']>;
-  username?: Maybe<Scalars['String']>;
-  userLesson?: Maybe<UserLesson>;
-  email?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  isAdmin?: Maybe<Scalars['String']>;
-  cliToken?: Maybe<Scalars['String']>;
-};
+  __typename?: 'User'
+  id?: Maybe<Scalars['String']>
+  username?: Maybe<Scalars['String']>
+  userLesson?: Maybe<UserLesson>
+  email?: Maybe<Scalars['String']>
+  name?: Maybe<Scalars['String']>
+  isAdmin?: Maybe<Scalars['String']>
+  cliToken?: Maybe<Scalars['String']>
+}
 
 export type UserLesson = {
-  __typename?: 'UserLesson';
-  id?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['String']>;
-  lessonId?: Maybe<Scalars['String']>;
-  isPassed?: Maybe<Scalars['String']>;
-  isTeaching?: Maybe<Scalars['String']>;
-  isEnrolled?: Maybe<Scalars['String']>;
-  starGiven?: Maybe<User>;
-  starComment?: Maybe<Scalars['String']>;
-};
+  __typename?: 'UserLesson'
+  id?: Maybe<Scalars['String']>
+  userId?: Maybe<Scalars['String']>
+  lessonId?: Maybe<Scalars['String']>
+  isPassed?: Maybe<Scalars['String']>
+  isTeaching?: Maybe<Scalars['String']>
+  isEnrolled?: Maybe<Scalars['String']>
+  starGiven?: Maybe<User>
+  starComment?: Maybe<Scalars['String']>
+}
 
 export type AcceptSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String'];
-  comment: Scalars['String'];
-}>;
+  submissionId: Scalars['String']
+  comment: Scalars['String']
+}>
 
-
-export type AcceptSubmissionMutation = (
-  { __typename?: 'Mutation' }
-  & { acceptSubmission?: Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'comment' | 'status'>
-  )> }
-);
+export type AcceptSubmissionMutation = { __typename?: 'Mutation' } & {
+  acceptSubmission?: Maybe<
+    { __typename?: 'Submission' } & Pick<
+      Submission,
+      'id' | 'comment' | 'status'
+    >
+  >
+}
 
 export type AddAlertMutationVariables = Exact<{
-  text: Scalars['String'];
-  type: Scalars['String'];
-}>;
+  text: Scalars['String']
+  type: Scalars['String']
+}>
 
+export type AddAlertMutation = { __typename?: 'Mutation' } & {
+  addAlert?: Maybe<
+    { __typename?: 'SuccessResponse' } & Pick<SuccessResponse, 'success'>
+  >
+}
 
-export type AddAlertMutation = (
-  { __typename?: 'Mutation' }
-  & { addAlert?: Maybe<(
-    { __typename?: 'SuccessResponse' }
-    & Pick<SuccessResponse, 'success'>
-  )> }
-);
+export type GetAppQueryVariables = Exact<{ [key: string]: never }>
 
-export type GetAppQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetAppQuery = (
-  { __typename?: 'Query' }
-  & { lessons: Array<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
-    )>>> }
-  )>, session?: Maybe<(
-    { __typename?: 'Session' }
-    & { user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username' | 'name'>
-    )>, submissions?: Maybe<Array<Maybe<(
-      { __typename?: 'Submission' }
-      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
-      & { reviewer?: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'username'>
-      )> }
-    )>>>, lessonStatus: Array<(
-      { __typename?: 'UserLesson' }
-      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
-    )> }
-  )>, alerts: Array<(
-    { __typename?: 'Alert' }
-    & Pick<Alert, 'id' | 'text' | 'type' | 'url' | 'urlCaption'>
-  )> }
-);
+export type GetAppQuery = { __typename?: 'Query' } & {
+  lessons: Array<
+    { __typename?: 'Lesson' } & Pick<
+      Lesson,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'docUrl'
+      | 'githubUrl'
+      | 'videoUrl'
+      | 'order'
+      | 'chatUrl'
+    > & {
+        challenges?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Challenge' } & Pick<
+                Challenge,
+                'id' | 'title' | 'description' | 'order'
+              >
+            >
+          >
+        >
+      }
+  >
+  session?: Maybe<
+    { __typename?: 'Session' } & {
+      user?: Maybe<
+        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
+      >
+      submissions?: Maybe<
+        Array<
+          Maybe<
+            { __typename?: 'Submission' } & Pick<
+              Submission,
+              | 'id'
+              | 'status'
+              | 'mrUrl'
+              | 'diff'
+              | 'viewCount'
+              | 'comment'
+              | 'order'
+              | 'challengeId'
+              | 'lessonId'
+              | 'createdAt'
+              | 'updatedAt'
+            > & {
+                reviewer?: Maybe<
+                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+                >
+              }
+          >
+        >
+      >
+      lessonStatus: Array<
+        { __typename?: 'UserLesson' } & Pick<
+          UserLesson,
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
+        >
+      >
+    }
+  >
+  alerts: Array<
+    { __typename?: 'Alert' } & Pick<
+      Alert,
+      'id' | 'text' | 'type' | 'url' | 'urlCaption'
+    >
+  >
+}
 
 export type SubmissionsQueryVariables = Exact<{
-  lessonId: Scalars['String'];
-}>;
+  lessonId: Scalars['String']
+}>
 
-
-export type SubmissionsQuery = (
-  { __typename?: 'Query' }
-  & { submissions?: Maybe<Array<Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'status' | 'diff' | 'comment' | 'challengeId' | 'createdAt' | 'updatedAt'>
-    & { user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username'>
-    )> }
-  )>>> }
-);
+export type SubmissionsQuery = { __typename?: 'Query' } & {
+  submissions?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Submission' } & Pick<
+          Submission,
+          | 'id'
+          | 'status'
+          | 'diff'
+          | 'comment'
+          | 'challengeId'
+          | 'createdAt'
+          | 'updatedAt'
+        > & {
+            user?: Maybe<
+              { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+            >
+          }
+      >
+    >
+  >
+}
 
 export type LoginMutationVariables = Exact<{
-  username: Scalars['String'];
-  password: Scalars['String'];
-}>;
+  username: Scalars['String']
+  password: Scalars['String']
+}>
 
+export type LoginMutation = { __typename?: 'Mutation' } & {
+  login?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'cliToken' | 'error'
+    >
+  >
+}
 
-export type LoginMutation = (
-  { __typename?: 'Mutation' }
-  & { login?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'cliToken' | 'error'>
-  )> }
-);
+export type LogoutMutationVariables = Exact<{ [key: string]: never }>
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
-
-
-export type LogoutMutation = (
-  { __typename?: 'Mutation' }
-  & { logout?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'error'>
-  )> }
-);
+export type LogoutMutation = { __typename?: 'Mutation' } & {
+  logout?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'error'
+    >
+  >
+}
 
 export type RejectSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String'];
-  comment: Scalars['String'];
-}>;
+  submissionId: Scalars['String']
+  comment: Scalars['String']
+}>
 
-
-export type RejectSubmissionMutation = (
-  { __typename?: 'Mutation' }
-  & { rejectSubmission?: Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'comment' | 'status'>
-  )> }
-);
+export type RejectSubmissionMutation = { __typename?: 'Mutation' } & {
+  rejectSubmission?: Maybe<
+    { __typename?: 'Submission' } & Pick<
+      Submission,
+      'id' | 'comment' | 'status'
+    >
+  >
+}
 
 export type ReqPwResetMutationVariables = Exact<{
-  userOrEmail: Scalars['String'];
-}>;
+  userOrEmail: Scalars['String']
+}>
 
-
-export type ReqPwResetMutation = (
-  { __typename?: 'Mutation' }
-  & { reqPwReset?: Maybe<(
-    { __typename?: 'TokenResponse' }
-    & Pick<TokenResponse, 'success' | 'token'>
-  )> }
-);
+export type ReqPwResetMutation = { __typename?: 'Mutation' } & {
+  reqPwReset?: Maybe<
+    { __typename?: 'TokenResponse' } & Pick<TokenResponse, 'success' | 'token'>
+  >
+}
 
 export type SignupMutationVariables = Exact<{
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  email: Scalars['String'];
-  username: Scalars['String'];
-}>;
+  firstName: Scalars['String']
+  lastName: Scalars['String']
+  email: Scalars['String']
+  username: Scalars['String']
+}>
 
-
-export type SignupMutation = (
-  { __typename?: 'Mutation' }
-  & { signup?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'error'>
-  )> }
-);
+export type SignupMutation = { __typename?: 'Mutation' } & {
+  signup?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'error'
+    >
+  >
+}
 
 export type ChangePwMutationVariables = Exact<{
-  token: Scalars['String'];
-  password: Scalars['String'];
-}>;
+  token: Scalars['String']
+  password: Scalars['String']
+}>
 
-
-export type ChangePwMutation = (
-  { __typename?: 'Mutation' }
-  & { changePw?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success'>
-  )> }
-);
+export type ChangePwMutation = { __typename?: 'Mutation' } & {
+  changePw?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<AuthResponse, 'success'>
+  >
+}
 
 export type UserInfoQueryVariables = Exact<{
-  username: Scalars['String'];
-}>;
+  username: Scalars['String']
+}>
 
+export type UserInfoQuery = { __typename?: 'Query' } & {
+  lessons: Array<
+    { __typename?: 'Lesson' } & Pick<
+      Lesson,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'docUrl'
+      | 'githubUrl'
+      | 'videoUrl'
+      | 'order'
+      | 'chatUrl'
+    > & {
+        challenges?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Challenge' } & Pick<
+                Challenge,
+                'id' | 'title' | 'description' | 'order'
+              >
+            >
+          >
+        >
+      }
+  >
+  userInfo?: Maybe<
+    { __typename?: 'Session' } & {
+      user?: Maybe<
+        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
+      >
+      submissions?: Maybe<
+        Array<
+          Maybe<
+            { __typename?: 'Submission' } & Pick<
+              Submission,
+              | 'id'
+              | 'status'
+              | 'mrUrl'
+              | 'diff'
+              | 'viewCount'
+              | 'comment'
+              | 'order'
+              | 'challengeId'
+              | 'lessonId'
+              | 'createdAt'
+              | 'updatedAt'
+            > & {
+                reviewer?: Maybe<
+                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+                >
+              }
+          >
+        >
+      >
+      lessonStatus: Array<
+        { __typename?: 'UserLesson' } & Pick<
+          UserLesson,
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
+        >
+      >
+    }
+  >
+}
 
-export type UserInfoQuery = (
-  { __typename?: 'Query' }
-  & { lessons: Array<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
-    )>>> }
-  )>, userInfo?: Maybe<(
-    { __typename?: 'Session' }
-    & { user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username' | 'name'>
-    )>, submissions?: Maybe<Array<Maybe<(
-      { __typename?: 'Submission' }
-      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
-      & { reviewer?: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'username'>
-      )> }
-    )>>>, lessonStatus: Array<(
-      { __typename?: 'UserLesson' }
-      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
-    )> }
-  )> }
-);
-
-
-
-export type ResolverTypeWrapper<T> = Promise<T> | T;
-
+export type ResolverTypeWrapper<T> = Promise<T> | T
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  fragment: string;
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-};
+  fragment: string
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
+}
 
 export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  selectionSet: string;
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-};
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+  selectionSet: string
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
+}
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
-  | StitchingResolver<TResult, TParent, TContext, TArgs>;
+  | StitchingResolver<TResult, TParent, TContext, TArgs>
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => Promise<TResult> | TResult;
+) => Promise<TResult> | TResult
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult>
 
-export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
-  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>
 }
 
-export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
-  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
-  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
   info: GraphQLResolveInfo
-) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>
 
-export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (
+  obj: T,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>
 
-export type NextResolverFn<T> = () => Promise<T>;
+export type NextResolverFn<T> = () => Promise<T>
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult>
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Query: ResolverTypeWrapper<{}>;
-  Lesson: ResolverTypeWrapper<Lesson>;
-  String: ResolverTypeWrapper<Scalars['String']>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
-  Challenge: ResolverTypeWrapper<Challenge>;
-  User: ResolverTypeWrapper<User>;
-  UserLesson: ResolverTypeWrapper<UserLesson>;
-  Session: ResolverTypeWrapper<Session>;
-  Submission: ResolverTypeWrapper<Submission>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  Alert: ResolverTypeWrapper<Alert>;
-  Mutation: ResolverTypeWrapper<{}>;
-  AuthResponse: ResolverTypeWrapper<AuthResponse>;
-  TokenResponse: ResolverTypeWrapper<TokenResponse>;
-  SuccessResponse: ResolverTypeWrapper<SuccessResponse>;
-  CacheControlScope: CacheControlScope;
-  Upload: ResolverTypeWrapper<Scalars['Upload']>;
-};
+  Query: ResolverTypeWrapper<{}>
+  Lesson: ResolverTypeWrapper<Lesson>
+  String: ResolverTypeWrapper<Scalars['String']>
+  Int: ResolverTypeWrapper<Scalars['Int']>
+  Challenge: ResolverTypeWrapper<Challenge>
+  User: ResolverTypeWrapper<User>
+  UserLesson: ResolverTypeWrapper<UserLesson>
+  Session: ResolverTypeWrapper<Session>
+  Submission: ResolverTypeWrapper<Submission>
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>
+  Alert: ResolverTypeWrapper<Alert>
+  Mutation: ResolverTypeWrapper<{}>
+  AuthResponse: ResolverTypeWrapper<AuthResponse>
+  TokenResponse: ResolverTypeWrapper<TokenResponse>
+  SuccessResponse: ResolverTypeWrapper<SuccessResponse>
+  CacheControlScope: CacheControlScope
+  Upload: ResolverTypeWrapper<Scalars['Upload']>
+}
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Query: {};
-  Lesson: Lesson;
-  String: Scalars['String'];
-  Int: Scalars['Int'];
-  Challenge: Challenge;
-  User: User;
-  UserLesson: UserLesson;
-  Session: Session;
-  Submission: Submission;
-  Boolean: Scalars['Boolean'];
-  Alert: Alert;
-  Mutation: {};
-  AuthResponse: AuthResponse;
-  TokenResponse: TokenResponse;
-  SuccessResponse: SuccessResponse;
-  Upload: Scalars['Upload'];
-};
-
-export type AlertResolvers<ContextType = any, ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']> = {
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  urlCaption?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type AuthResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type ChallengeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type LessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challenges?: Resolver<Maybe<Array<Maybe<ResolversTypes['Challenge']>>>, ParentType, ContextType>;
-  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
-  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
-  login?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationLoginArgs, 'username' | 'password'>>;
-  logout?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType>;
-  reqPwReset?: Resolver<Maybe<ResolversTypes['TokenResponse']>, ParentType, ContextType, RequireFields<MutationReqPwResetArgs, 'userOrEmail'>>;
-  changePw?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationChangePwArgs, 'token' | 'password'>>;
-  changeAdminRights?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationChangeAdminRightsArgs, 'username' | 'status'>>;
-  signup?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationSignupArgs, 'firstName' | 'lastName' | 'email' | 'username'>>;
-  addAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationAddAlertArgs, 'text' | 'type'>>;
-  removeAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationRemoveAlertArgs, 'id'>>;
-  createSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationCreateSubmissionArgs, 'lessonId' | 'challengeId' | 'cliToken' | 'diff'>>;
-  acceptSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>>;
-  rejectSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>>;
-  createLesson?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'id' | 'order'>>;
-  updateLesson?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationUpdateLessonArgs, 'id'>>;
-  createChallenge?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'id' | 'order'>>;
-  updateChallenge?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id' | 'order'>>;
-};
-
-export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>;
-  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>;
-  allUsers?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
-  userInfo?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType, RequireFields<QueryUserInfoArgs, 'username'>>;
-  isTokenValid?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<QueryIsTokenValidArgs, 'cliToken'>>;
-  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType, RequireFields<QuerySubmissionsArgs, 'lessonId'>>;
-  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>;
-};
-
-export type SessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']> = {
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType>;
-  lessonStatus?: Resolver<Array<ResolversTypes['UserLesson']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challengeId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challenge?: Resolver<Maybe<ResolversTypes['Challenge']>, ParentType, ContextType>;
-  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  reviewerId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type SuccessResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type TokenResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export interface UploadScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
-  name: 'Upload';
+  Query: {}
+  Lesson: Lesson
+  String: Scalars['String']
+  Int: Scalars['Int']
+  Challenge: Challenge
+  User: User
+  UserLesson: UserLesson
+  Session: Session
+  Submission: Submission
+  Boolean: Scalars['Boolean']
+  Alert: Alert
+  Mutation: {}
+  AuthResponse: AuthResponse
+  TokenResponse: TokenResponse
+  SuccessResponse: SuccessResponse
+  Upload: Scalars['Upload']
 }
 
-export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userLesson?: Resolver<Maybe<ResolversTypes['UserLesson']>, ParentType, ContextType>;
-  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
+export type AlertResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']
+> = {
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  urlCaption?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
 
-export type UserLessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isTeaching?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isEnrolled?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  starGiven?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  starComment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
+export type AuthResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type ChallengeResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  description?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type LessonResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  description?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  challenges?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Challenge']>>>,
+    ParentType,
+    ContextType
+  >
+  users?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['User']>>>,
+    ParentType,
+    ContextType
+  >
+  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type MutationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
+> = {
+  login?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationLoginArgs, 'username' | 'password'>
+  >
+  logout?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType
+  >
+  reqPwReset?: Resolver<
+    Maybe<ResolversTypes['TokenResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationReqPwResetArgs, 'userOrEmail'>
+  >
+  changePw?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationChangePwArgs, 'token' | 'password'>
+  >
+  changeAdminRights?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationChangeAdminRightsArgs, 'username' | 'status'>
+  >
+  signup?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationSignupArgs,
+      'firstName' | 'lastName' | 'email' | 'username'
+    >
+  >
+  addAlert?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationAddAlertArgs, 'text' | 'type'>
+  >
+  removeAlert?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationRemoveAlertArgs, 'id'>
+  >
+  createSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationCreateSubmissionArgs,
+      'lessonId' | 'challengeId' | 'cliToken' | 'diff'
+    >
+  >
+  acceptSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>
+  >
+  rejectSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>
+  >
+  createLesson?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationCreateLessonArgs,
+      'description' | 'title' | 'id' | 'order'
+    >
+  >
+  updateLesson?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateLessonArgs, 'id'>
+  >
+  createChallenge?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'id' | 'order'>
+  >
+  updateChallenge?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id' | 'order'>
+  >
+}
+
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>
+  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>
+  allUsers?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['User']>>>,
+    ParentType,
+    ContextType
+  >
+  userInfo?: Resolver<
+    Maybe<ResolversTypes['Session']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryUserInfoArgs, 'username'>
+  >
+  isTokenValid?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryIsTokenValidArgs, 'cliToken'>
+  >
+  submissions?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySubmissionsArgs, 'lessonId'>
+  >
+  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>
+}
+
+export type SessionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']
+> = {
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  submissions?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
+    ParentType,
+    ContextType
+  >
+  lessonStatus?: Resolver<
+    Array<ResolversTypes['UserLesson']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type SubmissionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  challengeId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  challenge?: Resolver<
+    Maybe<ResolversTypes['Challenge']>,
+    ParentType,
+    ContextType
+  >
+  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  reviewerId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type SuccessResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type TokenResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export interface UploadScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
+  name: 'Upload'
+}
+
+export type UserResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userLesson?: Resolver<
+    Maybe<ResolversTypes['UserLesson']>,
+    ParentType,
+    ContextType
+  >
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type UserLessonResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isTeaching?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  isEnrolled?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  starGiven?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  starComment?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
 
 export type Resolvers<ContextType = any> = {
-  Alert?: AlertResolvers<ContextType>;
-  AuthResponse?: AuthResponseResolvers<ContextType>;
-  Challenge?: ChallengeResolvers<ContextType>;
-  Lesson?: LessonResolvers<ContextType>;
-  Mutation?: MutationResolvers<ContextType>;
-  Query?: QueryResolvers<ContextType>;
-  Session?: SessionResolvers<ContextType>;
-  Submission?: SubmissionResolvers<ContextType>;
-  SuccessResponse?: SuccessResponseResolvers<ContextType>;
-  TokenResponse?: TokenResponseResolvers<ContextType>;
-  Upload?: GraphQLScalarType;
-  User?: UserResolvers<ContextType>;
-  UserLesson?: UserLessonResolvers<ContextType>;
-};
-
+  Alert?: AlertResolvers<ContextType>
+  AuthResponse?: AuthResponseResolvers<ContextType>
+  Challenge?: ChallengeResolvers<ContextType>
+  Lesson?: LessonResolvers<ContextType>
+  Mutation?: MutationResolvers<ContextType>
+  Query?: QueryResolvers<ContextType>
+  Session?: SessionResolvers<ContextType>
+  Submission?: SubmissionResolvers<ContextType>
+  SuccessResponse?: SuccessResponseResolvers<ContextType>
+  TokenResponse?: TokenResponseResolvers<ContextType>
+  Upload?: GraphQLScalarType
+  User?: UserResolvers<ContextType>
+  UserLesson?: UserLessonResolvers<ContextType>
+}
 
 /**
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
  */
-export type IResolvers<ContextType = any> = Resolvers<ContextType>;
-
+export type IResolvers<ContextType = any> = Resolvers<ContextType>
 
 export const AcceptSubmissionDocument = gql`
-    mutation acceptSubmission($submissionId: String!, $comment: String!) {
-  acceptSubmission(id: $submissionId, comment: $comment) {
-    id
-    comment
-    status
+  mutation acceptSubmission($submissionId: String!, $comment: String!) {
+    acceptSubmission(id: $submissionId, comment: $comment) {
+      id
+      comment
+      status
+    }
   }
-}
-    `;
-export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
-export type AcceptSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>, 'mutation'>;
-
-    export const AcceptSubmissionComponent = (props: AcceptSubmissionComponentProps) => (
-      <ApolloReactComponents.Mutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables> mutation={AcceptSubmissionDocument} {...props} />
-    );
-    
-export type AcceptSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>
-    } & TChildProps;
-export function withAcceptSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+`
+export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<
   AcceptSubmissionMutation,
-  AcceptSubmissionMutationVariables,
-  AcceptSubmissionProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, AcceptSubmissionMutation, AcceptSubmissionMutationVariables, AcceptSubmissionProps<TChildProps, TDataName>>(AcceptSubmissionDocument, {
-      alias: 'acceptSubmission',
-      ...operationOptions
-    });
-};
+  AcceptSubmissionMutationVariables
+>
+export type AcceptSubmissionComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >,
+  'mutation'
+>
+
+export const AcceptSubmissionComponent = (
+  props: AcceptSubmissionComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+    mutation={AcceptSubmissionDocument}
+    {...props}
+  />
+)
+
+export type AcceptSubmissionProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+} &
+  TChildProps
+export function withAcceptSubmission<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables,
+    AcceptSubmissionProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables,
+    AcceptSubmissionProps<TChildProps, TDataName>
+  >(AcceptSubmissionDocument, {
+    alias: 'acceptSubmission',
+    ...operationOptions
+  })
+}
 
 /**
  * __useAcceptSubmissionMutation__
@@ -797,39 +1126,85 @@ export function withAcceptSubmission<TProps, TChildProps = {}, TDataName extends
  *   },
  * });
  */
-export function useAcceptSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>) {
-        return ApolloReactHooks.useMutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>(AcceptSubmissionDocument, baseOptions);
-      }
-export type AcceptSubmissionMutationHookResult = ReturnType<typeof useAcceptSubmissionMutation>;
-export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<AcceptSubmissionMutation>;
-export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
-export const AddAlertDocument = gql`
-    mutation addAlert($text: String!, $type: String!) {
-  addAlert(text: $text, type: $type) {
-    success
-  }
+export function useAcceptSubmissionMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >(AcceptSubmissionDocument, baseOptions)
 }
-    `;
-export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>;
-export type AddAlertComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AddAlertMutation, AddAlertMutationVariables>, 'mutation'>;
-
-    export const AddAlertComponent = (props: AddAlertComponentProps) => (
-      <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables> mutation={AddAlertDocument} {...props} />
-    );
-    
-export type AddAlertProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>
-    } & TChildProps;
-export function withAddAlert<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type AcceptSubmissionMutationHookResult = ReturnType<
+  typeof useAcceptSubmissionMutation
+>
+export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<
+  AcceptSubmissionMutation
+>
+export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  AcceptSubmissionMutation,
+  AcceptSubmissionMutationVariables
+>
+export const AddAlertDocument = gql`
+  mutation addAlert($text: String!, $type: String!) {
+    addAlert(text: $text, type: $type) {
+      success
+    }
+  }
+`
+export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<
   AddAlertMutation,
-  AddAlertMutationVariables,
-  AddAlertProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, AddAlertMutation, AddAlertMutationVariables, AddAlertProps<TChildProps, TDataName>>(AddAlertDocument, {
-      alias: 'addAlert',
-      ...operationOptions
-    });
-};
+  AddAlertMutationVariables
+>
+export type AddAlertComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >,
+  'mutation'
+>
+
+export const AddAlertComponent = (props: AddAlertComponentProps) => (
+  <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables>
+    mutation={AddAlertDocument}
+    {...props}
+  />
+)
+
+export type AddAlertProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >
+} &
+  TChildProps
+export function withAddAlert<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    AddAlertMutation,
+    AddAlertMutationVariables,
+    AddAlertProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    AddAlertMutation,
+    AddAlertMutationVariables,
+    AddAlertProps<TChildProps, TDataName>
+  >(AddAlertDocument, {
+    alias: 'addAlert',
+    ...operationOptions
+  })
+}
 
 /**
  * __useAddAlertMutation__
@@ -849,88 +1224,126 @@ export function withAddAlert<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useAddAlertMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AddAlertMutation, AddAlertMutationVariables>) {
-        return ApolloReactHooks.useMutation<AddAlertMutation, AddAlertMutationVariables>(AddAlertDocument, baseOptions);
-      }
-export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>;
-export type AddAlertMutationResult = ApolloReactCommon.MutationResult<AddAlertMutation>;
-export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<AddAlertMutation, AddAlertMutationVariables>;
+export function useAddAlertMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >(AddAlertDocument, baseOptions)
+}
+export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>
+export type AddAlertMutationResult = ApolloReactCommon.MutationResult<
+  AddAlertMutation
+>
+export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  AddAlertMutation,
+  AddAlertMutationVariables
+>
 export const GetAppDocument = gql`
-    query getApp {
-  lessons {
-    id
-    title
-    description
-    docUrl
-    githubUrl
-    videoUrl
-    order
-    challenges {
+  query getApp {
+    lessons {
       id
       title
       description
+      docUrl
+      githubUrl
+      videoUrl
       order
+      challenges {
+        id
+        title
+        description
+        order
+      }
+      chatUrl
     }
-    chatUrl
-  }
-  session {
-    user {
-      id
-      username
-      name
-    }
-    submissions {
-      id
-      status
-      mrUrl
-      diff
-      viewCount
-      comment
-      order
-      challengeId
-      lessonId
-      reviewer {
+    session {
+      user {
         id
         username
+        name
       }
-      createdAt
-      updatedAt
+      submissions {
+        id
+        status
+        mrUrl
+        diff
+        viewCount
+        comment
+        order
+        challengeId
+        lessonId
+        reviewer {
+          id
+          username
+        }
+        createdAt
+        updatedAt
+      }
+      lessonStatus {
+        lessonId
+        isPassed
+        isTeaching
+        isEnrolled
+      }
     }
-    lessonStatus {
-      lessonId
-      isPassed
-      isTeaching
-      isEnrolled
+    alerts {
+      id
+      text
+      type
+      url
+      urlCaption
     }
   }
-  alerts {
-    id
-    text
-    type
-    url
-    urlCaption
-  }
-}
-    `;
-export type GetAppComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<GetAppQuery, GetAppQueryVariables>, 'query'>;
+`
+export type GetAppComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >,
+  'query'
+>
 
-    export const GetAppComponent = (props: GetAppComponentProps) => (
-      <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables> query={GetAppDocument} {...props} />
-    );
-    
+export const GetAppComponent = (props: GetAppComponentProps) => (
+  <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables>
+    query={GetAppDocument}
+    {...props}
+  />
+)
+
 export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<GetAppQuery, GetAppQueryVariables>
-    } & TChildProps;
-export function withGetApp<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+} &
+  TChildProps
+export function withGetApp<
   TProps,
-  GetAppQuery,
-  GetAppQueryVariables,
-  GetAppProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, GetAppQuery, GetAppQueryVariables, GetAppProps<TChildProps, TDataName>>(GetAppDocument, {
-      alias: 'getApp',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    GetAppQuery,
+    GetAppQueryVariables,
+    GetAppProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    GetAppQuery,
+    GetAppQueryVariables,
+    GetAppProps<TChildProps, TDataName>
+  >(GetAppDocument, {
+    alias: 'getApp',
+    ...operationOptions
+  })
+}
 
 /**
  * __useGetAppQuery__
@@ -947,51 +1360,99 @@ export function withGetApp<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useGetAppQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
-      }
-export function useGetAppLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
-        }
-export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>;
-export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>;
-export type GetAppQueryResult = ApolloReactCommon.QueryResult<GetAppQuery, GetAppQueryVariables>;
-export const SubmissionsDocument = gql`
-    query submissions($lessonId: String!) {
-  submissions(lessonId: $lessonId) {
-    id
-    status
-    diff
-    comment
-    challengeId
-    user {
-      id
-      username
-    }
-    createdAt
-    updatedAt
-  }
+export function useGetAppQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(
+    GetAppDocument,
+    baseOptions
+  )
 }
-    `;
-export type SubmissionsComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<SubmissionsQuery, SubmissionsQueryVariables>, 'query'> & ({ variables: SubmissionsQueryVariables; skip?: boolean; } | { skip: boolean; });
+export function useGetAppLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(
+    GetAppDocument,
+    baseOptions
+  )
+}
+export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>
+export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>
+export type GetAppQueryResult = ApolloReactCommon.QueryResult<
+  GetAppQuery,
+  GetAppQueryVariables
+>
+export const SubmissionsDocument = gql`
+  query submissions($lessonId: String!) {
+    submissions(lessonId: $lessonId) {
+      id
+      status
+      diff
+      comment
+      challengeId
+      user {
+        id
+        username
+      }
+      createdAt
+      updatedAt
+    }
+  }
+`
+export type SubmissionsComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >,
+  'query'
+> &
+  ({ variables: SubmissionsQueryVariables; skip?: boolean } | { skip: boolean })
 
-    export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
-      <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables> query={SubmissionsDocument} {...props} />
-    );
-    
-export type SubmissionsProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<SubmissionsQuery, SubmissionsQueryVariables>
-    } & TChildProps;
-export function withSubmissions<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
+  <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables>
+    query={SubmissionsDocument}
+    {...props}
+  />
+)
+
+export type SubmissionsProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+} &
+  TChildProps
+export function withSubmissions<
   TProps,
-  SubmissionsQuery,
-  SubmissionsQueryVariables,
-  SubmissionsProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, SubmissionsQuery, SubmissionsQueryVariables, SubmissionsProps<TChildProps, TDataName>>(SubmissionsDocument, {
-      alias: 'submissions',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    SubmissionsQuery,
+    SubmissionsQueryVariables,
+    SubmissionsProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    SubmissionsQuery,
+    SubmissionsQueryVariables,
+    SubmissionsProps<TChildProps, TDataName>
+  >(SubmissionsDocument, {
+    alias: 'submissions',
+    ...operationOptions
+  })
+}
 
 /**
  * __useSubmissionsQuery__
@@ -1009,45 +1470,97 @@ export function withSubmissions<TProps, TChildProps = {}, TDataName extends stri
  *   },
  * });
  */
-export function useSubmissionsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
-        return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
-      }
-export function useSubmissionsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
-        }
-export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>;
-export type SubmissionsLazyQueryHookResult = ReturnType<typeof useSubmissionsLazyQuery>;
-export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<SubmissionsQuery, SubmissionsQueryVariables>;
-export const LoginDocument = gql`
-    mutation login($username: String!, $password: String!) {
-  login(username: $username, password: $password) {
-    success
-    username
-    cliToken
-    error
-  }
+export function useSubmissionsQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(
+    SubmissionsDocument,
+    baseOptions
+  )
 }
-    `;
-export type LoginMutationFn = ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>;
-export type LoginComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LoginMutation, LoginMutationVariables>, 'mutation'>;
-
-    export const LoginComponent = (props: LoginComponentProps) => (
-      <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables> mutation={LoginDocument} {...props} />
-    );
-    
-export type LoginProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>
-    } & TChildProps;
-export function withLogin<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export function useSubmissionsLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >(SubmissionsDocument, baseOptions)
+}
+export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>
+export type SubmissionsLazyQueryHookResult = ReturnType<
+  typeof useSubmissionsLazyQuery
+>
+export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<
+  SubmissionsQuery,
+  SubmissionsQueryVariables
+>
+export const LoginDocument = gql`
+  mutation login($username: String!, $password: String!) {
+    login(username: $username, password: $password) {
+      success
+      username
+      cliToken
+      error
+    }
+  }
+`
+export type LoginMutationFn = ApolloReactCommon.MutationFunction<
   LoginMutation,
-  LoginMutationVariables,
-  LoginProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, LoginMutation, LoginMutationVariables, LoginProps<TChildProps, TDataName>>(LoginDocument, {
-      alias: 'login',
-      ...operationOptions
-    });
-};
+  LoginMutationVariables
+>
+export type LoginComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    LoginMutation,
+    LoginMutationVariables
+  >,
+  'mutation'
+>
+
+export const LoginComponent = (props: LoginComponentProps) => (
+  <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables>
+    mutation={LoginDocument}
+    {...props}
+  />
+)
+
+export type LoginProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    LoginMutation,
+    LoginMutationVariables
+  >
+} &
+  TChildProps
+export function withLogin<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    LoginMutation,
+    LoginMutationVariables,
+    LoginProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    LoginMutation,
+    LoginMutationVariables,
+    LoginProps<TChildProps, TDataName>
+  >(LoginDocument, {
+    alias: 'login',
+    ...operationOptions
+  })
+}
 
 /**
  * __useLoginMutation__
@@ -1067,41 +1580,85 @@ export function withLogin<TProps, TChildProps = {}, TDataName extends string = '
  *   },
  * });
  */
-export function useLoginMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
-        return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, baseOptions);
-      }
-export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
-export type LoginMutationResult = ApolloReactCommon.MutationResult<LoginMutation>;
-export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
-export const LogoutDocument = gql`
-    mutation logout {
-  logout {
-    success
-    username
-    error
-  }
+export function useLoginMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    LoginMutation,
+    LoginMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(
+    LoginDocument,
+    baseOptions
+  )
 }
-    `;
-export type LogoutMutationFn = ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>;
-export type LogoutComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LogoutMutation, LogoutMutationVariables>, 'mutation'>;
-
-    export const LogoutComponent = (props: LogoutComponentProps) => (
-      <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables> mutation={LogoutDocument} {...props} />
-    );
-    
-export type LogoutProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>
-    } & TChildProps;
-export function withLogout<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>
+export type LoginMutationResult = ApolloReactCommon.MutationResult<
+  LoginMutation
+>
+export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  LoginMutation,
+  LoginMutationVariables
+>
+export const LogoutDocument = gql`
+  mutation logout {
+    logout {
+      success
+      username
+      error
+    }
+  }
+`
+export type LogoutMutationFn = ApolloReactCommon.MutationFunction<
   LogoutMutation,
-  LogoutMutationVariables,
-  LogoutProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, LogoutMutation, LogoutMutationVariables, LogoutProps<TChildProps, TDataName>>(LogoutDocument, {
-      alias: 'logout',
-      ...operationOptions
-    });
-};
+  LogoutMutationVariables
+>
+export type LogoutComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    LogoutMutation,
+    LogoutMutationVariables
+  >,
+  'mutation'
+>
+
+export const LogoutComponent = (props: LogoutComponentProps) => (
+  <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables>
+    mutation={LogoutDocument}
+    {...props}
+  />
+)
+
+export type LogoutProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    LogoutMutation,
+    LogoutMutationVariables
+  >
+} &
+  TChildProps
+export function withLogout<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    LogoutMutation,
+    LogoutMutationVariables,
+    LogoutProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    LogoutMutation,
+    LogoutMutationVariables,
+    LogoutProps<TChildProps, TDataName>
+  >(LogoutDocument, {
+    alias: 'logout',
+    ...operationOptions
+  })
+}
 
 /**
  * __useLogoutMutation__
@@ -1119,41 +1676,90 @@ export function withLogout<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useLogoutMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
-        return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, baseOptions);
-      }
-export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
-export type LogoutMutationResult = ApolloReactCommon.MutationResult<LogoutMutation>;
-export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<LogoutMutation, LogoutMutationVariables>;
-export const RejectSubmissionDocument = gql`
-    mutation rejectSubmission($submissionId: String!, $comment: String!) {
-  rejectSubmission(id: $submissionId, comment: $comment) {
-    id
-    comment
-    status
-  }
+export function useLogoutMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    LogoutMutation,
+    LogoutMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(
+    LogoutDocument,
+    baseOptions
+  )
 }
-    `;
-export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
-export type RejectSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>, 'mutation'>;
-
-    export const RejectSubmissionComponent = (props: RejectSubmissionComponentProps) => (
-      <ApolloReactComponents.Mutation<RejectSubmissionMutation, RejectSubmissionMutationVariables> mutation={RejectSubmissionDocument} {...props} />
-    );
-    
-export type RejectSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>
-    } & TChildProps;
-export function withRejectSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>
+export type LogoutMutationResult = ApolloReactCommon.MutationResult<
+  LogoutMutation
+>
+export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  LogoutMutation,
+  LogoutMutationVariables
+>
+export const RejectSubmissionDocument = gql`
+  mutation rejectSubmission($submissionId: String!, $comment: String!) {
+    rejectSubmission(id: $submissionId, comment: $comment) {
+      id
+      comment
+      status
+    }
+  }
+`
+export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<
   RejectSubmissionMutation,
-  RejectSubmissionMutationVariables,
-  RejectSubmissionProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, RejectSubmissionMutation, RejectSubmissionMutationVariables, RejectSubmissionProps<TChildProps, TDataName>>(RejectSubmissionDocument, {
-      alias: 'rejectSubmission',
-      ...operationOptions
-    });
-};
+  RejectSubmissionMutationVariables
+>
+export type RejectSubmissionComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >,
+  'mutation'
+>
+
+export const RejectSubmissionComponent = (
+  props: RejectSubmissionComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+    mutation={RejectSubmissionDocument}
+    {...props}
+  />
+)
+
+export type RejectSubmissionProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+} &
+  TChildProps
+export function withRejectSubmission<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables,
+    RejectSubmissionProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables,
+    RejectSubmissionProps<TChildProps, TDataName>
+  >(RejectSubmissionDocument, {
+    alias: 'rejectSubmission',
+    ...operationOptions
+  })
+}
 
 /**
  * __useRejectSubmissionMutation__
@@ -1173,40 +1779,89 @@ export function withRejectSubmission<TProps, TChildProps = {}, TDataName extends
  *   },
  * });
  */
-export function useRejectSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>) {
-        return ApolloReactHooks.useMutation<RejectSubmissionMutation, RejectSubmissionMutationVariables>(RejectSubmissionDocument, baseOptions);
-      }
-export type RejectSubmissionMutationHookResult = ReturnType<typeof useRejectSubmissionMutation>;
-export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<RejectSubmissionMutation>;
-export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
-export const ReqPwResetDocument = gql`
-    mutation reqPwReset($userOrEmail: String!) {
-  reqPwReset(userOrEmail: $userOrEmail) {
-    success
-    token
-  }
+export function useRejectSubmissionMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >(RejectSubmissionDocument, baseOptions)
 }
-    `;
-export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>;
-export type ReqPwResetComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ReqPwResetMutation, ReqPwResetMutationVariables>, 'mutation'>;
-
-    export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
-      <ApolloReactComponents.Mutation<ReqPwResetMutation, ReqPwResetMutationVariables> mutation={ReqPwResetDocument} {...props} />
-    );
-    
-export type ReqPwResetProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>
-    } & TChildProps;
-export function withReqPwReset<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type RejectSubmissionMutationHookResult = ReturnType<
+  typeof useRejectSubmissionMutation
+>
+export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<
+  RejectSubmissionMutation
+>
+export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  RejectSubmissionMutation,
+  RejectSubmissionMutationVariables
+>
+export const ReqPwResetDocument = gql`
+  mutation reqPwReset($userOrEmail: String!) {
+    reqPwReset(userOrEmail: $userOrEmail) {
+      success
+      token
+    }
+  }
+`
+export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<
   ReqPwResetMutation,
-  ReqPwResetMutationVariables,
-  ReqPwResetProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, ReqPwResetMutation, ReqPwResetMutationVariables, ReqPwResetProps<TChildProps, TDataName>>(ReqPwResetDocument, {
-      alias: 'reqPwReset',
-      ...operationOptions
-    });
-};
+  ReqPwResetMutationVariables
+>
+export type ReqPwResetComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >,
+  'mutation'
+>
+
+export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
+  <ApolloReactComponents.Mutation<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+    mutation={ReqPwResetDocument}
+    {...props}
+  />
+)
+
+export type ReqPwResetProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+} &
+  TChildProps
+export function withReqPwReset<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables,
+    ReqPwResetProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables,
+    ReqPwResetProps<TChildProps, TDataName>
+  >(ReqPwResetDocument, {
+    alias: 'reqPwReset',
+    ...operationOptions
+  })
+}
 
 /**
  * __useReqPwResetMutation__
@@ -1225,41 +1880,97 @@ export function withReqPwReset<TProps, TChildProps = {}, TDataName extends strin
  *   },
  * });
  */
-export function useReqPwResetMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ReqPwResetMutation, ReqPwResetMutationVariables>) {
-        return ApolloReactHooks.useMutation<ReqPwResetMutation, ReqPwResetMutationVariables>(ReqPwResetDocument, baseOptions);
-      }
-export type ReqPwResetMutationHookResult = ReturnType<typeof useReqPwResetMutation>;
-export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<ReqPwResetMutation>;
-export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<ReqPwResetMutation, ReqPwResetMutationVariables>;
-export const SignupDocument = gql`
-    mutation signup($firstName: String!, $lastName: String!, $email: String!, $username: String!) {
-  signup(firstName: $firstName, lastName: $lastName, email: $email, username: $username) {
-    success
-    username
-    error
-  }
+export function useReqPwResetMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >(ReqPwResetDocument, baseOptions)
 }
-    `;
-export type SignupMutationFn = ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>;
-export type SignupComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<SignupMutation, SignupMutationVariables>, 'mutation'>;
-
-    export const SignupComponent = (props: SignupComponentProps) => (
-      <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables> mutation={SignupDocument} {...props} />
-    );
-    
-export type SignupProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>
-    } & TChildProps;
-export function withSignup<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type ReqPwResetMutationHookResult = ReturnType<
+  typeof useReqPwResetMutation
+>
+export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<
+  ReqPwResetMutation
+>
+export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  ReqPwResetMutation,
+  ReqPwResetMutationVariables
+>
+export const SignupDocument = gql`
+  mutation signup(
+    $firstName: String!
+    $lastName: String!
+    $email: String!
+    $username: String!
+  ) {
+    signup(
+      firstName: $firstName
+      lastName: $lastName
+      email: $email
+      username: $username
+    ) {
+      success
+      username
+      error
+    }
+  }
+`
+export type SignupMutationFn = ApolloReactCommon.MutationFunction<
   SignupMutation,
-  SignupMutationVariables,
-  SignupProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, SignupMutation, SignupMutationVariables, SignupProps<TChildProps, TDataName>>(SignupDocument, {
-      alias: 'signup',
-      ...operationOptions
-    });
-};
+  SignupMutationVariables
+>
+export type SignupComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    SignupMutation,
+    SignupMutationVariables
+  >,
+  'mutation'
+>
+
+export const SignupComponent = (props: SignupComponentProps) => (
+  <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables>
+    mutation={SignupDocument}
+    {...props}
+  />
+)
+
+export type SignupProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    SignupMutation,
+    SignupMutationVariables
+  >
+} &
+  TChildProps
+export function withSignup<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    SignupMutation,
+    SignupMutationVariables,
+    SignupProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    SignupMutation,
+    SignupMutationVariables,
+    SignupProps<TChildProps, TDataName>
+  >(SignupDocument, {
+    alias: 'signup',
+    ...operationOptions
+  })
+}
 
 /**
  * __useSignupMutation__
@@ -1281,39 +1992,83 @@ export function withSignup<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useSignupMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SignupMutation, SignupMutationVariables>) {
-        return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(SignupDocument, baseOptions);
-      }
-export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>;
-export type SignupMutationResult = ApolloReactCommon.MutationResult<SignupMutation>;
-export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<SignupMutation, SignupMutationVariables>;
-export const ChangePwDocument = gql`
-    mutation changePw($token: String!, $password: String!) {
-  changePw(token: $token, password: $password) {
-    success
-  }
+export function useSignupMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    SignupMutation,
+    SignupMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(
+    SignupDocument,
+    baseOptions
+  )
 }
-    `;
-export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>;
-export type ChangePwComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ChangePwMutation, ChangePwMutationVariables>, 'mutation'>;
-
-    export const ChangePwComponent = (props: ChangePwComponentProps) => (
-      <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables> mutation={ChangePwDocument} {...props} />
-    );
-    
-export type ChangePwProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>
-    } & TChildProps;
-export function withChangePw<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>
+export type SignupMutationResult = ApolloReactCommon.MutationResult<
+  SignupMutation
+>
+export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  SignupMutation,
+  SignupMutationVariables
+>
+export const ChangePwDocument = gql`
+  mutation changePw($token: String!, $password: String!) {
+    changePw(token: $token, password: $password) {
+      success
+    }
+  }
+`
+export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<
   ChangePwMutation,
-  ChangePwMutationVariables,
-  ChangePwProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, ChangePwMutation, ChangePwMutationVariables, ChangePwProps<TChildProps, TDataName>>(ChangePwDocument, {
-      alias: 'changePw',
-      ...operationOptions
-    });
-};
+  ChangePwMutationVariables
+>
+export type ChangePwComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >,
+  'mutation'
+>
+
+export const ChangePwComponent = (props: ChangePwComponentProps) => (
+  <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables>
+    mutation={ChangePwDocument}
+    {...props}
+  />
+)
+
+export type ChangePwProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >
+} &
+  TChildProps
+export function withChangePw<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    ChangePwMutation,
+    ChangePwMutationVariables,
+    ChangePwProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    ChangePwMutation,
+    ChangePwMutationVariables,
+    ChangePwProps<TChildProps, TDataName>
+  >(ChangePwDocument, {
+    alias: 'changePw',
+    ...operationOptions
+  })
+}
 
 /**
  * __useChangePwMutation__
@@ -1333,81 +2088,123 @@ export function withChangePw<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useChangePwMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ChangePwMutation, ChangePwMutationVariables>) {
-        return ApolloReactHooks.useMutation<ChangePwMutation, ChangePwMutationVariables>(ChangePwDocument, baseOptions);
-      }
-export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>;
-export type ChangePwMutationResult = ApolloReactCommon.MutationResult<ChangePwMutation>;
-export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<ChangePwMutation, ChangePwMutationVariables>;
+export function useChangePwMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >(ChangePwDocument, baseOptions)
+}
+export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>
+export type ChangePwMutationResult = ApolloReactCommon.MutationResult<
+  ChangePwMutation
+>
+export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  ChangePwMutation,
+  ChangePwMutationVariables
+>
 export const UserInfoDocument = gql`
-    query userInfo($username: String!) {
-  lessons {
-    id
-    title
-    description
-    docUrl
-    githubUrl
-    videoUrl
-    order
-    challenges {
+  query userInfo($username: String!) {
+    lessons {
       id
       title
       description
+      docUrl
+      githubUrl
+      videoUrl
       order
+      challenges {
+        id
+        title
+        description
+        order
+      }
+      chatUrl
     }
-    chatUrl
-  }
-  userInfo(username: $username) {
-    user {
-      id
-      username
-      name
-    }
-    submissions {
-      id
-      status
-      mrUrl
-      diff
-      viewCount
-      comment
-      order
-      challengeId
-      lessonId
-      reviewer {
+    userInfo(username: $username) {
+      user {
         id
         username
+        name
       }
-      createdAt
-      updatedAt
-    }
-    lessonStatus {
-      lessonId
-      isPassed
-      isTeaching
-      isEnrolled
+      submissions {
+        id
+        status
+        mrUrl
+        diff
+        viewCount
+        comment
+        order
+        challengeId
+        lessonId
+        reviewer {
+          id
+          username
+        }
+        createdAt
+        updatedAt
+      }
+      lessonStatus {
+        lessonId
+        isPassed
+        isTeaching
+        isEnrolled
+      }
     }
   }
-}
-    `;
-export type UserInfoComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<UserInfoQuery, UserInfoQueryVariables>, 'query'> & ({ variables: UserInfoQueryVariables; skip?: boolean; } | { skip: boolean; });
+`
+export type UserInfoComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >,
+  'query'
+> &
+  ({ variables: UserInfoQueryVariables; skip?: boolean } | { skip: boolean })
 
-    export const UserInfoComponent = (props: UserInfoComponentProps) => (
-      <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables> query={UserInfoDocument} {...props} />
-    );
-    
-export type UserInfoProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<UserInfoQuery, UserInfoQueryVariables>
-    } & TChildProps;
-export function withUserInfo<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+export const UserInfoComponent = (props: UserInfoComponentProps) => (
+  <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables>
+    query={UserInfoDocument}
+    {...props}
+  />
+)
+
+export type UserInfoProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+} &
+  TChildProps
+export function withUserInfo<
   TProps,
-  UserInfoQuery,
-  UserInfoQueryVariables,
-  UserInfoProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, UserInfoQuery, UserInfoQueryVariables, UserInfoProps<TChildProps, TDataName>>(UserInfoDocument, {
-      alias: 'userInfo',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UserInfoQuery,
+    UserInfoQueryVariables,
+    UserInfoProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    UserInfoQuery,
+    UserInfoQueryVariables,
+    UserInfoProps<TChildProps, TDataName>
+  >(UserInfoDocument, {
+    alias: 'userInfo',
+    ...operationOptions
+  })
+}
 
 /**
  * __useUserInfoQuery__
@@ -1425,12 +2222,33 @@ export function withUserInfo<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useUserInfoQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
-        return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
-      }
-export function useUserInfoLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
-        }
-export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>;
-export type UserInfoLazyQueryHookResult = ReturnType<typeof useUserInfoLazyQuery>;
-export type UserInfoQueryResult = ApolloReactCommon.QueryResult<UserInfoQuery, UserInfoQueryVariables>;
+export function useUserInfoQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(
+    UserInfoDocument,
+    baseOptions
+  )
+}
+export function useUserInfoLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(
+    UserInfoDocument,
+    baseOptions
+  )
+}
+export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>
+export type UserInfoLazyQueryHookResult = ReturnType<
+  typeof useUserInfoLazyQuery
+>
+export type UserInfoQueryResult = ApolloReactCommon.QueryResult<
+  UserInfoQuery,
+  UserInfoQueryVariables
+>

--- a/graphql/queryResolvers/allUsers.test.js
+++ b/graphql/queryResolvers/allUsers.test.js
@@ -1,0 +1,32 @@
+import { allUsers } from './allUsers'
+import db from '../../helpers/dbload'
+
+const mockUsers = [
+  {
+    username: 'lolcakes',
+    id: 2
+  },
+  {
+    username: 'superLolcakes',
+    id: 6
+  }
+]
+const ctx = {
+  req: {
+    user: { isAdmin: 'true' }
+  }
+}
+
+describe('allUsers resolver', () => {
+  const { User } = db
+
+  test('should return list of users', async () => {
+    User.findAll = jest.fn().mockReturnValue(mockUsers)
+    expect(allUsers(null, null, ctx)).toEqual(mockUsers)
+  })
+
+  test('Should throw Error when user is not an admin when querying allUsers', () => {
+    ctx.req.user.isAdmin = 'false'
+    expect(allUsers(null, null, ctx)).toBeNull
+  })
+})

--- a/graphql/queryResolvers/allUsers.test.js
+++ b/graphql/queryResolvers/allUsers.test.js
@@ -11,6 +11,7 @@ const mockUsers = [
     id: 6
   }
 ]
+
 const ctx = {
   req: {
     user: { isAdmin: 'true' }

--- a/graphql/queryResolvers/allUsers.test.js
+++ b/graphql/queryResolvers/allUsers.test.js
@@ -21,12 +21,12 @@ const ctx = {
 describe('allUsers resolver', () => {
   const { User } = db
 
-  test('should return list of users', async () => {
+  test('Should return list of users', async () => {
     User.findAll = jest.fn().mockReturnValue(mockUsers)
     expect(allUsers(null, null, ctx)).toEqual(mockUsers)
   })
 
-  test('Should throw Error when user is not an admin when querying allUsers', () => {
+  test('Should return null when user is not an admin when querying allUsers', () => {
     ctx.req.user.isAdmin = 'false'
     expect(allUsers(null, null, ctx)).toBeNull
   })

--- a/graphql/queryResolvers/allUsers.ts
+++ b/graphql/queryResolvers/allUsers.ts
@@ -1,0 +1,9 @@
+import db from '../../helpers/dbload'
+import { Context } from '../../@types/helpers'
+import { isAdmin } from '../../helpers/isAdmin'
+const { User } = db
+
+export const allUsers = (_parent: void, _args: void, context: Context) => {
+  const { req } = context
+  return !isAdmin(req) ? null : User.findAll()
+}

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -4,6 +4,10 @@ import {
   signup,
   isTokenValid
 } from '../helpers/controllers/authController'
+import {
+  createChallenge,
+  updateChallenge
+} from '../helpers/controllers/challengesController'
 import { userInfo } from '../helpers/controllers/userInfoController'
 import { addAlert, removeAlert } from '../helpers/controllers/alertController'
 import { reqPwReset, changePw } from '../helpers/controllers/passwordController'
@@ -16,10 +20,17 @@ import {
 import { alerts } from './queryResolvers/alerts'
 import { lessons } from './queryResolvers/lessons'
 import { session } from './queryResolvers/session'
+import { allUsers } from './queryResolvers/allUsers'
+import { changeAdminRights } from '../helpers/controllers/adminController'
+import {
+  createLesson,
+  updateLesson
+} from '../helpers/controllers/lessonsController'
 
 export default {
   Query: {
     submissions,
+    allUsers,
     isTokenValid,
     userInfo,
     lessons,
@@ -29,14 +40,19 @@ export default {
 
   Mutation: {
     changePw,
+    changeAdminRights,
     createSubmission,
     acceptSubmission,
     rejectSubmission,
+    createLesson,
+    updateLesson,
     login,
     logout,
     signup,
     addAlert,
     removeAlert,
-    reqPwReset
+    reqPwReset,
+    createChallenge,
+    updateChallenge
   }
 }

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -21,7 +21,7 @@ export default gql`
     logout: AuthResponse
     reqPwReset(userOrEmail: String!): TokenResponse
     changePw(token: String!, password: String!): AuthResponse
-    changeAdminRights(username: String!, status: String!): SuccessResponse
+    changeAdminRights(id: Int!, status: String!): SuccessResponse
     signup(
       firstName: String!
       lastName: String!
@@ -51,7 +51,6 @@ export default gql`
       videoUrl: String
       title: String!
       chatUrl: String
-      id: Int!
       order: Int!
     ): SuccessResponse
     updateLesson(
@@ -66,7 +65,6 @@ export default gql`
     ): SuccessResponse
     createChallenge(
       lessonId: Int!
-      id: Int!
       order: Int!
       description: String
       title: String

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -4,6 +4,7 @@ export default gql`
   type Query {
     lessons: [Lesson!]!
     session: Session
+    allUsers: [User]
     userInfo(username: String!): Session
     isTokenValid(cliToken: String!): Boolean!
     submissions(lessonId: String!): [Submission]
@@ -20,6 +21,7 @@ export default gql`
     logout: AuthResponse
     reqPwReset(userOrEmail: String!): TokenResponse
     changePw(token: String!, password: String!): AuthResponse
+    changeAdminRights(username: String!, status: String!): SuccessResponse
     signup(
       firstName: String!
       lastName: String!
@@ -32,8 +34,8 @@ export default gql`
       type: String!
       url: String
       urlCaption: String
-    ): AlertResponse
-    removeAlert(id: String!): AlertResponse
+    ): SuccessResponse
+    removeAlert(id: String!): SuccessResponse
     createSubmission(
       lessonId: String!
       challengeId: String!
@@ -42,6 +44,40 @@ export default gql`
     ): Submission
     acceptSubmission(id: String!, comment: String!): Submission
     rejectSubmission(id: String!, comment: String!): Submission
+    createLesson(
+      description: String!
+      docUrl: String
+      githubUrl: String
+      videoUrl: String
+      title: String!
+      chatUrl: String
+      id: Int!
+      order: Int!
+    ): SuccessResponse
+    updateLesson(
+      id: Int!
+      description: String
+      docUrl: String
+      githubUrl: String
+      videoUrl: String
+      title: String
+      chatUrl: String
+      order: Int
+    ): SuccessResponse
+    createChallenge(
+      lessonId: Int!
+      id: Int!
+      order: Int!
+      description: String
+      title: String
+    ): SuccessResponse
+    updateChallenge(
+      lessonId: Int!
+      id: Int!
+      order: Int!
+      description: String
+      title: String
+    ): SuccessResponse
   }
 
   type AuthResponse {
@@ -51,7 +87,7 @@ export default gql`
     cliToken: String
   }
 
-  type AlertResponse {
+  type SuccessResponse {
     success: Boolean
   }
 

--- a/helpers/controllers/adminController.test.js
+++ b/helpers/controllers/adminController.test.js
@@ -13,6 +13,7 @@ describe('Admin controller tests', () => {
       user: { isAdmin: 'true' }
     }
   }
+
   test('Should change admin rights', async () => {
     User.update = jest.fn().mockReturnValue(true)
     expect(changeAdminRights(null, mockUser, ctx)).resolves.toEqual({

--- a/helpers/controllers/adminController.test.js
+++ b/helpers/controllers/adminController.test.js
@@ -1,0 +1,35 @@
+jest.mock('../dbload')
+jest.mock('../mattermost')
+import db from '../dbload'
+import { changeAdminRights } from './adminController'
+
+const { User } = db
+
+const mockUser = { username: 'penelope', status: true }
+
+describe('Admin controller tests', () => {
+  const ctx = {
+    req: {
+      user: { isAdmin: 'true' }
+    }
+  }
+  test('Should change admin rights', async () => {
+    User.update = jest.fn().mockReturnValue(true)
+    expect(changeAdminRights(null, mockUser, ctx)).resolves.toEqual({
+      success: true
+    })
+  })
+
+  test('Should throw error if missing username', async () => {
+    expect(
+      changeAdminRights(null, { ...mockUser, username: '' }, ctx)
+    ).rejects.toThrowError('Missing username')
+  })
+
+  test('Should throw error when user is not an admin', async () => {
+    ctx.req.user.isAdmin = 'false'
+    expect(changeAdminRights(null, mockUser, ctx)).rejects.toThrowError(
+      'User is not an admin'
+    )
+  })
+})

--- a/helpers/controllers/adminController.test.js
+++ b/helpers/controllers/adminController.test.js
@@ -21,12 +21,6 @@ describe('Admin controller tests', () => {
     })
   })
 
-  test('Should throw error if missing username', async () => {
-    expect(
-      changeAdminRights(null, { ...mockUser, username: '' }, ctx)
-    ).rejects.toThrowError('Missing username')
-  })
-
   test('Should throw error when user is not an admin', async () => {
     ctx.req.user.isAdmin = 'false'
     expect(changeAdminRights(null, mockUser, ctx)).rejects.toThrowError(

--- a/helpers/controllers/adminController.ts
+++ b/helpers/controllers/adminController.ts
@@ -1,0 +1,45 @@
+import db from '../dbload'
+import { Context } from '../../@types/helpers'
+import _ from 'lodash'
+import { isAdmin } from '../isAdmin'
+
+const { User } = db
+
+type adminData = {
+  username: string
+  status: string
+}
+
+export const changeAdminRights = async (
+  _parent: void,
+  arg: adminData,
+  ctx: Context
+) => {
+  const { req } = ctx
+  try {
+    if (!isAdmin(req)) {
+      throw new Error('User is not an admin')
+    }
+
+    const { username, status } = arg
+
+    if (!username) {
+      throw new Error('Missing username')
+    }
+
+    await User.update(
+      { isAdmin: status },
+      {
+        where: {
+          username: username
+        }
+      }
+    )
+
+    return {
+      success: true
+    }
+  } catch (err) {
+    throw new Error(err)
+  }
+}

--- a/helpers/controllers/adminController.ts
+++ b/helpers/controllers/adminController.ts
@@ -6,7 +6,7 @@ import { isAdmin } from '../isAdmin'
 const { User } = db
 
 type adminData = {
-  username: string
+  id: number
   status: string
 }
 
@@ -21,20 +21,9 @@ export const changeAdminRights = async (
       throw new Error('User is not an admin')
     }
 
-    const { username, status } = arg
+    const { id, status } = arg
 
-    if (!username) {
-      throw new Error('Missing username')
-    }
-
-    await User.update(
-      { isAdmin: status },
-      {
-        where: {
-          username: username
-        }
-      }
-    )
+    await User.update({ isAdmin: status }, { where: { id } })
 
     return {
       success: true

--- a/helpers/controllers/adminController.ts
+++ b/helpers/controllers/adminController.ts
@@ -20,7 +20,6 @@ export const changeAdminRights = async (
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
-
     const { username, status } = arg
 
     if (!username) {

--- a/helpers/controllers/adminController.ts
+++ b/helpers/controllers/adminController.ts
@@ -20,6 +20,7 @@ export const changeAdminRights = async (
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
+
     const { username, status } = arg
 
     if (!username) {

--- a/helpers/controllers/challengesController.test.js
+++ b/helpers/controllers/challengesController.test.js
@@ -21,6 +21,7 @@ describe('Challenges controller tests', () => {
   }
 
   Challenge.build = jest.fn().mockReturnValue({ save: () => {} })
+
   test('Should create new challenge', async () => {
     expect(createChallenge(null, mockChallengeData, ctx)).resolves.toEqual({
       success: true

--- a/helpers/controllers/challengesController.test.js
+++ b/helpers/controllers/challengesController.test.js
@@ -1,0 +1,49 @@
+jest.mock('../dbload')
+jest.mock('../mattermost')
+import db from '../dbload'
+import { createChallenge, updateChallenge } from './challengesController'
+
+const { Challenge } = db
+
+const mockChallengeData = {
+  lessonId: 5,
+  id: 102,
+  order: 19,
+  description: 'lolz',
+  title: 'potato'
+}
+
+describe('Challenges controller tests', () => {
+  const ctx = {
+    req: {
+      user: { isAdmin: 'true' }
+    }
+  }
+
+  Challenge.build = jest.fn().mockReturnValue({ save: () => {} })
+  test('Should create new challenge', async () => {
+    expect(createChallenge(null, mockChallengeData, ctx)).resolves.toEqual({
+      success: true
+    })
+  })
+
+  test('Should update challenge', async () => {
+    expect(updateChallenge(null, mockChallengeData, ctx)).resolves.toEqual({
+      success: true
+    })
+  })
+
+  test('Should throw Error when user is not an admin when updating challenge', async () => {
+    ctx.req.user.isAdmin = 'false'
+    expect(updateChallenge(null, mockChallengeData, ctx)).rejects.toThrowError(
+      'User is not an admin'
+    )
+  })
+
+  test('Should throw Error when user is not an admin when creating challenge', async () => {
+    ctx.req.user.isAdmin = 'false'
+    expect(createChallenge(null, mockChallengeData, ctx)).rejects.toThrowError(
+      'User is not an admin'
+    )
+  })
+})

--- a/helpers/controllers/challengesController.ts
+++ b/helpers/controllers/challengesController.ts
@@ -24,15 +24,7 @@ export const createChallenge = async (
       throw new Error('User is not an admin')
     }
 
-    const { description, title, id, order, lessonId } = arg
-
-    const newChallenge = Challenge.build({
-      id,
-      description,
-      title,
-      order,
-      lessonId
-    })
+    const newChallenge = Challenge.build(arg)
 
     await newChallenge.save()
 
@@ -55,22 +47,9 @@ export const updateChallenge = async (
       throw new Error('User is not an admin')
     }
 
-    const { description, title, id, lessonId, order } = arg
+    const { id } = arg
 
-    await Challenge.update(
-      {
-        description,
-        lessonId,
-        order,
-        title,
-        id
-      },
-      {
-        where: {
-          id: id
-        }
-      }
-    )
+    await Challenge.update(arg, { where: { id } })
 
     return {
       success: true

--- a/helpers/controllers/challengesController.ts
+++ b/helpers/controllers/challengesController.ts
@@ -1,0 +1,81 @@
+import db from '../dbload'
+import { Context } from '../../@types/helpers'
+import _ from 'lodash'
+import { isAdmin } from '../isAdmin'
+
+const { Challenge } = db
+
+type challengeData = {
+  lessonId: number
+  id: number
+  order?: number
+  description?: string
+  title?: string
+}
+
+export const createChallenge = async (
+  _parent: void,
+  arg: challengeData,
+  ctx: Context
+) => {
+  const { req } = ctx
+  try {
+    if (!isAdmin(req)) {
+      throw new Error('User is not an admin')
+    }
+
+    const { description, title, id, order, lessonId } = arg
+
+    const newChallenge = Challenge.build({
+      id,
+      description,
+      title,
+      order,
+      lessonId
+    })
+
+    await newChallenge.save()
+
+    return {
+      success: true
+    }
+  } catch (err) {
+    throw new Error(err)
+  }
+}
+
+export const updateChallenge = async (
+  _parent: void,
+  arg: challengeData,
+  ctx: Context
+) => {
+  const { req } = ctx
+  try {
+    if (!isAdmin(req)) {
+      throw new Error('User is not an admin')
+    }
+
+    const { description, title, id, lessonId, order } = arg
+
+    await Challenge.update(
+      {
+        description,
+        lessonId,
+        order,
+        title,
+        id
+      },
+      {
+        where: {
+          id: id
+        }
+      }
+    )
+
+    return {
+      success: true
+    }
+  } catch (err) {
+    throw new Error(err)
+  }
+}

--- a/helpers/controllers/lessonsController.test.js
+++ b/helpers/controllers/lessonsController.test.js
@@ -25,6 +25,7 @@ describe('Lessons controller tests', () => {
   }
 
   Lesson.build = jest.fn().mockReturnValue({ save: () => {} })
+
   test('Should create new lesson', async () => {
     expect(createLesson(null, mockLessonData, ctx)).resolves.toEqual({
       success: true

--- a/helpers/controllers/lessonsController.test.js
+++ b/helpers/controllers/lessonsController.test.js
@@ -1,0 +1,53 @@
+jest.mock('../dbload')
+jest.mock('../mattermost')
+import db from '../dbload'
+import { createLesson, updateLesson } from './lessonsController'
+
+const { Lesson } = db
+
+const mockLessonData = {
+  lessonId: 5,
+  id: 102,
+  order: 19,
+  description: 'lolz',
+  title: 'potato',
+  docUrl: '',
+  githubUrl: '',
+  videoUrl: '',
+  chatUrl: ''
+}
+
+describe('Lessons controller tests', () => {
+  const ctx = {
+    req: {
+      user: { isAdmin: 'true' }
+    }
+  }
+
+  Lesson.build = jest.fn().mockReturnValue({ save: () => {} })
+  test('Should create new lesson', async () => {
+    expect(createLesson(null, mockLessonData, ctx)).resolves.toEqual({
+      success: true
+    })
+  })
+
+  test('Should update lesson', async () => {
+    expect(updateLesson(null, mockLessonData, ctx)).resolves.toEqual({
+      success: true
+    })
+  })
+
+  test('Should throw Error when user is not an admin when updating lesson', async () => {
+    ctx.req.user.isAdmin = 'false'
+    expect(updateLesson(null, mockLessonData, ctx)).rejects.toThrowError(
+      'User is not an admin'
+    )
+  })
+
+  test('Should throw Error when user is not an admin when creating lesson', async () => {
+    ctx.req.user.isAdmin = 'false'
+    expect(createLesson(null, mockLessonData, ctx)).rejects.toThrowError(
+      'User is not an admin'
+    )
+  })
+})

--- a/helpers/controllers/lessonsController.ts
+++ b/helpers/controllers/lessonsController.ts
@@ -1,0 +1,107 @@
+import db from '../dbload'
+import { Context } from '../../@types/helpers'
+import _ from 'lodash'
+import { isAdmin } from '../isAdmin'
+
+const { Lesson } = db
+
+type lessonData = {
+  id: number
+  order: number
+  description: string
+  docUrl: string
+  githubUrl: string
+  videoUrl: string
+  title: string
+  chatUrl: string
+}
+
+export const createLesson = async (
+  _parent: void,
+  arg: lessonData,
+  ctx: Context
+) => {
+  const { req } = ctx
+  try {
+    if (!isAdmin(req)) {
+      throw new Error('User is not an admin')
+    }
+
+    const {
+      description,
+      docUrl,
+      githubUrl,
+      videoUrl,
+      title,
+      chatUrl,
+      id,
+      order
+    } = arg
+
+    const newLesson = Lesson.build({
+      id,
+      description,
+      docUrl,
+      githubUrl,
+      videoUrl,
+      title,
+      order,
+      chatUrl
+    })
+
+    await newLesson.save()
+
+    return {
+      success: true
+    }
+  } catch (err) {
+    throw new Error(err)
+  }
+}
+
+export const updateLesson = async (
+  _parent: void,
+  arg: lessonData,
+  ctx: Context
+) => {
+  const { req } = ctx
+  try {
+    if (!isAdmin(req)) {
+      throw new Error('User is not an admin')
+    }
+
+    const {
+      description,
+      docUrl,
+      githubUrl,
+      videoUrl,
+      title,
+      chatUrl,
+      id,
+      order
+    } = arg
+
+    await Lesson.update(
+      {
+        description,
+        docUrl,
+        githubUrl,
+        videoUrl,
+        title,
+        chatUrl,
+        order
+      },
+      {
+        where: {
+          id: id
+        }
+      }
+    )
+
+    return {
+      success: true
+    }
+  } catch (err) {
+    throw new Error(err)
+  }
+}

--- a/helpers/controllers/lessonsController.ts
+++ b/helpers/controllers/lessonsController.ts
@@ -26,28 +26,7 @@ export const createLesson = async (
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
-
-    const {
-      description,
-      docUrl,
-      githubUrl,
-      videoUrl,
-      title,
-      chatUrl,
-      id,
-      order
-    } = arg
-
-    const newLesson = Lesson.build({
-      id,
-      description,
-      docUrl,
-      githubUrl,
-      videoUrl,
-      title,
-      order,
-      chatUrl
-    })
+    const newLesson = Lesson.build(arg)
 
     await newLesson.save()
 
@@ -70,33 +49,9 @@ export const updateLesson = async (
       throw new Error('User is not an admin')
     }
 
-    const {
-      description,
-      docUrl,
-      githubUrl,
-      videoUrl,
-      title,
-      chatUrl,
-      id,
-      order
-    } = arg
+    const { id } = arg
 
-    await Lesson.update(
-      {
-        description,
-        docUrl,
-        githubUrl,
-        videoUrl,
-        title,
-        chatUrl,
-        order
-      },
-      {
-        where: {
-          id: id
-        }
-      }
-    )
+    await Lesson.update(arg, { where: { id } })
 
     return {
       success: true


### PR DESCRIPTION
There are various graphql resolvers that need to be made for the back-end of the Admin Page.

These are:

1) Query to retrieve all users from the database
2) Mutation to make a user an admin
3) Mutations to create/update a lesson
4) Mutations to create/update a challenge

This PR creates all of the listed resolvers.

# Example of new lessons:
<img width="542" alt="Screen Shot 2020-07-16 at 2 32 49 PM" src="https://user-images.githubusercontent.com/45890848/87736171-542ff780-c78c-11ea-9fed-b4a5807a1354.png">
 
# Example of new challenges:
<img width="609" alt="Screen Shot 2020-07-16 at 6 54 43 PM" src="https://user-images.githubusercontent.com/45890848/87739932-dbce3400-c795-11ea-811e-db441dedcc07.png">

