### PR TITLE
closes #340 - update return information of update/create challenge re…

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -1,41 +1,48 @@
-import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
-import gql from 'graphql-tag';
-import * as ApolloReactCommon from '@apollo/react-common';
-import * as React from 'react';
-import * as ApolloReactComponents from '@apollo/react-components';
-import * as ApolloReactHoc from '@apollo/react-hoc';
-import * as ApolloReactHooks from '@apollo/react-hooks';
-export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
-export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig
+} from 'graphql'
+import gql from 'graphql-tag'
+import * as ApolloReactCommon from '@apollo/react-common'
+import * as React from 'react'
+import * as ApolloReactComponents from '@apollo/react-components'
+import * as ApolloReactHoc from '@apollo/react-hoc'
+import * as ApolloReactHooks from '@apollo/react-hooks'
+export type Maybe<T> = T | null
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] }
+export type RequireFields<T, K extends keyof T> = {
+  [X in Exclude<keyof T, K>]?: T[X]
+} &
+  { [P in K]-?: NonNullable<T[P]> }
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: string
+  String: string
+  Boolean: boolean
+  Int: number
+  Float: number
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
-};
+  Upload: any
+}
 
 export type Alert = {
-  __typename?: 'Alert';
-  id: Scalars['String'];
-  text?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
-  urlCaption?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Alert'
+  id: Scalars['String']
+  text?: Maybe<Scalars['String']>
+  type?: Maybe<Scalars['String']>
+  url?: Maybe<Scalars['String']>
+  urlCaption?: Maybe<Scalars['String']>
+}
 
 export type AuthResponse = {
-  __typename?: 'AuthResponse';
-  success?: Maybe<Scalars['Boolean']>;
-  username?: Maybe<Scalars['String']>;
-  error?: Maybe<Scalars['String']>;
-  cliToken?: Maybe<Scalars['String']>;
-};
+  __typename?: 'AuthResponse'
+  success?: Maybe<Scalars['Boolean']>
+  username?: Maybe<Scalars['String']>
+  error?: Maybe<Scalars['String']>
+  cliToken?: Maybe<Scalars['String']>
+}
 
 export enum CacheControlScope {
   Public = 'PUBLIC',
@@ -43,783 +50,1141 @@ export enum CacheControlScope {
 }
 
 export type Challenge = {
-  __typename?: 'Challenge';
-  id?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  lessonId?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-};
+  __typename?: 'Challenge'
+  id?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>
+  lessonId?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+}
 
 export type Lesson = {
-  __typename?: 'Lesson';
-  id?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  title?: Maybe<Scalars['String']>;
-  challenges?: Maybe<Array<Maybe<Challenge>>>;
-  users?: Maybe<Array<Maybe<User>>>;
-  currentUser?: Maybe<User>;
-  chatUrl?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Lesson'
+  id?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+  title?: Maybe<Scalars['String']>
+  challenges?: Maybe<Array<Maybe<Challenge>>>
+  users?: Maybe<Array<Maybe<User>>>
+  currentUser?: Maybe<User>
+  chatUrl?: Maybe<Scalars['String']>
+}
 
 export type Mutation = {
-  __typename?: 'Mutation';
-  login?: Maybe<AuthResponse>;
-  logout?: Maybe<AuthResponse>;
-  reqPwReset?: Maybe<TokenResponse>;
-  changePw?: Maybe<AuthResponse>;
-  changeAdminRights?: Maybe<SuccessResponse>;
-  signup?: Maybe<AuthResponse>;
-  addAlert?: Maybe<SuccessResponse>;
-  removeAlert?: Maybe<SuccessResponse>;
-  createSubmission?: Maybe<Submission>;
-  acceptSubmission?: Maybe<Submission>;
-  rejectSubmission?: Maybe<Submission>;
-  createLesson?: Maybe<SuccessResponse>;
-  updateLesson?: Maybe<SuccessResponse>;
-  createChallenge?: Maybe<Array<Maybe<Lesson>>>;
-  updateChallenge?: Maybe<Array<Maybe<Lesson>>>;
-};
-
+  __typename?: 'Mutation'
+  login?: Maybe<AuthResponse>
+  logout?: Maybe<AuthResponse>
+  reqPwReset?: Maybe<TokenResponse>
+  changePw?: Maybe<AuthResponse>
+  changeAdminRights?: Maybe<SuccessResponse>
+  signup?: Maybe<AuthResponse>
+  addAlert?: Maybe<SuccessResponse>
+  removeAlert?: Maybe<SuccessResponse>
+  createSubmission?: Maybe<Submission>
+  acceptSubmission?: Maybe<Submission>
+  rejectSubmission?: Maybe<Submission>
+  createLesson?: Maybe<SuccessResponse>
+  updateLesson?: Maybe<SuccessResponse>
+  createChallenge?: Maybe<Array<Maybe<Lesson>>>
+  updateChallenge?: Maybe<Array<Maybe<Lesson>>>
+}
 
 export type MutationLoginArgs = {
-  username: Scalars['String'];
-  password: Scalars['String'];
-};
-
+  username: Scalars['String']
+  password: Scalars['String']
+}
 
 export type MutationReqPwResetArgs = {
-  userOrEmail: Scalars['String'];
-};
-
+  userOrEmail: Scalars['String']
+}
 
 export type MutationChangePwArgs = {
-  token: Scalars['String'];
-  password: Scalars['String'];
-};
-
+  token: Scalars['String']
+  password: Scalars['String']
+}
 
 export type MutationChangeAdminRightsArgs = {
-  id: Scalars['Int'];
-  status: Scalars['String'];
-};
-
+  id: Scalars['Int']
+  status: Scalars['String']
+}
 
 export type MutationSignupArgs = {
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  email: Scalars['String'];
-  username: Scalars['String'];
-  password?: Maybe<Scalars['String']>;
-};
-
+  firstName: Scalars['String']
+  lastName: Scalars['String']
+  email: Scalars['String']
+  username: Scalars['String']
+  password?: Maybe<Scalars['String']>
+}
 
 export type MutationAddAlertArgs = {
-  text: Scalars['String'];
-  type: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
-  urlCaption?: Maybe<Scalars['String']>;
-};
-
+  text: Scalars['String']
+  type: Scalars['String']
+  url?: Maybe<Scalars['String']>
+  urlCaption?: Maybe<Scalars['String']>
+}
 
 export type MutationRemoveAlertArgs = {
-  id: Scalars['String'];
-};
-
+  id: Scalars['String']
+}
 
 export type MutationCreateSubmissionArgs = {
-  lessonId: Scalars['String'];
-  challengeId: Scalars['String'];
-  cliToken: Scalars['String'];
-  diff: Scalars['String'];
-};
-
+  lessonId: Scalars['String']
+  challengeId: Scalars['String']
+  cliToken: Scalars['String']
+  diff: Scalars['String']
+}
 
 export type MutationAcceptSubmissionArgs = {
-  id: Scalars['String'];
-  comment: Scalars['String'];
-};
-
+  id: Scalars['String']
+  comment: Scalars['String']
+}
 
 export type MutationRejectSubmissionArgs = {
-  id: Scalars['String'];
-  comment: Scalars['String'];
-};
-
+  id: Scalars['String']
+  comment: Scalars['String']
+}
 
 export type MutationCreateLessonArgs = {
-  description: Scalars['String'];
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
-  chatUrl?: Maybe<Scalars['String']>;
-  order: Scalars['Int'];
-};
-
+  description: Scalars['String']
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  title: Scalars['String']
+  chatUrl?: Maybe<Scalars['String']>
+  order: Scalars['Int']
+}
 
 export type MutationUpdateLessonArgs = {
-  id: Scalars['Int'];
-  description?: Maybe<Scalars['String']>;
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  chatUrl?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-};
-
+  id: Scalars['Int']
+  description?: Maybe<Scalars['String']>
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+  chatUrl?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+}
 
 export type MutationCreateChallengeArgs = {
-  lessonId: Scalars['Int'];
-  order: Scalars['Int'];
-  description: Scalars['String'];
-  title: Scalars['String'];
-};
-
+  lessonId: Scalars['Int']
+  order: Scalars['Int']
+  description: Scalars['String']
+  title: Scalars['String']
+}
 
 export type MutationUpdateChallengeArgs = {
-  lessonId: Scalars['Int'];
-  id: Scalars['Int'];
-  order?: Maybe<Scalars['Int']>;
-  description?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-};
+  lessonId: Scalars['Int']
+  id: Scalars['Int']
+  order?: Maybe<Scalars['Int']>
+  description?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+}
 
 export type Query = {
-  __typename?: 'Query';
-  lessons: Array<Lesson>;
-  session?: Maybe<Session>;
-  allUsers?: Maybe<Array<Maybe<User>>>;
-  userInfo?: Maybe<Session>;
-  isTokenValid: Scalars['Boolean'];
-  submissions?: Maybe<Array<Maybe<Submission>>>;
-  alerts: Array<Alert>;
-};
-
+  __typename?: 'Query'
+  lessons: Array<Lesson>
+  session?: Maybe<Session>
+  allUsers?: Maybe<Array<Maybe<User>>>
+  userInfo?: Maybe<Session>
+  isTokenValid: Scalars['Boolean']
+  submissions?: Maybe<Array<Maybe<Submission>>>
+  alerts: Array<Alert>
+}
 
 export type QueryUserInfoArgs = {
-  username: Scalars['String'];
-};
-
+  username: Scalars['String']
+}
 
 export type QueryIsTokenValidArgs = {
-  cliToken: Scalars['String'];
-};
-
+  cliToken: Scalars['String']
+}
 
 export type QuerySubmissionsArgs = {
-  lessonId: Scalars['String'];
-};
+  lessonId: Scalars['String']
+}
 
 export type Session = {
-  __typename?: 'Session';
-  user?: Maybe<User>;
-  submissions?: Maybe<Array<Maybe<Submission>>>;
-  lessonStatus: Array<UserLesson>;
-};
+  __typename?: 'Session'
+  user?: Maybe<User>
+  submissions?: Maybe<Array<Maybe<Submission>>>
+  lessonStatus: Array<UserLesson>
+}
 
 export type Submission = {
-  __typename?: 'Submission';
-  id?: Maybe<Scalars['String']>;
-  status?: Maybe<Scalars['String']>;
-  mrUrl?: Maybe<Scalars['String']>;
-  diff?: Maybe<Scalars['String']>;
-  viewCount?: Maybe<Scalars['Int']>;
-  comment?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  lessonId?: Maybe<Scalars['String']>;
-  challengeId?: Maybe<Scalars['String']>;
-  challenge?: Maybe<Challenge>;
-  reviewer?: Maybe<User>;
-  user?: Maybe<User>;
-  reviewerId?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Submission'
+  id?: Maybe<Scalars['String']>
+  status?: Maybe<Scalars['String']>
+  mrUrl?: Maybe<Scalars['String']>
+  diff?: Maybe<Scalars['String']>
+  viewCount?: Maybe<Scalars['Int']>
+  comment?: Maybe<Scalars['String']>
+  userId?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+  lessonId?: Maybe<Scalars['String']>
+  challengeId?: Maybe<Scalars['String']>
+  challenge?: Maybe<Challenge>
+  reviewer?: Maybe<User>
+  user?: Maybe<User>
+  reviewerId?: Maybe<Scalars['String']>
+  createdAt?: Maybe<Scalars['String']>
+  updatedAt?: Maybe<Scalars['String']>
+}
 
 export type SuccessResponse = {
-  __typename?: 'SuccessResponse';
-  success?: Maybe<Scalars['Boolean']>;
-};
+  __typename?: 'SuccessResponse'
+  success?: Maybe<Scalars['Boolean']>
+}
 
 export type TokenResponse = {
-  __typename?: 'TokenResponse';
-  success?: Maybe<Scalars['Boolean']>;
-  token?: Maybe<Scalars['String']>;
-};
-
+  __typename?: 'TokenResponse'
+  success?: Maybe<Scalars['Boolean']>
+  token?: Maybe<Scalars['String']>
+}
 
 export type User = {
-  __typename?: 'User';
-  id?: Maybe<Scalars['String']>;
-  username?: Maybe<Scalars['String']>;
-  userLesson?: Maybe<UserLesson>;
-  email?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  isAdmin?: Maybe<Scalars['String']>;
-  cliToken?: Maybe<Scalars['String']>;
-};
+  __typename?: 'User'
+  id?: Maybe<Scalars['String']>
+  username?: Maybe<Scalars['String']>
+  userLesson?: Maybe<UserLesson>
+  email?: Maybe<Scalars['String']>
+  name?: Maybe<Scalars['String']>
+  isAdmin?: Maybe<Scalars['String']>
+  cliToken?: Maybe<Scalars['String']>
+}
 
 export type UserLesson = {
-  __typename?: 'UserLesson';
-  id?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['String']>;
-  lessonId?: Maybe<Scalars['String']>;
-  isPassed?: Maybe<Scalars['String']>;
-  isTeaching?: Maybe<Scalars['String']>;
-  isEnrolled?: Maybe<Scalars['String']>;
-  starGiven?: Maybe<User>;
-  starComment?: Maybe<Scalars['String']>;
-};
+  __typename?: 'UserLesson'
+  id?: Maybe<Scalars['String']>
+  userId?: Maybe<Scalars['String']>
+  lessonId?: Maybe<Scalars['String']>
+  isPassed?: Maybe<Scalars['String']>
+  isTeaching?: Maybe<Scalars['String']>
+  isEnrolled?: Maybe<Scalars['String']>
+  starGiven?: Maybe<User>
+  starComment?: Maybe<Scalars['String']>
+}
 
 export type AcceptSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String'];
-  comment: Scalars['String'];
-}>;
+  submissionId: Scalars['String']
+  comment: Scalars['String']
+}>
 
-
-export type AcceptSubmissionMutation = (
-  { __typename?: 'Mutation' }
-  & { acceptSubmission?: Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'comment' | 'status'>
-  )> }
-);
+export type AcceptSubmissionMutation = { __typename?: 'Mutation' } & {
+  acceptSubmission?: Maybe<
+    { __typename?: 'Submission' } & Pick<
+      Submission,
+      'id' | 'comment' | 'status'
+    >
+  >
+}
 
 export type AddAlertMutationVariables = Exact<{
-  text: Scalars['String'];
-  type: Scalars['String'];
-}>;
+  text: Scalars['String']
+  type: Scalars['String']
+}>
 
-
-export type AddAlertMutation = (
-  { __typename?: 'Mutation' }
-  & { addAlert?: Maybe<(
-    { __typename?: 'SuccessResponse' }
-    & Pick<SuccessResponse, 'success'>
-  )> }
-);
+export type AddAlertMutation = { __typename?: 'Mutation' } & {
+  addAlert?: Maybe<
+    { __typename?: 'SuccessResponse' } & Pick<SuccessResponse, 'success'>
+  >
+}
 
 export type CreateChallengeMutationVariables = Exact<{
-  lessonId: Scalars['Int'];
-  order: Scalars['Int'];
-  description: Scalars['String'];
-  title: Scalars['String'];
-}>;
+  lessonId: Scalars['Int']
+  order: Scalars['Int']
+  description: Scalars['String']
+  title: Scalars['String']
+}>
 
+export type CreateChallengeMutation = { __typename?: 'Mutation' } & {
+  createChallenge?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Lesson' } & Pick<
+          Lesson,
+          | 'id'
+          | 'docUrl'
+          | 'githubUrl'
+          | 'videoUrl'
+          | 'chatUrl'
+          | 'order'
+          | 'description'
+          | 'title'
+        > & {
+            challenges?: Maybe<
+              Array<
+                Maybe<
+                  { __typename?: 'Challenge' } & Pick<
+                    Challenge,
+                    'id' | 'description' | 'lessonId' | 'title' | 'order'
+                  >
+                >
+              >
+            >
+          }
+      >
+    >
+  >
+}
 
-export type CreateChallengeMutation = (
-  { __typename?: 'Mutation' }
-  & { createChallenge?: Maybe<Array<Maybe<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'chatUrl' | 'order' | 'description' | 'title'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'description' | 'lessonId' | 'title' | 'order'>
-    )>>> }
-  )>>> }
-);
+export type GetAppQueryVariables = Exact<{ [key: string]: never }>
 
-export type GetAppQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetAppQuery = (
-  { __typename?: 'Query' }
-  & { lessons: Array<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
-    )>>> }
-  )>, session?: Maybe<(
-    { __typename?: 'Session' }
-    & { user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username' | 'name'>
-    )>, submissions?: Maybe<Array<Maybe<(
-      { __typename?: 'Submission' }
-      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
-      & { reviewer?: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'username'>
-      )> }
-    )>>>, lessonStatus: Array<(
-      { __typename?: 'UserLesson' }
-      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
-    )> }
-  )>, alerts: Array<(
-    { __typename?: 'Alert' }
-    & Pick<Alert, 'id' | 'text' | 'type' | 'url' | 'urlCaption'>
-  )> }
-);
+export type GetAppQuery = { __typename?: 'Query' } & {
+  lessons: Array<
+    { __typename?: 'Lesson' } & Pick<
+      Lesson,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'docUrl'
+      | 'githubUrl'
+      | 'videoUrl'
+      | 'order'
+      | 'chatUrl'
+    > & {
+        challenges?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Challenge' } & Pick<
+                Challenge,
+                'id' | 'title' | 'description' | 'order'
+              >
+            >
+          >
+        >
+      }
+  >
+  session?: Maybe<
+    { __typename?: 'Session' } & {
+      user?: Maybe<
+        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
+      >
+      submissions?: Maybe<
+        Array<
+          Maybe<
+            { __typename?: 'Submission' } & Pick<
+              Submission,
+              | 'id'
+              | 'status'
+              | 'mrUrl'
+              | 'diff'
+              | 'viewCount'
+              | 'comment'
+              | 'order'
+              | 'challengeId'
+              | 'lessonId'
+              | 'createdAt'
+              | 'updatedAt'
+            > & {
+                reviewer?: Maybe<
+                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+                >
+              }
+          >
+        >
+      >
+      lessonStatus: Array<
+        { __typename?: 'UserLesson' } & Pick<
+          UserLesson,
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
+        >
+      >
+    }
+  >
+  alerts: Array<
+    { __typename?: 'Alert' } & Pick<
+      Alert,
+      'id' | 'text' | 'type' | 'url' | 'urlCaption'
+    >
+  >
+}
 
 export type SubmissionsQueryVariables = Exact<{
-  lessonId: Scalars['String'];
-}>;
+  lessonId: Scalars['String']
+}>
 
-
-export type SubmissionsQuery = (
-  { __typename?: 'Query' }
-  & { submissions?: Maybe<Array<Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'status' | 'diff' | 'comment' | 'challengeId' | 'createdAt' | 'updatedAt'>
-    & { challenge?: Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'title'>
-    )>, user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username'>
-    )> }
-  )>>> }
-);
+export type SubmissionsQuery = { __typename?: 'Query' } & {
+  submissions?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Submission' } & Pick<
+          Submission,
+          | 'id'
+          | 'status'
+          | 'diff'
+          | 'comment'
+          | 'challengeId'
+          | 'createdAt'
+          | 'updatedAt'
+        > & {
+            challenge?: Maybe<
+              { __typename?: 'Challenge' } & Pick<Challenge, 'title'>
+            >
+            user?: Maybe<
+              { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+            >
+          }
+      >
+    >
+  >
+}
 
 export type LoginMutationVariables = Exact<{
-  username: Scalars['String'];
-  password: Scalars['String'];
-}>;
+  username: Scalars['String']
+  password: Scalars['String']
+}>
 
+export type LoginMutation = { __typename?: 'Mutation' } & {
+  login?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'cliToken' | 'error'
+    >
+  >
+}
 
-export type LoginMutation = (
-  { __typename?: 'Mutation' }
-  & { login?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'cliToken' | 'error'>
-  )> }
-);
+export type LogoutMutationVariables = Exact<{ [key: string]: never }>
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
-
-
-export type LogoutMutation = (
-  { __typename?: 'Mutation' }
-  & { logout?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'error'>
-  )> }
-);
+export type LogoutMutation = { __typename?: 'Mutation' } & {
+  logout?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'error'
+    >
+  >
+}
 
 export type RejectSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String'];
-  comment: Scalars['String'];
-}>;
+  submissionId: Scalars['String']
+  comment: Scalars['String']
+}>
 
-
-export type RejectSubmissionMutation = (
-  { __typename?: 'Mutation' }
-  & { rejectSubmission?: Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'comment' | 'status'>
-  )> }
-);
+export type RejectSubmissionMutation = { __typename?: 'Mutation' } & {
+  rejectSubmission?: Maybe<
+    { __typename?: 'Submission' } & Pick<
+      Submission,
+      'id' | 'comment' | 'status'
+    >
+  >
+}
 
 export type ReqPwResetMutationVariables = Exact<{
-  userOrEmail: Scalars['String'];
-}>;
+  userOrEmail: Scalars['String']
+}>
 
-
-export type ReqPwResetMutation = (
-  { __typename?: 'Mutation' }
-  & { reqPwReset?: Maybe<(
-    { __typename?: 'TokenResponse' }
-    & Pick<TokenResponse, 'success' | 'token'>
-  )> }
-);
+export type ReqPwResetMutation = { __typename?: 'Mutation' } & {
+  reqPwReset?: Maybe<
+    { __typename?: 'TokenResponse' } & Pick<TokenResponse, 'success' | 'token'>
+  >
+}
 
 export type SignupMutationVariables = Exact<{
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  email: Scalars['String'];
-  username: Scalars['String'];
-}>;
+  firstName: Scalars['String']
+  lastName: Scalars['String']
+  email: Scalars['String']
+  username: Scalars['String']
+}>
 
-
-export type SignupMutation = (
-  { __typename?: 'Mutation' }
-  & { signup?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'error'>
-  )> }
-);
+export type SignupMutation = { __typename?: 'Mutation' } & {
+  signup?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'error'
+    >
+  >
+}
 
 export type UpdateChallengeMutationVariables = Exact<{
-  lessonId: Scalars['Int'];
-  order?: Maybe<Scalars['Int']>;
-  description?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
-}>;
+  lessonId: Scalars['Int']
+  order?: Maybe<Scalars['Int']>
+  description?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+  id: Scalars['Int']
+}>
 
-
-export type UpdateChallengeMutation = (
-  { __typename?: 'Mutation' }
-  & { updateChallenge?: Maybe<Array<Maybe<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'chatUrl' | 'order' | 'description' | 'title'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'description' | 'lessonId' | 'title' | 'order'>
-    )>>> }
-  )>>> }
-);
+export type UpdateChallengeMutation = { __typename?: 'Mutation' } & {
+  updateChallenge?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Lesson' } & Pick<
+          Lesson,
+          | 'id'
+          | 'docUrl'
+          | 'githubUrl'
+          | 'videoUrl'
+          | 'chatUrl'
+          | 'order'
+          | 'description'
+          | 'title'
+        > & {
+            challenges?: Maybe<
+              Array<
+                Maybe<
+                  { __typename?: 'Challenge' } & Pick<
+                    Challenge,
+                    'id' | 'description' | 'lessonId' | 'title' | 'order'
+                  >
+                >
+              >
+            >
+          }
+      >
+    >
+  >
+}
 
 export type ChangePwMutationVariables = Exact<{
-  token: Scalars['String'];
-  password: Scalars['String'];
-}>;
+  token: Scalars['String']
+  password: Scalars['String']
+}>
 
-
-export type ChangePwMutation = (
-  { __typename?: 'Mutation' }
-  & { changePw?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success'>
-  )> }
-);
+export type ChangePwMutation = { __typename?: 'Mutation' } & {
+  changePw?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<AuthResponse, 'success'>
+  >
+}
 
 export type UserInfoQueryVariables = Exact<{
-  username: Scalars['String'];
-}>;
+  username: Scalars['String']
+}>
 
+export type UserInfoQuery = { __typename?: 'Query' } & {
+  lessons: Array<
+    { __typename?: 'Lesson' } & Pick<
+      Lesson,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'docUrl'
+      | 'githubUrl'
+      | 'videoUrl'
+      | 'order'
+      | 'chatUrl'
+    > & {
+        challenges?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Challenge' } & Pick<
+                Challenge,
+                'id' | 'title' | 'description' | 'order'
+              >
+            >
+          >
+        >
+      }
+  >
+  userInfo?: Maybe<
+    { __typename?: 'Session' } & {
+      user?: Maybe<
+        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
+      >
+      submissions?: Maybe<
+        Array<
+          Maybe<
+            { __typename?: 'Submission' } & Pick<
+              Submission,
+              | 'id'
+              | 'status'
+              | 'mrUrl'
+              | 'diff'
+              | 'viewCount'
+              | 'comment'
+              | 'order'
+              | 'challengeId'
+              | 'lessonId'
+              | 'createdAt'
+              | 'updatedAt'
+            > & {
+                reviewer?: Maybe<
+                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+                >
+              }
+          >
+        >
+      >
+      lessonStatus: Array<
+        { __typename?: 'UserLesson' } & Pick<
+          UserLesson,
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
+        >
+      >
+    }
+  >
+}
 
-export type UserInfoQuery = (
-  { __typename?: 'Query' }
-  & { lessons: Array<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
-    )>>> }
-  )>, userInfo?: Maybe<(
-    { __typename?: 'Session' }
-    & { user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username' | 'name'>
-    )>, submissions?: Maybe<Array<Maybe<(
-      { __typename?: 'Submission' }
-      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
-      & { reviewer?: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'username'>
-      )> }
-    )>>>, lessonStatus: Array<(
-      { __typename?: 'UserLesson' }
-      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
-    )> }
-  )> }
-);
-
-
-
-export type ResolverTypeWrapper<T> = Promise<T> | T;
-
+export type ResolverTypeWrapper<T> = Promise<T> | T
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  fragment: string;
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-};
+  fragment: string
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
+}
 
 export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  selectionSet: string;
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-};
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+  selectionSet: string
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
+}
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
-  | StitchingResolver<TResult, TParent, TContext, TArgs>;
+  | StitchingResolver<TResult, TParent, TContext, TArgs>
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => Promise<TResult> | TResult;
+) => Promise<TResult> | TResult
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult>
 
-export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
-  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>
 }
 
-export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
-  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
-  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
   info: GraphQLResolveInfo
-) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>
 
-export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (
+  obj: T,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>
 
-export type NextResolverFn<T> = () => Promise<T>;
+export type NextResolverFn<T> = () => Promise<T>
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult>
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Query: ResolverTypeWrapper<{}>;
-  Lesson: ResolverTypeWrapper<Lesson>;
-  String: ResolverTypeWrapper<Scalars['String']>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
-  Challenge: ResolverTypeWrapper<Challenge>;
-  User: ResolverTypeWrapper<User>;
-  UserLesson: ResolverTypeWrapper<UserLesson>;
-  Session: ResolverTypeWrapper<Session>;
-  Submission: ResolverTypeWrapper<Submission>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  Alert: ResolverTypeWrapper<Alert>;
-  Mutation: ResolverTypeWrapper<{}>;
-  AuthResponse: ResolverTypeWrapper<AuthResponse>;
-  TokenResponse: ResolverTypeWrapper<TokenResponse>;
-  SuccessResponse: ResolverTypeWrapper<SuccessResponse>;
-  CacheControlScope: CacheControlScope;
-  Upload: ResolverTypeWrapper<Scalars['Upload']>;
-};
+  Query: ResolverTypeWrapper<{}>
+  Lesson: ResolverTypeWrapper<Lesson>
+  String: ResolverTypeWrapper<Scalars['String']>
+  Int: ResolverTypeWrapper<Scalars['Int']>
+  Challenge: ResolverTypeWrapper<Challenge>
+  User: ResolverTypeWrapper<User>
+  UserLesson: ResolverTypeWrapper<UserLesson>
+  Session: ResolverTypeWrapper<Session>
+  Submission: ResolverTypeWrapper<Submission>
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>
+  Alert: ResolverTypeWrapper<Alert>
+  Mutation: ResolverTypeWrapper<{}>
+  AuthResponse: ResolverTypeWrapper<AuthResponse>
+  TokenResponse: ResolverTypeWrapper<TokenResponse>
+  SuccessResponse: ResolverTypeWrapper<SuccessResponse>
+  CacheControlScope: CacheControlScope
+  Upload: ResolverTypeWrapper<Scalars['Upload']>
+}
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Query: {};
-  Lesson: Lesson;
-  String: Scalars['String'];
-  Int: Scalars['Int'];
-  Challenge: Challenge;
-  User: User;
-  UserLesson: UserLesson;
-  Session: Session;
-  Submission: Submission;
-  Boolean: Scalars['Boolean'];
-  Alert: Alert;
-  Mutation: {};
-  AuthResponse: AuthResponse;
-  TokenResponse: TokenResponse;
-  SuccessResponse: SuccessResponse;
-  Upload: Scalars['Upload'];
-};
-
-export type AlertResolvers<ContextType = any, ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']> = {
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  urlCaption?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type AuthResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type ChallengeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type LessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challenges?: Resolver<Maybe<Array<Maybe<ResolversTypes['Challenge']>>>, ParentType, ContextType>;
-  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
-  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
-  login?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationLoginArgs, 'username' | 'password'>>;
-  logout?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType>;
-  reqPwReset?: Resolver<Maybe<ResolversTypes['TokenResponse']>, ParentType, ContextType, RequireFields<MutationReqPwResetArgs, 'userOrEmail'>>;
-  changePw?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationChangePwArgs, 'token' | 'password'>>;
-  changeAdminRights?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationChangeAdminRightsArgs, 'id' | 'status'>>;
-  signup?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationSignupArgs, 'firstName' | 'lastName' | 'email' | 'username'>>;
-  addAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationAddAlertArgs, 'text' | 'type'>>;
-  removeAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationRemoveAlertArgs, 'id'>>;
-  createSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationCreateSubmissionArgs, 'lessonId' | 'challengeId' | 'cliToken' | 'diff'>>;
-  acceptSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>>;
-  rejectSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>>;
-  createLesson?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>>;
-  updateLesson?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationUpdateLessonArgs, 'id'>>;
-  createChallenge?: Resolver<Maybe<Array<Maybe<ResolversTypes['Lesson']>>>, ParentType, ContextType, RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'order' | 'description' | 'title'>>;
-  updateChallenge?: Resolver<Maybe<Array<Maybe<ResolversTypes['Lesson']>>>, ParentType, ContextType, RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id'>>;
-};
-
-export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>;
-  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>;
-  allUsers?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
-  userInfo?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType, RequireFields<QueryUserInfoArgs, 'username'>>;
-  isTokenValid?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<QueryIsTokenValidArgs, 'cliToken'>>;
-  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType, RequireFields<QuerySubmissionsArgs, 'lessonId'>>;
-  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>;
-};
-
-export type SessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']> = {
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType>;
-  lessonStatus?: Resolver<Array<ResolversTypes['UserLesson']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challengeId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challenge?: Resolver<Maybe<ResolversTypes['Challenge']>, ParentType, ContextType>;
-  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  reviewerId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type SuccessResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type TokenResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export interface UploadScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
-  name: 'Upload';
+  Query: {}
+  Lesson: Lesson
+  String: Scalars['String']
+  Int: Scalars['Int']
+  Challenge: Challenge
+  User: User
+  UserLesson: UserLesson
+  Session: Session
+  Submission: Submission
+  Boolean: Scalars['Boolean']
+  Alert: Alert
+  Mutation: {}
+  AuthResponse: AuthResponse
+  TokenResponse: TokenResponse
+  SuccessResponse: SuccessResponse
+  Upload: Scalars['Upload']
 }
 
-export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userLesson?: Resolver<Maybe<ResolversTypes['UserLesson']>, ParentType, ContextType>;
-  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
+export type AlertResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']
+> = {
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  urlCaption?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
 
-export type UserLessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isTeaching?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isEnrolled?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  starGiven?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  starComment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
+export type AuthResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type ChallengeResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  description?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type LessonResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  description?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  challenges?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Challenge']>>>,
+    ParentType,
+    ContextType
+  >
+  users?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['User']>>>,
+    ParentType,
+    ContextType
+  >
+  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type MutationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
+> = {
+  login?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationLoginArgs, 'username' | 'password'>
+  >
+  logout?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType
+  >
+  reqPwReset?: Resolver<
+    Maybe<ResolversTypes['TokenResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationReqPwResetArgs, 'userOrEmail'>
+  >
+  changePw?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationChangePwArgs, 'token' | 'password'>
+  >
+  changeAdminRights?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationChangeAdminRightsArgs, 'id' | 'status'>
+  >
+  signup?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationSignupArgs,
+      'firstName' | 'lastName' | 'email' | 'username'
+    >
+  >
+  addAlert?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationAddAlertArgs, 'text' | 'type'>
+  >
+  removeAlert?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationRemoveAlertArgs, 'id'>
+  >
+  createSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationCreateSubmissionArgs,
+      'lessonId' | 'challengeId' | 'cliToken' | 'diff'
+    >
+  >
+  acceptSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>
+  >
+  rejectSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>
+  >
+  createLesson?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>
+  >
+  updateLesson?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateLessonArgs, 'id'>
+  >
+  createChallenge?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationCreateChallengeArgs,
+      'lessonId' | 'order' | 'description' | 'title'
+    >
+  >
+  updateChallenge?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id'>
+  >
+}
+
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>
+  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>
+  allUsers?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['User']>>>,
+    ParentType,
+    ContextType
+  >
+  userInfo?: Resolver<
+    Maybe<ResolversTypes['Session']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryUserInfoArgs, 'username'>
+  >
+  isTokenValid?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryIsTokenValidArgs, 'cliToken'>
+  >
+  submissions?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySubmissionsArgs, 'lessonId'>
+  >
+  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>
+}
+
+export type SessionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']
+> = {
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  submissions?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
+    ParentType,
+    ContextType
+  >
+  lessonStatus?: Resolver<
+    Array<ResolversTypes['UserLesson']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type SubmissionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  challengeId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  challenge?: Resolver<
+    Maybe<ResolversTypes['Challenge']>,
+    ParentType,
+    ContextType
+  >
+  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  reviewerId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type SuccessResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type TokenResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export interface UploadScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
+  name: 'Upload'
+}
+
+export type UserResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userLesson?: Resolver<
+    Maybe<ResolversTypes['UserLesson']>,
+    ParentType,
+    ContextType
+  >
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type UserLessonResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isTeaching?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  isEnrolled?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  starGiven?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  starComment?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
 
 export type Resolvers<ContextType = any> = {
-  Alert?: AlertResolvers<ContextType>;
-  AuthResponse?: AuthResponseResolvers<ContextType>;
-  Challenge?: ChallengeResolvers<ContextType>;
-  Lesson?: LessonResolvers<ContextType>;
-  Mutation?: MutationResolvers<ContextType>;
-  Query?: QueryResolvers<ContextType>;
-  Session?: SessionResolvers<ContextType>;
-  Submission?: SubmissionResolvers<ContextType>;
-  SuccessResponse?: SuccessResponseResolvers<ContextType>;
-  TokenResponse?: TokenResponseResolvers<ContextType>;
-  Upload?: GraphQLScalarType;
-  User?: UserResolvers<ContextType>;
-  UserLesson?: UserLessonResolvers<ContextType>;
-};
-
+  Alert?: AlertResolvers<ContextType>
+  AuthResponse?: AuthResponseResolvers<ContextType>
+  Challenge?: ChallengeResolvers<ContextType>
+  Lesson?: LessonResolvers<ContextType>
+  Mutation?: MutationResolvers<ContextType>
+  Query?: QueryResolvers<ContextType>
+  Session?: SessionResolvers<ContextType>
+  Submission?: SubmissionResolvers<ContextType>
+  SuccessResponse?: SuccessResponseResolvers<ContextType>
+  TokenResponse?: TokenResponseResolvers<ContextType>
+  Upload?: GraphQLScalarType
+  User?: UserResolvers<ContextType>
+  UserLesson?: UserLessonResolvers<ContextType>
+}
 
 /**
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
  */
-export type IResolvers<ContextType = any> = Resolvers<ContextType>;
-
+export type IResolvers<ContextType = any> = Resolvers<ContextType>
 
 export const AcceptSubmissionDocument = gql`
-    mutation acceptSubmission($submissionId: String!, $comment: String!) {
-  acceptSubmission(id: $submissionId, comment: $comment) {
-    id
-    comment
-    status
+  mutation acceptSubmission($submissionId: String!, $comment: String!) {
+    acceptSubmission(id: $submissionId, comment: $comment) {
+      id
+      comment
+      status
+    }
   }
-}
-    `;
-export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
-export type AcceptSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>, 'mutation'>;
-
-    export const AcceptSubmissionComponent = (props: AcceptSubmissionComponentProps) => (
-      <ApolloReactComponents.Mutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables> mutation={AcceptSubmissionDocument} {...props} />
-    );
-    
-export type AcceptSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>
-    } & TChildProps;
-export function withAcceptSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+`
+export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<
   AcceptSubmissionMutation,
-  AcceptSubmissionMutationVariables,
-  AcceptSubmissionProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, AcceptSubmissionMutation, AcceptSubmissionMutationVariables, AcceptSubmissionProps<TChildProps, TDataName>>(AcceptSubmissionDocument, {
-      alias: 'acceptSubmission',
-      ...operationOptions
-    });
-};
+  AcceptSubmissionMutationVariables
+>
+export type AcceptSubmissionComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >,
+  'mutation'
+>
+
+export const AcceptSubmissionComponent = (
+  props: AcceptSubmissionComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+    mutation={AcceptSubmissionDocument}
+    {...props}
+  />
+)
+
+export type AcceptSubmissionProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+} &
+  TChildProps
+export function withAcceptSubmission<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables,
+    AcceptSubmissionProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables,
+    AcceptSubmissionProps<TChildProps, TDataName>
+  >(AcceptSubmissionDocument, {
+    alias: 'acceptSubmission',
+    ...operationOptions
+  })
+}
 
 /**
  * __useAcceptSubmissionMutation__
@@ -839,39 +1204,85 @@ export function withAcceptSubmission<TProps, TChildProps = {}, TDataName extends
  *   },
  * });
  */
-export function useAcceptSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>) {
-        return ApolloReactHooks.useMutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>(AcceptSubmissionDocument, baseOptions);
-      }
-export type AcceptSubmissionMutationHookResult = ReturnType<typeof useAcceptSubmissionMutation>;
-export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<AcceptSubmissionMutation>;
-export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
-export const AddAlertDocument = gql`
-    mutation addAlert($text: String!, $type: String!) {
-  addAlert(text: $text, type: $type) {
-    success
-  }
+export function useAcceptSubmissionMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >(AcceptSubmissionDocument, baseOptions)
 }
-    `;
-export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>;
-export type AddAlertComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AddAlertMutation, AddAlertMutationVariables>, 'mutation'>;
-
-    export const AddAlertComponent = (props: AddAlertComponentProps) => (
-      <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables> mutation={AddAlertDocument} {...props} />
-    );
-    
-export type AddAlertProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>
-    } & TChildProps;
-export function withAddAlert<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type AcceptSubmissionMutationHookResult = ReturnType<
+  typeof useAcceptSubmissionMutation
+>
+export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<
+  AcceptSubmissionMutation
+>
+export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  AcceptSubmissionMutation,
+  AcceptSubmissionMutationVariables
+>
+export const AddAlertDocument = gql`
+  mutation addAlert($text: String!, $type: String!) {
+    addAlert(text: $text, type: $type) {
+      success
+    }
+  }
+`
+export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<
   AddAlertMutation,
-  AddAlertMutationVariables,
-  AddAlertProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, AddAlertMutation, AddAlertMutationVariables, AddAlertProps<TChildProps, TDataName>>(AddAlertDocument, {
-      alias: 'addAlert',
-      ...operationOptions
-    });
-};
+  AddAlertMutationVariables
+>
+export type AddAlertComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >,
+  'mutation'
+>
+
+export const AddAlertComponent = (props: AddAlertComponentProps) => (
+  <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables>
+    mutation={AddAlertDocument}
+    {...props}
+  />
+)
+
+export type AddAlertProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >
+} &
+  TChildProps
+export function withAddAlert<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    AddAlertMutation,
+    AddAlertMutationVariables,
+    AddAlertProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    AddAlertMutation,
+    AddAlertMutationVariables,
+    AddAlertProps<TChildProps, TDataName>
+  >(AddAlertDocument, {
+    alias: 'addAlert',
+    ...operationOptions
+  })
+}
 
 /**
  * __useAddAlertMutation__
@@ -891,53 +1302,112 @@ export function withAddAlert<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useAddAlertMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AddAlertMutation, AddAlertMutationVariables>) {
-        return ApolloReactHooks.useMutation<AddAlertMutation, AddAlertMutationVariables>(AddAlertDocument, baseOptions);
-      }
-export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>;
-export type AddAlertMutationResult = ApolloReactCommon.MutationResult<AddAlertMutation>;
-export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<AddAlertMutation, AddAlertMutationVariables>;
+export function useAddAlertMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >(AddAlertDocument, baseOptions)
+}
+export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>
+export type AddAlertMutationResult = ApolloReactCommon.MutationResult<
+  AddAlertMutation
+>
+export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  AddAlertMutation,
+  AddAlertMutationVariables
+>
 export const CreateChallengeDocument = gql`
-    mutation createChallenge($lessonId: Int!, $order: Int!, $description: String!, $title: String!) {
-  createChallenge(lessonId: $lessonId, order: $order, description: $description, title: $title) {
-    id
-    docUrl
-    githubUrl
-    videoUrl
-    chatUrl
-    order
-    description
-    title
-    challenges {
+  mutation createChallenge(
+    $lessonId: Int!
+    $order: Int!
+    $description: String!
+    $title: String!
+  ) {
+    createChallenge(
+      lessonId: $lessonId
+      order: $order
+      description: $description
+      title: $title
+    ) {
       id
-      description
-      lessonId
-      title
+      docUrl
+      githubUrl
+      videoUrl
+      chatUrl
       order
+      description
+      title
+      challenges {
+        id
+        description
+        lessonId
+        title
+        order
+      }
     }
   }
-}
-    `;
-export type CreateChallengeMutationFn = ApolloReactCommon.MutationFunction<CreateChallengeMutation, CreateChallengeMutationVariables>;
-export type CreateChallengeComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<CreateChallengeMutation, CreateChallengeMutationVariables>, 'mutation'>;
-
-    export const CreateChallengeComponent = (props: CreateChallengeComponentProps) => (
-      <ApolloReactComponents.Mutation<CreateChallengeMutation, CreateChallengeMutationVariables> mutation={CreateChallengeDocument} {...props} />
-    );
-    
-export type CreateChallengeProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<CreateChallengeMutation, CreateChallengeMutationVariables>
-    } & TChildProps;
-export function withCreateChallenge<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+`
+export type CreateChallengeMutationFn = ApolloReactCommon.MutationFunction<
   CreateChallengeMutation,
-  CreateChallengeMutationVariables,
-  CreateChallengeProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, CreateChallengeMutation, CreateChallengeMutationVariables, CreateChallengeProps<TChildProps, TDataName>>(CreateChallengeDocument, {
-      alias: 'createChallenge',
-      ...operationOptions
-    });
-};
+  CreateChallengeMutationVariables
+>
+export type CreateChallengeComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >,
+  'mutation'
+>
+
+export const CreateChallengeComponent = (
+  props: CreateChallengeComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >
+    mutation={CreateChallengeDocument}
+    {...props}
+  />
+)
+
+export type CreateChallengeProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >
+} &
+  TChildProps
+export function withCreateChallenge<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables,
+    CreateChallengeProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables,
+    CreateChallengeProps<TChildProps, TDataName>
+  >(CreateChallengeDocument, {
+    alias: 'createChallenge',
+    ...operationOptions
+  })
+}
 
 /**
  * __useCreateChallengeMutation__
@@ -959,88 +1429,128 @@ export function withCreateChallenge<TProps, TChildProps = {}, TDataName extends 
  *   },
  * });
  */
-export function useCreateChallengeMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateChallengeMutation, CreateChallengeMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateChallengeMutation, CreateChallengeMutationVariables>(CreateChallengeDocument, baseOptions);
-      }
-export type CreateChallengeMutationHookResult = ReturnType<typeof useCreateChallengeMutation>;
-export type CreateChallengeMutationResult = ApolloReactCommon.MutationResult<CreateChallengeMutation>;
-export type CreateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateChallengeMutation, CreateChallengeMutationVariables>;
+export function useCreateChallengeMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >(CreateChallengeDocument, baseOptions)
+}
+export type CreateChallengeMutationHookResult = ReturnType<
+  typeof useCreateChallengeMutation
+>
+export type CreateChallengeMutationResult = ApolloReactCommon.MutationResult<
+  CreateChallengeMutation
+>
+export type CreateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  CreateChallengeMutation,
+  CreateChallengeMutationVariables
+>
 export const GetAppDocument = gql`
-    query getApp {
-  lessons {
-    id
-    title
-    description
-    docUrl
-    githubUrl
-    videoUrl
-    order
-    challenges {
+  query getApp {
+    lessons {
       id
       title
       description
+      docUrl
+      githubUrl
+      videoUrl
       order
+      challenges {
+        id
+        title
+        description
+        order
+      }
+      chatUrl
     }
-    chatUrl
-  }
-  session {
-    user {
-      id
-      username
-      name
-    }
-    submissions {
-      id
-      status
-      mrUrl
-      diff
-      viewCount
-      comment
-      order
-      challengeId
-      lessonId
-      reviewer {
+    session {
+      user {
         id
         username
+        name
       }
-      createdAt
-      updatedAt
+      submissions {
+        id
+        status
+        mrUrl
+        diff
+        viewCount
+        comment
+        order
+        challengeId
+        lessonId
+        reviewer {
+          id
+          username
+        }
+        createdAt
+        updatedAt
+      }
+      lessonStatus {
+        lessonId
+        isPassed
+        isTeaching
+        isEnrolled
+      }
     }
-    lessonStatus {
-      lessonId
-      isPassed
-      isTeaching
-      isEnrolled
+    alerts {
+      id
+      text
+      type
+      url
+      urlCaption
     }
   }
-  alerts {
-    id
-    text
-    type
-    url
-    urlCaption
-  }
-}
-    `;
-export type GetAppComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<GetAppQuery, GetAppQueryVariables>, 'query'>;
+`
+export type GetAppComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >,
+  'query'
+>
 
-    export const GetAppComponent = (props: GetAppComponentProps) => (
-      <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables> query={GetAppDocument} {...props} />
-    );
-    
+export const GetAppComponent = (props: GetAppComponentProps) => (
+  <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables>
+    query={GetAppDocument}
+    {...props}
+  />
+)
+
 export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<GetAppQuery, GetAppQueryVariables>
-    } & TChildProps;
-export function withGetApp<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+} &
+  TChildProps
+export function withGetApp<
   TProps,
-  GetAppQuery,
-  GetAppQueryVariables,
-  GetAppProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, GetAppQuery, GetAppQueryVariables, GetAppProps<TChildProps, TDataName>>(GetAppDocument, {
-      alias: 'getApp',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    GetAppQuery,
+    GetAppQueryVariables,
+    GetAppProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    GetAppQuery,
+    GetAppQueryVariables,
+    GetAppProps<TChildProps, TDataName>
+  >(GetAppDocument, {
+    alias: 'getApp',
+    ...operationOptions
+  })
+}
 
 /**
  * __useGetAppQuery__
@@ -1057,54 +1567,102 @@ export function withGetApp<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useGetAppQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
-      }
-export function useGetAppLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
-        }
-export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>;
-export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>;
-export type GetAppQueryResult = ApolloReactCommon.QueryResult<GetAppQuery, GetAppQueryVariables>;
-export const SubmissionsDocument = gql`
-    query submissions($lessonId: String!) {
-  submissions(lessonId: $lessonId) {
-    id
-    status
-    diff
-    comment
-    challenge {
-      title
-    }
-    challengeId
-    user {
-      id
-      username
-    }
-    createdAt
-    updatedAt
-  }
+export function useGetAppQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(
+    GetAppDocument,
+    baseOptions
+  )
 }
-    `;
-export type SubmissionsComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<SubmissionsQuery, SubmissionsQueryVariables>, 'query'> & ({ variables: SubmissionsQueryVariables; skip?: boolean; } | { skip: boolean; });
+export function useGetAppLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(
+    GetAppDocument,
+    baseOptions
+  )
+}
+export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>
+export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>
+export type GetAppQueryResult = ApolloReactCommon.QueryResult<
+  GetAppQuery,
+  GetAppQueryVariables
+>
+export const SubmissionsDocument = gql`
+  query submissions($lessonId: String!) {
+    submissions(lessonId: $lessonId) {
+      id
+      status
+      diff
+      comment
+      challenge {
+        title
+      }
+      challengeId
+      user {
+        id
+        username
+      }
+      createdAt
+      updatedAt
+    }
+  }
+`
+export type SubmissionsComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >,
+  'query'
+> &
+  ({ variables: SubmissionsQueryVariables; skip?: boolean } | { skip: boolean })
 
-    export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
-      <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables> query={SubmissionsDocument} {...props} />
-    );
-    
-export type SubmissionsProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<SubmissionsQuery, SubmissionsQueryVariables>
-    } & TChildProps;
-export function withSubmissions<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
+  <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables>
+    query={SubmissionsDocument}
+    {...props}
+  />
+)
+
+export type SubmissionsProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+} &
+  TChildProps
+export function withSubmissions<
   TProps,
-  SubmissionsQuery,
-  SubmissionsQueryVariables,
-  SubmissionsProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, SubmissionsQuery, SubmissionsQueryVariables, SubmissionsProps<TChildProps, TDataName>>(SubmissionsDocument, {
-      alias: 'submissions',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    SubmissionsQuery,
+    SubmissionsQueryVariables,
+    SubmissionsProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    SubmissionsQuery,
+    SubmissionsQueryVariables,
+    SubmissionsProps<TChildProps, TDataName>
+  >(SubmissionsDocument, {
+    alias: 'submissions',
+    ...operationOptions
+  })
+}
 
 /**
  * __useSubmissionsQuery__
@@ -1122,45 +1680,97 @@ export function withSubmissions<TProps, TChildProps = {}, TDataName extends stri
  *   },
  * });
  */
-export function useSubmissionsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
-        return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
-      }
-export function useSubmissionsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
-        }
-export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>;
-export type SubmissionsLazyQueryHookResult = ReturnType<typeof useSubmissionsLazyQuery>;
-export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<SubmissionsQuery, SubmissionsQueryVariables>;
-export const LoginDocument = gql`
-    mutation login($username: String!, $password: String!) {
-  login(username: $username, password: $password) {
-    success
-    username
-    cliToken
-    error
-  }
+export function useSubmissionsQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(
+    SubmissionsDocument,
+    baseOptions
+  )
 }
-    `;
-export type LoginMutationFn = ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>;
-export type LoginComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LoginMutation, LoginMutationVariables>, 'mutation'>;
-
-    export const LoginComponent = (props: LoginComponentProps) => (
-      <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables> mutation={LoginDocument} {...props} />
-    );
-    
-export type LoginProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>
-    } & TChildProps;
-export function withLogin<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export function useSubmissionsLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >(SubmissionsDocument, baseOptions)
+}
+export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>
+export type SubmissionsLazyQueryHookResult = ReturnType<
+  typeof useSubmissionsLazyQuery
+>
+export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<
+  SubmissionsQuery,
+  SubmissionsQueryVariables
+>
+export const LoginDocument = gql`
+  mutation login($username: String!, $password: String!) {
+    login(username: $username, password: $password) {
+      success
+      username
+      cliToken
+      error
+    }
+  }
+`
+export type LoginMutationFn = ApolloReactCommon.MutationFunction<
   LoginMutation,
-  LoginMutationVariables,
-  LoginProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, LoginMutation, LoginMutationVariables, LoginProps<TChildProps, TDataName>>(LoginDocument, {
-      alias: 'login',
-      ...operationOptions
-    });
-};
+  LoginMutationVariables
+>
+export type LoginComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    LoginMutation,
+    LoginMutationVariables
+  >,
+  'mutation'
+>
+
+export const LoginComponent = (props: LoginComponentProps) => (
+  <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables>
+    mutation={LoginDocument}
+    {...props}
+  />
+)
+
+export type LoginProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    LoginMutation,
+    LoginMutationVariables
+  >
+} &
+  TChildProps
+export function withLogin<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    LoginMutation,
+    LoginMutationVariables,
+    LoginProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    LoginMutation,
+    LoginMutationVariables,
+    LoginProps<TChildProps, TDataName>
+  >(LoginDocument, {
+    alias: 'login',
+    ...operationOptions
+  })
+}
 
 /**
  * __useLoginMutation__
@@ -1180,41 +1790,85 @@ export function withLogin<TProps, TChildProps = {}, TDataName extends string = '
  *   },
  * });
  */
-export function useLoginMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
-        return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, baseOptions);
-      }
-export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
-export type LoginMutationResult = ApolloReactCommon.MutationResult<LoginMutation>;
-export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
-export const LogoutDocument = gql`
-    mutation logout {
-  logout {
-    success
-    username
-    error
-  }
+export function useLoginMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    LoginMutation,
+    LoginMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(
+    LoginDocument,
+    baseOptions
+  )
 }
-    `;
-export type LogoutMutationFn = ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>;
-export type LogoutComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LogoutMutation, LogoutMutationVariables>, 'mutation'>;
-
-    export const LogoutComponent = (props: LogoutComponentProps) => (
-      <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables> mutation={LogoutDocument} {...props} />
-    );
-    
-export type LogoutProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>
-    } & TChildProps;
-export function withLogout<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>
+export type LoginMutationResult = ApolloReactCommon.MutationResult<
+  LoginMutation
+>
+export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  LoginMutation,
+  LoginMutationVariables
+>
+export const LogoutDocument = gql`
+  mutation logout {
+    logout {
+      success
+      username
+      error
+    }
+  }
+`
+export type LogoutMutationFn = ApolloReactCommon.MutationFunction<
   LogoutMutation,
-  LogoutMutationVariables,
-  LogoutProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, LogoutMutation, LogoutMutationVariables, LogoutProps<TChildProps, TDataName>>(LogoutDocument, {
-      alias: 'logout',
-      ...operationOptions
-    });
-};
+  LogoutMutationVariables
+>
+export type LogoutComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    LogoutMutation,
+    LogoutMutationVariables
+  >,
+  'mutation'
+>
+
+export const LogoutComponent = (props: LogoutComponentProps) => (
+  <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables>
+    mutation={LogoutDocument}
+    {...props}
+  />
+)
+
+export type LogoutProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    LogoutMutation,
+    LogoutMutationVariables
+  >
+} &
+  TChildProps
+export function withLogout<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    LogoutMutation,
+    LogoutMutationVariables,
+    LogoutProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    LogoutMutation,
+    LogoutMutationVariables,
+    LogoutProps<TChildProps, TDataName>
+  >(LogoutDocument, {
+    alias: 'logout',
+    ...operationOptions
+  })
+}
 
 /**
  * __useLogoutMutation__
@@ -1232,41 +1886,90 @@ export function withLogout<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useLogoutMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
-        return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, baseOptions);
-      }
-export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
-export type LogoutMutationResult = ApolloReactCommon.MutationResult<LogoutMutation>;
-export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<LogoutMutation, LogoutMutationVariables>;
-export const RejectSubmissionDocument = gql`
-    mutation rejectSubmission($submissionId: String!, $comment: String!) {
-  rejectSubmission(id: $submissionId, comment: $comment) {
-    id
-    comment
-    status
-  }
+export function useLogoutMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    LogoutMutation,
+    LogoutMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(
+    LogoutDocument,
+    baseOptions
+  )
 }
-    `;
-export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
-export type RejectSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>, 'mutation'>;
-
-    export const RejectSubmissionComponent = (props: RejectSubmissionComponentProps) => (
-      <ApolloReactComponents.Mutation<RejectSubmissionMutation, RejectSubmissionMutationVariables> mutation={RejectSubmissionDocument} {...props} />
-    );
-    
-export type RejectSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>
-    } & TChildProps;
-export function withRejectSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>
+export type LogoutMutationResult = ApolloReactCommon.MutationResult<
+  LogoutMutation
+>
+export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  LogoutMutation,
+  LogoutMutationVariables
+>
+export const RejectSubmissionDocument = gql`
+  mutation rejectSubmission($submissionId: String!, $comment: String!) {
+    rejectSubmission(id: $submissionId, comment: $comment) {
+      id
+      comment
+      status
+    }
+  }
+`
+export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<
   RejectSubmissionMutation,
-  RejectSubmissionMutationVariables,
-  RejectSubmissionProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, RejectSubmissionMutation, RejectSubmissionMutationVariables, RejectSubmissionProps<TChildProps, TDataName>>(RejectSubmissionDocument, {
-      alias: 'rejectSubmission',
-      ...operationOptions
-    });
-};
+  RejectSubmissionMutationVariables
+>
+export type RejectSubmissionComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >,
+  'mutation'
+>
+
+export const RejectSubmissionComponent = (
+  props: RejectSubmissionComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+    mutation={RejectSubmissionDocument}
+    {...props}
+  />
+)
+
+export type RejectSubmissionProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+} &
+  TChildProps
+export function withRejectSubmission<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables,
+    RejectSubmissionProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables,
+    RejectSubmissionProps<TChildProps, TDataName>
+  >(RejectSubmissionDocument, {
+    alias: 'rejectSubmission',
+    ...operationOptions
+  })
+}
 
 /**
  * __useRejectSubmissionMutation__
@@ -1286,40 +1989,89 @@ export function withRejectSubmission<TProps, TChildProps = {}, TDataName extends
  *   },
  * });
  */
-export function useRejectSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>) {
-        return ApolloReactHooks.useMutation<RejectSubmissionMutation, RejectSubmissionMutationVariables>(RejectSubmissionDocument, baseOptions);
-      }
-export type RejectSubmissionMutationHookResult = ReturnType<typeof useRejectSubmissionMutation>;
-export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<RejectSubmissionMutation>;
-export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
-export const ReqPwResetDocument = gql`
-    mutation reqPwReset($userOrEmail: String!) {
-  reqPwReset(userOrEmail: $userOrEmail) {
-    success
-    token
-  }
+export function useRejectSubmissionMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >(RejectSubmissionDocument, baseOptions)
 }
-    `;
-export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>;
-export type ReqPwResetComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ReqPwResetMutation, ReqPwResetMutationVariables>, 'mutation'>;
-
-    export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
-      <ApolloReactComponents.Mutation<ReqPwResetMutation, ReqPwResetMutationVariables> mutation={ReqPwResetDocument} {...props} />
-    );
-    
-export type ReqPwResetProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>
-    } & TChildProps;
-export function withReqPwReset<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type RejectSubmissionMutationHookResult = ReturnType<
+  typeof useRejectSubmissionMutation
+>
+export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<
+  RejectSubmissionMutation
+>
+export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  RejectSubmissionMutation,
+  RejectSubmissionMutationVariables
+>
+export const ReqPwResetDocument = gql`
+  mutation reqPwReset($userOrEmail: String!) {
+    reqPwReset(userOrEmail: $userOrEmail) {
+      success
+      token
+    }
+  }
+`
+export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<
   ReqPwResetMutation,
-  ReqPwResetMutationVariables,
-  ReqPwResetProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, ReqPwResetMutation, ReqPwResetMutationVariables, ReqPwResetProps<TChildProps, TDataName>>(ReqPwResetDocument, {
-      alias: 'reqPwReset',
-      ...operationOptions
-    });
-};
+  ReqPwResetMutationVariables
+>
+export type ReqPwResetComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >,
+  'mutation'
+>
+
+export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
+  <ApolloReactComponents.Mutation<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+    mutation={ReqPwResetDocument}
+    {...props}
+  />
+)
+
+export type ReqPwResetProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+} &
+  TChildProps
+export function withReqPwReset<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables,
+    ReqPwResetProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables,
+    ReqPwResetProps<TChildProps, TDataName>
+  >(ReqPwResetDocument, {
+    alias: 'reqPwReset',
+    ...operationOptions
+  })
+}
 
 /**
  * __useReqPwResetMutation__
@@ -1338,41 +2090,97 @@ export function withReqPwReset<TProps, TChildProps = {}, TDataName extends strin
  *   },
  * });
  */
-export function useReqPwResetMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ReqPwResetMutation, ReqPwResetMutationVariables>) {
-        return ApolloReactHooks.useMutation<ReqPwResetMutation, ReqPwResetMutationVariables>(ReqPwResetDocument, baseOptions);
-      }
-export type ReqPwResetMutationHookResult = ReturnType<typeof useReqPwResetMutation>;
-export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<ReqPwResetMutation>;
-export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<ReqPwResetMutation, ReqPwResetMutationVariables>;
-export const SignupDocument = gql`
-    mutation signup($firstName: String!, $lastName: String!, $email: String!, $username: String!) {
-  signup(firstName: $firstName, lastName: $lastName, email: $email, username: $username) {
-    success
-    username
-    error
-  }
+export function useReqPwResetMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >(ReqPwResetDocument, baseOptions)
 }
-    `;
-export type SignupMutationFn = ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>;
-export type SignupComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<SignupMutation, SignupMutationVariables>, 'mutation'>;
-
-    export const SignupComponent = (props: SignupComponentProps) => (
-      <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables> mutation={SignupDocument} {...props} />
-    );
-    
-export type SignupProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>
-    } & TChildProps;
-export function withSignup<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type ReqPwResetMutationHookResult = ReturnType<
+  typeof useReqPwResetMutation
+>
+export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<
+  ReqPwResetMutation
+>
+export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  ReqPwResetMutation,
+  ReqPwResetMutationVariables
+>
+export const SignupDocument = gql`
+  mutation signup(
+    $firstName: String!
+    $lastName: String!
+    $email: String!
+    $username: String!
+  ) {
+    signup(
+      firstName: $firstName
+      lastName: $lastName
+      email: $email
+      username: $username
+    ) {
+      success
+      username
+      error
+    }
+  }
+`
+export type SignupMutationFn = ApolloReactCommon.MutationFunction<
   SignupMutation,
-  SignupMutationVariables,
-  SignupProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, SignupMutation, SignupMutationVariables, SignupProps<TChildProps, TDataName>>(SignupDocument, {
-      alias: 'signup',
-      ...operationOptions
-    });
-};
+  SignupMutationVariables
+>
+export type SignupComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    SignupMutation,
+    SignupMutationVariables
+  >,
+  'mutation'
+>
+
+export const SignupComponent = (props: SignupComponentProps) => (
+  <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables>
+    mutation={SignupDocument}
+    {...props}
+  />
+)
+
+export type SignupProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    SignupMutation,
+    SignupMutationVariables
+  >
+} &
+  TChildProps
+export function withSignup<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    SignupMutation,
+    SignupMutationVariables,
+    SignupProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    SignupMutation,
+    SignupMutationVariables,
+    SignupProps<TChildProps, TDataName>
+  >(SignupDocument, {
+    alias: 'signup',
+    ...operationOptions
+  })
+}
 
 /**
  * __useSignupMutation__
@@ -1394,53 +2202,114 @@ export function withSignup<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useSignupMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SignupMutation, SignupMutationVariables>) {
-        return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(SignupDocument, baseOptions);
-      }
-export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>;
-export type SignupMutationResult = ApolloReactCommon.MutationResult<SignupMutation>;
-export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<SignupMutation, SignupMutationVariables>;
+export function useSignupMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    SignupMutation,
+    SignupMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(
+    SignupDocument,
+    baseOptions
+  )
+}
+export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>
+export type SignupMutationResult = ApolloReactCommon.MutationResult<
+  SignupMutation
+>
+export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  SignupMutation,
+  SignupMutationVariables
+>
 export const UpdateChallengeDocument = gql`
-    mutation updateChallenge($lessonId: Int!, $order: Int, $description: String, $title: String, $id: Int!) {
-  updateChallenge(id: $id, lessonId: $lessonId, order: $order, description: $description, title: $title) {
-    id
-    docUrl
-    githubUrl
-    videoUrl
-    chatUrl
-    order
-    description
-    title
-    challenges {
+  mutation updateChallenge(
+    $lessonId: Int!
+    $order: Int
+    $description: String
+    $title: String
+    $id: Int!
+  ) {
+    updateChallenge(
+      id: $id
+      lessonId: $lessonId
+      order: $order
+      description: $description
+      title: $title
+    ) {
       id
-      description
-      lessonId
-      title
+      docUrl
+      githubUrl
+      videoUrl
+      chatUrl
       order
+      description
+      title
+      challenges {
+        id
+        description
+        lessonId
+        title
+        order
+      }
     }
   }
-}
-    `;
-export type UpdateChallengeMutationFn = ApolloReactCommon.MutationFunction<UpdateChallengeMutation, UpdateChallengeMutationVariables>;
-export type UpdateChallengeComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>, 'mutation'>;
-
-    export const UpdateChallengeComponent = (props: UpdateChallengeComponentProps) => (
-      <ApolloReactComponents.Mutation<UpdateChallengeMutation, UpdateChallengeMutationVariables> mutation={UpdateChallengeDocument} {...props} />
-    );
-    
-export type UpdateChallengeProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<UpdateChallengeMutation, UpdateChallengeMutationVariables>
-    } & TChildProps;
-export function withUpdateChallenge<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+`
+export type UpdateChallengeMutationFn = ApolloReactCommon.MutationFunction<
   UpdateChallengeMutation,
-  UpdateChallengeMutationVariables,
-  UpdateChallengeProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, UpdateChallengeMutation, UpdateChallengeMutationVariables, UpdateChallengeProps<TChildProps, TDataName>>(UpdateChallengeDocument, {
-      alias: 'updateChallenge',
-      ...operationOptions
-    });
-};
+  UpdateChallengeMutationVariables
+>
+export type UpdateChallengeComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >,
+  'mutation'
+>
+
+export const UpdateChallengeComponent = (
+  props: UpdateChallengeComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >
+    mutation={UpdateChallengeDocument}
+    {...props}
+  />
+)
+
+export type UpdateChallengeProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >
+} &
+  TChildProps
+export function withUpdateChallenge<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables,
+    UpdateChallengeProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables,
+    UpdateChallengeProps<TChildProps, TDataName>
+  >(UpdateChallengeDocument, {
+    alias: 'updateChallenge',
+    ...operationOptions
+  })
+}
 
 /**
  * __useUpdateChallengeMutation__
@@ -1463,39 +2332,85 @@ export function withUpdateChallenge<TProps, TChildProps = {}, TDataName extends 
  *   },
  * });
  */
-export function useUpdateChallengeMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>) {
-        return ApolloReactHooks.useMutation<UpdateChallengeMutation, UpdateChallengeMutationVariables>(UpdateChallengeDocument, baseOptions);
-      }
-export type UpdateChallengeMutationHookResult = ReturnType<typeof useUpdateChallengeMutation>;
-export type UpdateChallengeMutationResult = ApolloReactCommon.MutationResult<UpdateChallengeMutation>;
-export type UpdateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>;
-export const ChangePwDocument = gql`
-    mutation changePw($token: String!, $password: String!) {
-  changePw(token: $token, password: $password) {
-    success
-  }
+export function useUpdateChallengeMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >(UpdateChallengeDocument, baseOptions)
 }
-    `;
-export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>;
-export type ChangePwComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ChangePwMutation, ChangePwMutationVariables>, 'mutation'>;
-
-    export const ChangePwComponent = (props: ChangePwComponentProps) => (
-      <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables> mutation={ChangePwDocument} {...props} />
-    );
-    
-export type ChangePwProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>
-    } & TChildProps;
-export function withChangePw<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type UpdateChallengeMutationHookResult = ReturnType<
+  typeof useUpdateChallengeMutation
+>
+export type UpdateChallengeMutationResult = ApolloReactCommon.MutationResult<
+  UpdateChallengeMutation
+>
+export type UpdateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  UpdateChallengeMutation,
+  UpdateChallengeMutationVariables
+>
+export const ChangePwDocument = gql`
+  mutation changePw($token: String!, $password: String!) {
+    changePw(token: $token, password: $password) {
+      success
+    }
+  }
+`
+export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<
   ChangePwMutation,
-  ChangePwMutationVariables,
-  ChangePwProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, ChangePwMutation, ChangePwMutationVariables, ChangePwProps<TChildProps, TDataName>>(ChangePwDocument, {
-      alias: 'changePw',
-      ...operationOptions
-    });
-};
+  ChangePwMutationVariables
+>
+export type ChangePwComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >,
+  'mutation'
+>
+
+export const ChangePwComponent = (props: ChangePwComponentProps) => (
+  <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables>
+    mutation={ChangePwDocument}
+    {...props}
+  />
+)
+
+export type ChangePwProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >
+} &
+  TChildProps
+export function withChangePw<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    ChangePwMutation,
+    ChangePwMutationVariables,
+    ChangePwProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    ChangePwMutation,
+    ChangePwMutationVariables,
+    ChangePwProps<TChildProps, TDataName>
+  >(ChangePwDocument, {
+    alias: 'changePw',
+    ...operationOptions
+  })
+}
 
 /**
  * __useChangePwMutation__
@@ -1515,81 +2430,123 @@ export function withChangePw<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useChangePwMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ChangePwMutation, ChangePwMutationVariables>) {
-        return ApolloReactHooks.useMutation<ChangePwMutation, ChangePwMutationVariables>(ChangePwDocument, baseOptions);
-      }
-export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>;
-export type ChangePwMutationResult = ApolloReactCommon.MutationResult<ChangePwMutation>;
-export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<ChangePwMutation, ChangePwMutationVariables>;
+export function useChangePwMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >(ChangePwDocument, baseOptions)
+}
+export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>
+export type ChangePwMutationResult = ApolloReactCommon.MutationResult<
+  ChangePwMutation
+>
+export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  ChangePwMutation,
+  ChangePwMutationVariables
+>
 export const UserInfoDocument = gql`
-    query userInfo($username: String!) {
-  lessons {
-    id
-    title
-    description
-    docUrl
-    githubUrl
-    videoUrl
-    order
-    challenges {
+  query userInfo($username: String!) {
+    lessons {
       id
       title
       description
+      docUrl
+      githubUrl
+      videoUrl
       order
+      challenges {
+        id
+        title
+        description
+        order
+      }
+      chatUrl
     }
-    chatUrl
-  }
-  userInfo(username: $username) {
-    user {
-      id
-      username
-      name
-    }
-    submissions {
-      id
-      status
-      mrUrl
-      diff
-      viewCount
-      comment
-      order
-      challengeId
-      lessonId
-      reviewer {
+    userInfo(username: $username) {
+      user {
         id
         username
+        name
       }
-      createdAt
-      updatedAt
-    }
-    lessonStatus {
-      lessonId
-      isPassed
-      isTeaching
-      isEnrolled
+      submissions {
+        id
+        status
+        mrUrl
+        diff
+        viewCount
+        comment
+        order
+        challengeId
+        lessonId
+        reviewer {
+          id
+          username
+        }
+        createdAt
+        updatedAt
+      }
+      lessonStatus {
+        lessonId
+        isPassed
+        isTeaching
+        isEnrolled
+      }
     }
   }
-}
-    `;
-export type UserInfoComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<UserInfoQuery, UserInfoQueryVariables>, 'query'> & ({ variables: UserInfoQueryVariables; skip?: boolean; } | { skip: boolean; });
+`
+export type UserInfoComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >,
+  'query'
+> &
+  ({ variables: UserInfoQueryVariables; skip?: boolean } | { skip: boolean })
 
-    export const UserInfoComponent = (props: UserInfoComponentProps) => (
-      <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables> query={UserInfoDocument} {...props} />
-    );
-    
-export type UserInfoProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<UserInfoQuery, UserInfoQueryVariables>
-    } & TChildProps;
-export function withUserInfo<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+export const UserInfoComponent = (props: UserInfoComponentProps) => (
+  <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables>
+    query={UserInfoDocument}
+    {...props}
+  />
+)
+
+export type UserInfoProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+} &
+  TChildProps
+export function withUserInfo<
   TProps,
-  UserInfoQuery,
-  UserInfoQueryVariables,
-  UserInfoProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, UserInfoQuery, UserInfoQueryVariables, UserInfoProps<TChildProps, TDataName>>(UserInfoDocument, {
-      alias: 'userInfo',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UserInfoQuery,
+    UserInfoQueryVariables,
+    UserInfoProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    UserInfoQuery,
+    UserInfoQueryVariables,
+    UserInfoProps<TChildProps, TDataName>
+  >(UserInfoDocument, {
+    alias: 'userInfo',
+    ...operationOptions
+  })
+}
 
 /**
  * __useUserInfoQuery__
@@ -1607,12 +2564,33 @@ export function withUserInfo<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useUserInfoQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
-        return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
-      }
-export function useUserInfoLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
-        }
-export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>;
-export type UserInfoLazyQueryHookResult = ReturnType<typeof useUserInfoLazyQuery>;
-export type UserInfoQueryResult = ApolloReactCommon.QueryResult<UserInfoQuery, UserInfoQueryVariables>;
+export function useUserInfoQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(
+    UserInfoDocument,
+    baseOptions
+  )
+}
+export function useUserInfoLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(
+    UserInfoDocument,
+    baseOptions
+  )
+}
+export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>
+export type UserInfoLazyQueryHookResult = ReturnType<
+  typeof useUserInfoLazyQuery
+>
+export type UserInfoQueryResult = ApolloReactCommon.QueryResult<
+  UserInfoQuery,
+  UserInfoQueryVariables
+>

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -1,48 +1,41 @@
-import {
-  GraphQLResolveInfo,
-  GraphQLScalarType,
-  GraphQLScalarTypeConfig
-} from 'graphql'
-import gql from 'graphql-tag'
-import * as ApolloReactCommon from '@apollo/react-common'
-import * as React from 'react'
-import * as ApolloReactComponents from '@apollo/react-components'
-import * as ApolloReactHoc from '@apollo/react-hoc'
-import * as ApolloReactHooks from '@apollo/react-hooks'
-export type Maybe<T> = T | null
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] }
-export type RequireFields<T, K extends keyof T> = {
-  [X in Exclude<keyof T, K>]?: T[X]
-} &
-  { [P in K]-?: NonNullable<T[P]> }
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import gql from 'graphql-tag';
+import * as ApolloReactCommon from '@apollo/react-common';
+import * as React from 'react';
+import * as ApolloReactComponents from '@apollo/react-components';
+import * as ApolloReactHoc from '@apollo/react-hoc';
+import * as ApolloReactHooks from '@apollo/react-hooks';
+export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string
-  String: string
-  Boolean: boolean
-  Int: number
-  Float: number
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any
-}
+  Upload: any;
+};
 
 export type Alert = {
-  __typename?: 'Alert'
-  id: Scalars['String']
-  text?: Maybe<Scalars['String']>
-  type?: Maybe<Scalars['String']>
-  url?: Maybe<Scalars['String']>
-  urlCaption?: Maybe<Scalars['String']>
-}
+  __typename?: 'Alert';
+  id: Scalars['String'];
+  text?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+  urlCaption?: Maybe<Scalars['String']>;
+};
 
 export type AuthResponse = {
-  __typename?: 'AuthResponse'
-  success?: Maybe<Scalars['Boolean']>
-  username?: Maybe<Scalars['String']>
-  error?: Maybe<Scalars['String']>
-  cliToken?: Maybe<Scalars['String']>
-}
+  __typename?: 'AuthResponse';
+  success?: Maybe<Scalars['Boolean']>;
+  username?: Maybe<Scalars['String']>;
+  error?: Maybe<Scalars['String']>;
+  cliToken?: Maybe<Scalars['String']>;
+};
 
 export enum CacheControlScope {
   Public = 'PUBLIC',
@@ -50,1061 +43,783 @@ export enum CacheControlScope {
 }
 
 export type Challenge = {
-  __typename?: 'Challenge'
-  id?: Maybe<Scalars['String']>
-  description?: Maybe<Scalars['String']>
-  lessonId?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
-}
+  __typename?: 'Challenge';
+  id?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  lessonId?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+};
 
 export type Lesson = {
-  __typename?: 'Lesson'
-  id?: Maybe<Scalars['String']>
-  description?: Maybe<Scalars['String']>
-  docUrl?: Maybe<Scalars['String']>
-  githubUrl?: Maybe<Scalars['String']>
-  videoUrl?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
-  title?: Maybe<Scalars['String']>
-  challenges?: Maybe<Array<Maybe<Challenge>>>
-  users?: Maybe<Array<Maybe<User>>>
-  currentUser?: Maybe<User>
-  chatUrl?: Maybe<Scalars['String']>
-}
+  __typename?: 'Lesson';
+  id?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  docUrl?: Maybe<Scalars['String']>;
+  githubUrl?: Maybe<Scalars['String']>;
+  videoUrl?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  title?: Maybe<Scalars['String']>;
+  challenges?: Maybe<Array<Maybe<Challenge>>>;
+  users?: Maybe<Array<Maybe<User>>>;
+  currentUser?: Maybe<User>;
+  chatUrl?: Maybe<Scalars['String']>;
+};
 
 export type Mutation = {
-  __typename?: 'Mutation'
-  login?: Maybe<AuthResponse>
-  logout?: Maybe<AuthResponse>
-  reqPwReset?: Maybe<TokenResponse>
-  changePw?: Maybe<AuthResponse>
-  changeAdminRights?: Maybe<SuccessResponse>
-  signup?: Maybe<AuthResponse>
-  addAlert?: Maybe<SuccessResponse>
-  removeAlert?: Maybe<SuccessResponse>
-  createSubmission?: Maybe<Submission>
-  acceptSubmission?: Maybe<Submission>
-  rejectSubmission?: Maybe<Submission>
-  createLesson?: Maybe<SuccessResponse>
-  updateLesson?: Maybe<SuccessResponse>
-  createChallenge?: Maybe<SuccessResponse>
-  updateChallenge?: Maybe<SuccessResponse>
-}
+  __typename?: 'Mutation';
+  login?: Maybe<AuthResponse>;
+  logout?: Maybe<AuthResponse>;
+  reqPwReset?: Maybe<TokenResponse>;
+  changePw?: Maybe<AuthResponse>;
+  changeAdminRights?: Maybe<SuccessResponse>;
+  signup?: Maybe<AuthResponse>;
+  addAlert?: Maybe<SuccessResponse>;
+  removeAlert?: Maybe<SuccessResponse>;
+  createSubmission?: Maybe<Submission>;
+  acceptSubmission?: Maybe<Submission>;
+  rejectSubmission?: Maybe<Submission>;
+  createLesson?: Maybe<SuccessResponse>;
+  updateLesson?: Maybe<SuccessResponse>;
+  createChallenge?: Maybe<Array<Maybe<Lesson>>>;
+  updateChallenge?: Maybe<Array<Maybe<Lesson>>>;
+};
+
 
 export type MutationLoginArgs = {
-  username: Scalars['String']
-  password: Scalars['String']
-}
+  username: Scalars['String'];
+  password: Scalars['String'];
+};
+
 
 export type MutationReqPwResetArgs = {
-  userOrEmail: Scalars['String']
-}
+  userOrEmail: Scalars['String'];
+};
+
 
 export type MutationChangePwArgs = {
-  token: Scalars['String']
-  password: Scalars['String']
-}
+  token: Scalars['String'];
+  password: Scalars['String'];
+};
+
 
 export type MutationChangeAdminRightsArgs = {
-  id: Scalars['Int']
-  status: Scalars['String']
-}
+  id: Scalars['Int'];
+  status: Scalars['String'];
+};
+
 
 export type MutationSignupArgs = {
-  firstName: Scalars['String']
-  lastName: Scalars['String']
-  email: Scalars['String']
-  username: Scalars['String']
-  password?: Maybe<Scalars['String']>
-}
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  email: Scalars['String'];
+  username: Scalars['String'];
+  password?: Maybe<Scalars['String']>;
+};
+
 
 export type MutationAddAlertArgs = {
-  text: Scalars['String']
-  type: Scalars['String']
-  url?: Maybe<Scalars['String']>
-  urlCaption?: Maybe<Scalars['String']>
-}
+  text: Scalars['String'];
+  type: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
+  urlCaption?: Maybe<Scalars['String']>;
+};
+
 
 export type MutationRemoveAlertArgs = {
-  id: Scalars['String']
-}
+  id: Scalars['String'];
+};
+
 
 export type MutationCreateSubmissionArgs = {
-  lessonId: Scalars['String']
-  challengeId: Scalars['String']
-  cliToken: Scalars['String']
-  diff: Scalars['String']
-}
+  lessonId: Scalars['String'];
+  challengeId: Scalars['String'];
+  cliToken: Scalars['String'];
+  diff: Scalars['String'];
+};
+
 
 export type MutationAcceptSubmissionArgs = {
-  id: Scalars['String']
-  comment: Scalars['String']
-}
+  id: Scalars['String'];
+  comment: Scalars['String'];
+};
+
 
 export type MutationRejectSubmissionArgs = {
-  id: Scalars['String']
-  comment: Scalars['String']
-}
+  id: Scalars['String'];
+  comment: Scalars['String'];
+};
+
 
 export type MutationCreateLessonArgs = {
-  description: Scalars['String']
-  docUrl?: Maybe<Scalars['String']>
-  githubUrl?: Maybe<Scalars['String']>
-  videoUrl?: Maybe<Scalars['String']>
-  title: Scalars['String']
-  chatUrl?: Maybe<Scalars['String']>
-  order: Scalars['Int']
-}
+  description: Scalars['String'];
+  docUrl?: Maybe<Scalars['String']>;
+  githubUrl?: Maybe<Scalars['String']>;
+  videoUrl?: Maybe<Scalars['String']>;
+  title: Scalars['String'];
+  chatUrl?: Maybe<Scalars['String']>;
+  order: Scalars['Int'];
+};
+
 
 export type MutationUpdateLessonArgs = {
-  id: Scalars['Int']
-  description?: Maybe<Scalars['String']>
-  docUrl?: Maybe<Scalars['String']>
-  githubUrl?: Maybe<Scalars['String']>
-  videoUrl?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
-  chatUrl?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
-}
+  id: Scalars['Int'];
+  description?: Maybe<Scalars['String']>;
+  docUrl?: Maybe<Scalars['String']>;
+  githubUrl?: Maybe<Scalars['String']>;
+  videoUrl?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  chatUrl?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+};
+
 
 export type MutationCreateChallengeArgs = {
-  lessonId: Scalars['Int']
-  order: Scalars['Int']
-  description?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
-}
+  lessonId: Scalars['Int'];
+  order: Scalars['Int'];
+  description: Scalars['String'];
+  title: Scalars['String'];
+};
+
 
 export type MutationUpdateChallengeArgs = {
-  lessonId: Scalars['Int']
-  id: Scalars['Int']
-  order: Scalars['Int']
-  description?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
-}
+  lessonId: Scalars['Int'];
+  id: Scalars['Int'];
+  order?: Maybe<Scalars['Int']>;
+  description?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
 
 export type Query = {
-  __typename?: 'Query'
-  lessons: Array<Lesson>
-  session?: Maybe<Session>
-  allUsers?: Maybe<Array<Maybe<User>>>
-  userInfo?: Maybe<Session>
-  isTokenValid: Scalars['Boolean']
-  submissions?: Maybe<Array<Maybe<Submission>>>
-  alerts: Array<Alert>
-}
+  __typename?: 'Query';
+  lessons: Array<Lesson>;
+  session?: Maybe<Session>;
+  allUsers?: Maybe<Array<Maybe<User>>>;
+  userInfo?: Maybe<Session>;
+  isTokenValid: Scalars['Boolean'];
+  submissions?: Maybe<Array<Maybe<Submission>>>;
+  alerts: Array<Alert>;
+};
+
 
 export type QueryUserInfoArgs = {
-  username: Scalars['String']
-}
+  username: Scalars['String'];
+};
+
 
 export type QueryIsTokenValidArgs = {
-  cliToken: Scalars['String']
-}
+  cliToken: Scalars['String'];
+};
+
 
 export type QuerySubmissionsArgs = {
-  lessonId: Scalars['String']
-}
+  lessonId: Scalars['String'];
+};
 
 export type Session = {
-  __typename?: 'Session'
-  user?: Maybe<User>
-  submissions?: Maybe<Array<Maybe<Submission>>>
-  lessonStatus: Array<UserLesson>
-}
+  __typename?: 'Session';
+  user?: Maybe<User>;
+  submissions?: Maybe<Array<Maybe<Submission>>>;
+  lessonStatus: Array<UserLesson>;
+};
 
 export type Submission = {
-  __typename?: 'Submission'
-  id?: Maybe<Scalars['String']>
-  status?: Maybe<Scalars['String']>
-  mrUrl?: Maybe<Scalars['String']>
-  diff?: Maybe<Scalars['String']>
-  viewCount?: Maybe<Scalars['Int']>
-  comment?: Maybe<Scalars['String']>
-  userId?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
-  lessonId?: Maybe<Scalars['String']>
-  challengeId?: Maybe<Scalars['String']>
-  challenge?: Maybe<Challenge>
-  reviewer?: Maybe<User>
-  user?: Maybe<User>
-  reviewerId?: Maybe<Scalars['String']>
-  createdAt?: Maybe<Scalars['String']>
-  updatedAt?: Maybe<Scalars['String']>
-}
+  __typename?: 'Submission';
+  id?: Maybe<Scalars['String']>;
+  status?: Maybe<Scalars['String']>;
+  mrUrl?: Maybe<Scalars['String']>;
+  diff?: Maybe<Scalars['String']>;
+  viewCount?: Maybe<Scalars['Int']>;
+  comment?: Maybe<Scalars['String']>;
+  userId?: Maybe<Scalars['String']>;
+  order?: Maybe<Scalars['Int']>;
+  lessonId?: Maybe<Scalars['String']>;
+  challengeId?: Maybe<Scalars['String']>;
+  challenge?: Maybe<Challenge>;
+  reviewer?: Maybe<User>;
+  user?: Maybe<User>;
+  reviewerId?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['String']>;
+};
 
 export type SuccessResponse = {
-  __typename?: 'SuccessResponse'
-  success?: Maybe<Scalars['Boolean']>
-}
+  __typename?: 'SuccessResponse';
+  success?: Maybe<Scalars['Boolean']>;
+};
 
 export type TokenResponse = {
-  __typename?: 'TokenResponse'
-  success?: Maybe<Scalars['Boolean']>
-  token?: Maybe<Scalars['String']>
-}
+  __typename?: 'TokenResponse';
+  success?: Maybe<Scalars['Boolean']>;
+  token?: Maybe<Scalars['String']>;
+};
+
 
 export type User = {
-  __typename?: 'User'
-  id?: Maybe<Scalars['String']>
-  username?: Maybe<Scalars['String']>
-  userLesson?: Maybe<UserLesson>
-  email?: Maybe<Scalars['String']>
-  name?: Maybe<Scalars['String']>
-  isAdmin?: Maybe<Scalars['String']>
-  cliToken?: Maybe<Scalars['String']>
-}
+  __typename?: 'User';
+  id?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+  userLesson?: Maybe<UserLesson>;
+  email?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  isAdmin?: Maybe<Scalars['String']>;
+  cliToken?: Maybe<Scalars['String']>;
+};
 
 export type UserLesson = {
-  __typename?: 'UserLesson'
-  id?: Maybe<Scalars['String']>
-  userId?: Maybe<Scalars['String']>
-  lessonId?: Maybe<Scalars['String']>
-  isPassed?: Maybe<Scalars['String']>
-  isTeaching?: Maybe<Scalars['String']>
-  isEnrolled?: Maybe<Scalars['String']>
-  starGiven?: Maybe<User>
-  starComment?: Maybe<Scalars['String']>
-}
+  __typename?: 'UserLesson';
+  id?: Maybe<Scalars['String']>;
+  userId?: Maybe<Scalars['String']>;
+  lessonId?: Maybe<Scalars['String']>;
+  isPassed?: Maybe<Scalars['String']>;
+  isTeaching?: Maybe<Scalars['String']>;
+  isEnrolled?: Maybe<Scalars['String']>;
+  starGiven?: Maybe<User>;
+  starComment?: Maybe<Scalars['String']>;
+};
 
 export type AcceptSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String']
-  comment: Scalars['String']
-}>
+  submissionId: Scalars['String'];
+  comment: Scalars['String'];
+}>;
 
-export type AcceptSubmissionMutation = { __typename?: 'Mutation' } & {
-  acceptSubmission?: Maybe<
-    { __typename?: 'Submission' } & Pick<
-      Submission,
-      'id' | 'comment' | 'status'
-    >
-  >
-}
+
+export type AcceptSubmissionMutation = (
+  { __typename?: 'Mutation' }
+  & { acceptSubmission?: Maybe<(
+    { __typename?: 'Submission' }
+    & Pick<Submission, 'id' | 'comment' | 'status'>
+  )> }
+);
 
 export type AddAlertMutationVariables = Exact<{
-  text: Scalars['String']
-  type: Scalars['String']
-}>
+  text: Scalars['String'];
+  type: Scalars['String'];
+}>;
 
-export type AddAlertMutation = { __typename?: 'Mutation' } & {
-  addAlert?: Maybe<
-    { __typename?: 'SuccessResponse' } & Pick<SuccessResponse, 'success'>
-  >
-}
 
-export type GetAppQueryVariables = Exact<{ [key: string]: never }>
+export type AddAlertMutation = (
+  { __typename?: 'Mutation' }
+  & { addAlert?: Maybe<(
+    { __typename?: 'SuccessResponse' }
+    & Pick<SuccessResponse, 'success'>
+  )> }
+);
 
-export type GetAppQuery = { __typename?: 'Query' } & {
-  lessons: Array<
-    { __typename?: 'Lesson' } & Pick<
-      Lesson,
-      | 'id'
-      | 'title'
-      | 'description'
-      | 'docUrl'
-      | 'githubUrl'
-      | 'videoUrl'
-      | 'order'
-      | 'chatUrl'
-    > & {
-        challenges?: Maybe<
-          Array<
-            Maybe<
-              { __typename?: 'Challenge' } & Pick<
-                Challenge,
-                'id' | 'title' | 'description' | 'order'
-              >
-            >
-          >
-        >
-      }
-  >
-  session?: Maybe<
-    { __typename?: 'Session' } & {
-      user?: Maybe<
-        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
-      >
-      submissions?: Maybe<
-        Array<
-          Maybe<
-            { __typename?: 'Submission' } & Pick<
-              Submission,
-              | 'id'
-              | 'status'
-              | 'mrUrl'
-              | 'diff'
-              | 'viewCount'
-              | 'comment'
-              | 'order'
-              | 'challengeId'
-              | 'lessonId'
-              | 'createdAt'
-              | 'updatedAt'
-            > & {
-                reviewer?: Maybe<
-                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
-                >
-              }
-          >
-        >
-      >
-      lessonStatus: Array<
-        { __typename?: 'UserLesson' } & Pick<
-          UserLesson,
-          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
-        >
-      >
-    }
-  >
-  alerts: Array<
-    { __typename?: 'Alert' } & Pick<
-      Alert,
-      'id' | 'text' | 'type' | 'url' | 'urlCaption'
-    >
-  >
-}
+export type CreateChallengeMutationVariables = Exact<{
+  lessonId: Scalars['Int'];
+  order: Scalars['Int'];
+  description: Scalars['String'];
+  title: Scalars['String'];
+}>;
+
+
+export type CreateChallengeMutation = (
+  { __typename?: 'Mutation' }
+  & { createChallenge?: Maybe<Array<Maybe<(
+    { __typename?: 'Lesson' }
+    & Pick<Lesson, 'id' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'chatUrl' | 'order' | 'description' | 'title'>
+    & { challenges?: Maybe<Array<Maybe<(
+      { __typename?: 'Challenge' }
+      & Pick<Challenge, 'id' | 'description' | 'lessonId' | 'title' | 'order'>
+    )>>> }
+  )>>> }
+);
+
+export type GetAppQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAppQuery = (
+  { __typename?: 'Query' }
+  & { lessons: Array<(
+    { __typename?: 'Lesson' }
+    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
+    & { challenges?: Maybe<Array<Maybe<(
+      { __typename?: 'Challenge' }
+      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
+    )>>> }
+  )>, session?: Maybe<(
+    { __typename?: 'Session' }
+    & { user?: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'username' | 'name'>
+    )>, submissions?: Maybe<Array<Maybe<(
+      { __typename?: 'Submission' }
+      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
+      & { reviewer?: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'id' | 'username'>
+      )> }
+    )>>>, lessonStatus: Array<(
+      { __typename?: 'UserLesson' }
+      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
+    )> }
+  )>, alerts: Array<(
+    { __typename?: 'Alert' }
+    & Pick<Alert, 'id' | 'text' | 'type' | 'url' | 'urlCaption'>
+  )> }
+);
 
 export type SubmissionsQueryVariables = Exact<{
-  lessonId: Scalars['String']
-}>
+  lessonId: Scalars['String'];
+}>;
 
-export type SubmissionsQuery = { __typename?: 'Query' } & {
-  submissions?: Maybe<
-    Array<
-      Maybe<
-        { __typename?: 'Submission' } & Pick<
-          Submission,
-          | 'id'
-          | 'status'
-          | 'diff'
-          | 'comment'
-          | 'challengeId'
-          | 'createdAt'
-          | 'updatedAt'
-        > & {
-            challenge?: Maybe<
-              { __typename?: 'Challenge' } & Pick<Challenge, 'title'>
-            >
-            user?: Maybe<
-              { __typename?: 'User' } & Pick<User, 'id' | 'username'>
-            >
-          }
-      >
-    >
-  >
-}
+
+export type SubmissionsQuery = (
+  { __typename?: 'Query' }
+  & { submissions?: Maybe<Array<Maybe<(
+    { __typename?: 'Submission' }
+    & Pick<Submission, 'id' | 'status' | 'diff' | 'comment' | 'challengeId' | 'createdAt' | 'updatedAt'>
+    & { challenge?: Maybe<(
+      { __typename?: 'Challenge' }
+      & Pick<Challenge, 'title'>
+    )>, user?: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'username'>
+    )> }
+  )>>> }
+);
 
 export type LoginMutationVariables = Exact<{
-  username: Scalars['String']
-  password: Scalars['String']
-}>
+  username: Scalars['String'];
+  password: Scalars['String'];
+}>;
 
-export type LoginMutation = { __typename?: 'Mutation' } & {
-  login?: Maybe<
-    { __typename?: 'AuthResponse' } & Pick<
-      AuthResponse,
-      'success' | 'username' | 'cliToken' | 'error'
-    >
-  >
-}
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never }>
+export type LoginMutation = (
+  { __typename?: 'Mutation' }
+  & { login?: Maybe<(
+    { __typename?: 'AuthResponse' }
+    & Pick<AuthResponse, 'success' | 'username' | 'cliToken' | 'error'>
+  )> }
+);
 
-export type LogoutMutation = { __typename?: 'Mutation' } & {
-  logout?: Maybe<
-    { __typename?: 'AuthResponse' } & Pick<
-      AuthResponse,
-      'success' | 'username' | 'error'
-    >
-  >
-}
+export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LogoutMutation = (
+  { __typename?: 'Mutation' }
+  & { logout?: Maybe<(
+    { __typename?: 'AuthResponse' }
+    & Pick<AuthResponse, 'success' | 'username' | 'error'>
+  )> }
+);
 
 export type RejectSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String']
-  comment: Scalars['String']
-}>
+  submissionId: Scalars['String'];
+  comment: Scalars['String'];
+}>;
 
-export type RejectSubmissionMutation = { __typename?: 'Mutation' } & {
-  rejectSubmission?: Maybe<
-    { __typename?: 'Submission' } & Pick<
-      Submission,
-      'id' | 'comment' | 'status'
-    >
-  >
-}
+
+export type RejectSubmissionMutation = (
+  { __typename?: 'Mutation' }
+  & { rejectSubmission?: Maybe<(
+    { __typename?: 'Submission' }
+    & Pick<Submission, 'id' | 'comment' | 'status'>
+  )> }
+);
 
 export type ReqPwResetMutationVariables = Exact<{
-  userOrEmail: Scalars['String']
-}>
+  userOrEmail: Scalars['String'];
+}>;
 
-export type ReqPwResetMutation = { __typename?: 'Mutation' } & {
-  reqPwReset?: Maybe<
-    { __typename?: 'TokenResponse' } & Pick<TokenResponse, 'success' | 'token'>
-  >
-}
+
+export type ReqPwResetMutation = (
+  { __typename?: 'Mutation' }
+  & { reqPwReset?: Maybe<(
+    { __typename?: 'TokenResponse' }
+    & Pick<TokenResponse, 'success' | 'token'>
+  )> }
+);
 
 export type SignupMutationVariables = Exact<{
-  firstName: Scalars['String']
-  lastName: Scalars['String']
-  email: Scalars['String']
-  username: Scalars['String']
-}>
+  firstName: Scalars['String'];
+  lastName: Scalars['String'];
+  email: Scalars['String'];
+  username: Scalars['String'];
+}>;
 
-export type SignupMutation = { __typename?: 'Mutation' } & {
-  signup?: Maybe<
-    { __typename?: 'AuthResponse' } & Pick<
-      AuthResponse,
-      'success' | 'username' | 'error'
-    >
-  >
-}
+
+export type SignupMutation = (
+  { __typename?: 'Mutation' }
+  & { signup?: Maybe<(
+    { __typename?: 'AuthResponse' }
+    & Pick<AuthResponse, 'success' | 'username' | 'error'>
+  )> }
+);
+
+export type UpdateChallengeMutationVariables = Exact<{
+  lessonId: Scalars['Int'];
+  order?: Maybe<Scalars['Int']>;
+  description?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
+}>;
+
+
+export type UpdateChallengeMutation = (
+  { __typename?: 'Mutation' }
+  & { updateChallenge?: Maybe<Array<Maybe<(
+    { __typename?: 'Lesson' }
+    & Pick<Lesson, 'id' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'chatUrl' | 'order' | 'description' | 'title'>
+    & { challenges?: Maybe<Array<Maybe<(
+      { __typename?: 'Challenge' }
+      & Pick<Challenge, 'id' | 'description' | 'lessonId' | 'title' | 'order'>
+    )>>> }
+  )>>> }
+);
 
 export type ChangePwMutationVariables = Exact<{
-  token: Scalars['String']
-  password: Scalars['String']
-}>
+  token: Scalars['String'];
+  password: Scalars['String'];
+}>;
 
-export type ChangePwMutation = { __typename?: 'Mutation' } & {
-  changePw?: Maybe<
-    { __typename?: 'AuthResponse' } & Pick<AuthResponse, 'success'>
-  >
-}
+
+export type ChangePwMutation = (
+  { __typename?: 'Mutation' }
+  & { changePw?: Maybe<(
+    { __typename?: 'AuthResponse' }
+    & Pick<AuthResponse, 'success'>
+  )> }
+);
 
 export type UserInfoQueryVariables = Exact<{
-  username: Scalars['String']
-}>
+  username: Scalars['String'];
+}>;
 
-export type UserInfoQuery = { __typename?: 'Query' } & {
-  lessons: Array<
-    { __typename?: 'Lesson' } & Pick<
-      Lesson,
-      | 'id'
-      | 'title'
-      | 'description'
-      | 'docUrl'
-      | 'githubUrl'
-      | 'videoUrl'
-      | 'order'
-      | 'chatUrl'
-    > & {
-        challenges?: Maybe<
-          Array<
-            Maybe<
-              { __typename?: 'Challenge' } & Pick<
-                Challenge,
-                'id' | 'title' | 'description' | 'order'
-              >
-            >
-          >
-        >
-      }
-  >
-  userInfo?: Maybe<
-    { __typename?: 'Session' } & {
-      user?: Maybe<
-        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
-      >
-      submissions?: Maybe<
-        Array<
-          Maybe<
-            { __typename?: 'Submission' } & Pick<
-              Submission,
-              | 'id'
-              | 'status'
-              | 'mrUrl'
-              | 'diff'
-              | 'viewCount'
-              | 'comment'
-              | 'order'
-              | 'challengeId'
-              | 'lessonId'
-              | 'createdAt'
-              | 'updatedAt'
-            > & {
-                reviewer?: Maybe<
-                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
-                >
-              }
-          >
-        >
-      >
-      lessonStatus: Array<
-        { __typename?: 'UserLesson' } & Pick<
-          UserLesson,
-          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
-        >
-      >
-    }
-  >
-}
 
-export type ResolverTypeWrapper<T> = Promise<T> | T
+export type UserInfoQuery = (
+  { __typename?: 'Query' }
+  & { lessons: Array<(
+    { __typename?: 'Lesson' }
+    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
+    & { challenges?: Maybe<Array<Maybe<(
+      { __typename?: 'Challenge' }
+      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
+    )>>> }
+  )>, userInfo?: Maybe<(
+    { __typename?: 'Session' }
+    & { user?: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'username' | 'name'>
+    )>, submissions?: Maybe<Array<Maybe<(
+      { __typename?: 'Submission' }
+      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
+      & { reviewer?: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'id' | 'username'>
+      )> }
+    )>>>, lessonStatus: Array<(
+      { __typename?: 'UserLesson' }
+      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
+    )> }
+  )> }
+);
+
+
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  fragment: string
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
-}
+  fragment: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
 
 export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  selectionSet: string
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
-}
-export type StitchingResolver<TResult, TParent, TContext, TArgs> =
-  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
-  | NewStitchingResolver<TResult, TParent, TContext, TArgs>
+  selectionSet: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
-  | StitchingResolver<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => Promise<TResult> | TResult
+) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>
+) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> {
-  subscribe: SubscriptionSubscribeFn<
-    { [key in TKey]: TResult },
-    TParent,
-    TContext,
-    TArgs
-  >
-  resolve?: SubscriptionResolveFn<
-    TResult,
-    { [key in TKey]: TResult },
-    TContext,
-    TArgs
-  >
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>
-  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs
-> =
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
-  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<
-  TResult,
-  TKey extends string,
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> =
-  | ((
-      ...args: any[]
-    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
-  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
   info: GraphQLResolveInfo
-) => Maybe<TTypes> | Promise<Maybe<TTypes>>
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}> = (
-  obj: T,
-  info: GraphQLResolveInfo
-) => boolean | Promise<boolean>
+export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
-export type NextResolverFn<T> = () => Promise<T>
+export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<
-  TResult = {},
-  TParent = {},
-  TContext = {},
-  TArgs = {}
-> = (
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>
+) => TResult | Promise<TResult>;
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Query: ResolverTypeWrapper<{}>
-  Lesson: ResolverTypeWrapper<Lesson>
-  String: ResolverTypeWrapper<Scalars['String']>
-  Int: ResolverTypeWrapper<Scalars['Int']>
-  Challenge: ResolverTypeWrapper<Challenge>
-  User: ResolverTypeWrapper<User>
-  UserLesson: ResolverTypeWrapper<UserLesson>
-  Session: ResolverTypeWrapper<Session>
-  Submission: ResolverTypeWrapper<Submission>
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>
-  Alert: ResolverTypeWrapper<Alert>
-  Mutation: ResolverTypeWrapper<{}>
-  AuthResponse: ResolverTypeWrapper<AuthResponse>
-  TokenResponse: ResolverTypeWrapper<TokenResponse>
-  SuccessResponse: ResolverTypeWrapper<SuccessResponse>
-  CacheControlScope: CacheControlScope
-  Upload: ResolverTypeWrapper<Scalars['Upload']>
-}
+  Query: ResolverTypeWrapper<{}>;
+  Lesson: ResolverTypeWrapper<Lesson>;
+  String: ResolverTypeWrapper<Scalars['String']>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
+  Challenge: ResolverTypeWrapper<Challenge>;
+  User: ResolverTypeWrapper<User>;
+  UserLesson: ResolverTypeWrapper<UserLesson>;
+  Session: ResolverTypeWrapper<Session>;
+  Submission: ResolverTypeWrapper<Submission>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  Alert: ResolverTypeWrapper<Alert>;
+  Mutation: ResolverTypeWrapper<{}>;
+  AuthResponse: ResolverTypeWrapper<AuthResponse>;
+  TokenResponse: ResolverTypeWrapper<TokenResponse>;
+  SuccessResponse: ResolverTypeWrapper<SuccessResponse>;
+  CacheControlScope: CacheControlScope;
+  Upload: ResolverTypeWrapper<Scalars['Upload']>;
+};
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Query: {}
-  Lesson: Lesson
-  String: Scalars['String']
-  Int: Scalars['Int']
-  Challenge: Challenge
-  User: User
-  UserLesson: UserLesson
-  Session: Session
-  Submission: Submission
-  Boolean: Scalars['Boolean']
-  Alert: Alert
-  Mutation: {}
-  AuthResponse: AuthResponse
-  TokenResponse: TokenResponse
-  SuccessResponse: SuccessResponse
-  Upload: Scalars['Upload']
+  Query: {};
+  Lesson: Lesson;
+  String: Scalars['String'];
+  Int: Scalars['Int'];
+  Challenge: Challenge;
+  User: User;
+  UserLesson: UserLesson;
+  Session: Session;
+  Submission: Submission;
+  Boolean: Scalars['Boolean'];
+  Alert: Alert;
+  Mutation: {};
+  AuthResponse: AuthResponse;
+  TokenResponse: TokenResponse;
+  SuccessResponse: SuccessResponse;
+  Upload: Scalars['Upload'];
+};
+
+export type AlertResolvers<ContextType = any, ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']> = {
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  urlCaption?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type AuthResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type ChallengeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type LessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  challenges?: Resolver<Maybe<Array<Maybe<ResolversTypes['Challenge']>>>, ParentType, ContextType>;
+  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
+  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  login?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationLoginArgs, 'username' | 'password'>>;
+  logout?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType>;
+  reqPwReset?: Resolver<Maybe<ResolversTypes['TokenResponse']>, ParentType, ContextType, RequireFields<MutationReqPwResetArgs, 'userOrEmail'>>;
+  changePw?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationChangePwArgs, 'token' | 'password'>>;
+  changeAdminRights?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationChangeAdminRightsArgs, 'id' | 'status'>>;
+  signup?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationSignupArgs, 'firstName' | 'lastName' | 'email' | 'username'>>;
+  addAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationAddAlertArgs, 'text' | 'type'>>;
+  removeAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationRemoveAlertArgs, 'id'>>;
+  createSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationCreateSubmissionArgs, 'lessonId' | 'challengeId' | 'cliToken' | 'diff'>>;
+  acceptSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>>;
+  rejectSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>>;
+  createLesson?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>>;
+  updateLesson?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationUpdateLessonArgs, 'id'>>;
+  createChallenge?: Resolver<Maybe<Array<Maybe<ResolversTypes['Lesson']>>>, ParentType, ContextType, RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'order' | 'description' | 'title'>>;
+  updateChallenge?: Resolver<Maybe<Array<Maybe<ResolversTypes['Lesson']>>>, ParentType, ContextType, RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id'>>;
+};
+
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>;
+  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>;
+  allUsers?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
+  userInfo?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType, RequireFields<QueryUserInfoArgs, 'username'>>;
+  isTokenValid?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<QueryIsTokenValidArgs, 'cliToken'>>;
+  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType, RequireFields<QuerySubmissionsArgs, 'lessonId'>>;
+  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>;
+};
+
+export type SessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']> = {
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType>;
+  lessonStatus?: Resolver<Array<ResolversTypes['UserLesson']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  challengeId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  challenge?: Resolver<Maybe<ResolversTypes['Challenge']>, ParentType, ContextType>;
+  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  reviewerId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type SuccessResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export type TokenResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
+
+export interface UploadScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
+  name: 'Upload';
 }
 
-export type AlertResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']
-> = {
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
-  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  urlCaption?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
+export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  userLesson?: Resolver<Maybe<ResolversTypes['UserLesson']>, ParentType, ContextType>;
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
 
-export type AuthResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']
-> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type ChallengeResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  description?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type LessonResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  description?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  challenges?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Challenge']>>>,
-    ParentType,
-    ContextType
-  >
-  users?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['User']>>>,
-    ParentType,
-    ContextType
-  >
-  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type MutationResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
-> = {
-  login?: Resolver<
-    Maybe<ResolversTypes['AuthResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationLoginArgs, 'username' | 'password'>
-  >
-  logout?: Resolver<
-    Maybe<ResolversTypes['AuthResponse']>,
-    ParentType,
-    ContextType
-  >
-  reqPwReset?: Resolver<
-    Maybe<ResolversTypes['TokenResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationReqPwResetArgs, 'userOrEmail'>
-  >
-  changePw?: Resolver<
-    Maybe<ResolversTypes['AuthResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationChangePwArgs, 'token' | 'password'>
-  >
-  changeAdminRights?: Resolver<
-    Maybe<ResolversTypes['SuccessResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationChangeAdminRightsArgs, 'id' | 'status'>
-  >
-  signup?: Resolver<
-    Maybe<ResolversTypes['AuthResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<
-      MutationSignupArgs,
-      'firstName' | 'lastName' | 'email' | 'username'
-    >
-  >
-  addAlert?: Resolver<
-    Maybe<ResolversTypes['SuccessResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationAddAlertArgs, 'text' | 'type'>
-  >
-  removeAlert?: Resolver<
-    Maybe<ResolversTypes['SuccessResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationRemoveAlertArgs, 'id'>
-  >
-  createSubmission?: Resolver<
-    Maybe<ResolversTypes['Submission']>,
-    ParentType,
-    ContextType,
-    RequireFields<
-      MutationCreateSubmissionArgs,
-      'lessonId' | 'challengeId' | 'cliToken' | 'diff'
-    >
-  >
-  acceptSubmission?: Resolver<
-    Maybe<ResolversTypes['Submission']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>
-  >
-  rejectSubmission?: Resolver<
-    Maybe<ResolversTypes['Submission']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>
-  >
-  createLesson?: Resolver<
-    Maybe<ResolversTypes['SuccessResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>
-  >
-  updateLesson?: Resolver<
-    Maybe<ResolversTypes['SuccessResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationUpdateLessonArgs, 'id'>
-  >
-  createChallenge?: Resolver<
-    Maybe<ResolversTypes['SuccessResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'order'>
-  >
-  updateChallenge?: Resolver<
-    Maybe<ResolversTypes['SuccessResponse']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id' | 'order'>
-  >
-}
-
-export type QueryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
-> = {
-  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>
-  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>
-  allUsers?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['User']>>>,
-    ParentType,
-    ContextType
-  >
-  userInfo?: Resolver<
-    Maybe<ResolversTypes['Session']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryUserInfoArgs, 'username'>
-  >
-  isTokenValid?: Resolver<
-    ResolversTypes['Boolean'],
-    ParentType,
-    ContextType,
-    RequireFields<QueryIsTokenValidArgs, 'cliToken'>
-  >
-  submissions?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
-    ParentType,
-    ContextType,
-    RequireFields<QuerySubmissionsArgs, 'lessonId'>
-  >
-  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>
-}
-
-export type SessionResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']
-> = {
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  submissions?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
-    ParentType,
-    ContextType
-  >
-  lessonStatus?: Resolver<
-    Array<ResolversTypes['UserLesson']>,
-    ParentType,
-    ContextType
-  >
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type SubmissionResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  challengeId?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  challenge?: Resolver<
-    Maybe<ResolversTypes['Challenge']>,
-    ParentType,
-    ContextType
-  >
-  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  reviewerId?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type SuccessResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']
-> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type TokenResponseResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']
-> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
-  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export interface UploadScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
-  name: 'Upload'
-}
-
-export type UserResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  userLesson?: Resolver<
-    Maybe<ResolversTypes['UserLesson']>,
-    ParentType,
-    ContextType
-  >
-  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
-
-export type UserLessonResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']
-> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  isTeaching?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  isEnrolled?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  starGiven?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  starComment?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
-}
+export type UserLessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isTeaching?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isEnrolled?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  starGiven?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  starComment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
+};
 
 export type Resolvers<ContextType = any> = {
-  Alert?: AlertResolvers<ContextType>
-  AuthResponse?: AuthResponseResolvers<ContextType>
-  Challenge?: ChallengeResolvers<ContextType>
-  Lesson?: LessonResolvers<ContextType>
-  Mutation?: MutationResolvers<ContextType>
-  Query?: QueryResolvers<ContextType>
-  Session?: SessionResolvers<ContextType>
-  Submission?: SubmissionResolvers<ContextType>
-  SuccessResponse?: SuccessResponseResolvers<ContextType>
-  TokenResponse?: TokenResponseResolvers<ContextType>
-  Upload?: GraphQLScalarType
-  User?: UserResolvers<ContextType>
-  UserLesson?: UserLessonResolvers<ContextType>
-}
+  Alert?: AlertResolvers<ContextType>;
+  AuthResponse?: AuthResponseResolvers<ContextType>;
+  Challenge?: ChallengeResolvers<ContextType>;
+  Lesson?: LessonResolvers<ContextType>;
+  Mutation?: MutationResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+  Session?: SessionResolvers<ContextType>;
+  Submission?: SubmissionResolvers<ContextType>;
+  SuccessResponse?: SuccessResponseResolvers<ContextType>;
+  TokenResponse?: TokenResponseResolvers<ContextType>;
+  Upload?: GraphQLScalarType;
+  User?: UserResolvers<ContextType>;
+  UserLesson?: UserLessonResolvers<ContextType>;
+};
+
 
 /**
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
  */
-export type IResolvers<ContextType = any> = Resolvers<ContextType>
+export type IResolvers<ContextType = any> = Resolvers<ContextType>;
+
 
 export const AcceptSubmissionDocument = gql`
-  mutation acceptSubmission($submissionId: String!, $comment: String!) {
-    acceptSubmission(id: $submissionId, comment: $comment) {
-      id
-      comment
-      status
-    }
+    mutation acceptSubmission($submissionId: String!, $comment: String!) {
+  acceptSubmission(id: $submissionId, comment: $comment) {
+    id
+    comment
+    status
   }
-`
-export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<
-  AcceptSubmissionMutation,
-  AcceptSubmissionMutationVariables
->
-export type AcceptSubmissionComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >,
-  'mutation'
->
-
-export const AcceptSubmissionComponent = (
-  props: AcceptSubmissionComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >
-    mutation={AcceptSubmissionDocument}
-    {...props}
-  />
-)
-
-export type AcceptSubmissionProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >
-} &
-  TChildProps
-export function withAcceptSubmission<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables,
-    AcceptSubmissionProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables,
-    AcceptSubmissionProps<TChildProps, TDataName>
-  >(AcceptSubmissionDocument, {
-    alias: 'acceptSubmission',
-    ...operationOptions
-  })
 }
+    `;
+export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
+export type AcceptSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>, 'mutation'>;
+
+    export const AcceptSubmissionComponent = (props: AcceptSubmissionComponentProps) => (
+      <ApolloReactComponents.Mutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables> mutation={AcceptSubmissionDocument} {...props} />
+    );
+    
+export type AcceptSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>
+    } & TChildProps;
+export function withAcceptSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  AcceptSubmissionMutation,
+  AcceptSubmissionMutationVariables,
+  AcceptSubmissionProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, AcceptSubmissionMutation, AcceptSubmissionMutationVariables, AcceptSubmissionProps<TChildProps, TDataName>>(AcceptSubmissionDocument, {
+      alias: 'acceptSubmission',
+      ...operationOptions
+    });
+};
 
 /**
  * __useAcceptSubmissionMutation__
@@ -1124,85 +839,39 @@ export function withAcceptSubmission<
  *   },
  * });
  */
-export function useAcceptSubmissionMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >(AcceptSubmissionDocument, baseOptions)
-}
-export type AcceptSubmissionMutationHookResult = ReturnType<
-  typeof useAcceptSubmissionMutation
->
-export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<
-  AcceptSubmissionMutation
->
-export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  AcceptSubmissionMutation,
-  AcceptSubmissionMutationVariables
->
+export function useAcceptSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>) {
+        return ApolloReactHooks.useMutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>(AcceptSubmissionDocument, baseOptions);
+      }
+export type AcceptSubmissionMutationHookResult = ReturnType<typeof useAcceptSubmissionMutation>;
+export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<AcceptSubmissionMutation>;
+export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
 export const AddAlertDocument = gql`
-  mutation addAlert($text: String!, $type: String!) {
-    addAlert(text: $text, type: $type) {
-      success
-    }
+    mutation addAlert($text: String!, $type: String!) {
+  addAlert(text: $text, type: $type) {
+    success
   }
-`
-export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<
-  AddAlertMutation,
-  AddAlertMutationVariables
->
-export type AddAlertComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >,
-  'mutation'
->
-
-export const AddAlertComponent = (props: AddAlertComponentProps) => (
-  <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables>
-    mutation={AddAlertDocument}
-    {...props}
-  />
-)
-
-export type AddAlertProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >
-} &
-  TChildProps
-export function withAddAlert<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    AddAlertMutation,
-    AddAlertMutationVariables,
-    AddAlertProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    AddAlertMutation,
-    AddAlertMutationVariables,
-    AddAlertProps<TChildProps, TDataName>
-  >(AddAlertDocument, {
-    alias: 'addAlert',
-    ...operationOptions
-  })
 }
+    `;
+export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>;
+export type AddAlertComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AddAlertMutation, AddAlertMutationVariables>, 'mutation'>;
+
+    export const AddAlertComponent = (props: AddAlertComponentProps) => (
+      <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables> mutation={AddAlertDocument} {...props} />
+    );
+    
+export type AddAlertProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>
+    } & TChildProps;
+export function withAddAlert<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  AddAlertMutation,
+  AddAlertMutationVariables,
+  AddAlertProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, AddAlertMutation, AddAlertMutationVariables, AddAlertProps<TChildProps, TDataName>>(AddAlertDocument, {
+      alias: 'addAlert',
+      ...operationOptions
+    });
+};
 
 /**
  * __useAddAlertMutation__
@@ -1222,126 +891,156 @@ export function withAddAlert<
  *   },
  * });
  */
-export function useAddAlertMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >(AddAlertDocument, baseOptions)
+export function useAddAlertMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AddAlertMutation, AddAlertMutationVariables>) {
+        return ApolloReactHooks.useMutation<AddAlertMutation, AddAlertMutationVariables>(AddAlertDocument, baseOptions);
+      }
+export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>;
+export type AddAlertMutationResult = ApolloReactCommon.MutationResult<AddAlertMutation>;
+export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<AddAlertMutation, AddAlertMutationVariables>;
+export const CreateChallengeDocument = gql`
+    mutation createChallenge($lessonId: Int!, $order: Int!, $description: String!, $title: String!) {
+  createChallenge(lessonId: $lessonId, order: $order, description: $description, title: $title) {
+    id
+    docUrl
+    githubUrl
+    videoUrl
+    chatUrl
+    order
+    description
+    title
+    challenges {
+      id
+      description
+      lessonId
+      title
+      order
+    }
+  }
 }
-export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>
-export type AddAlertMutationResult = ApolloReactCommon.MutationResult<
-  AddAlertMutation
->
-export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  AddAlertMutation,
-  AddAlertMutationVariables
->
+    `;
+export type CreateChallengeMutationFn = ApolloReactCommon.MutationFunction<CreateChallengeMutation, CreateChallengeMutationVariables>;
+export type CreateChallengeComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<CreateChallengeMutation, CreateChallengeMutationVariables>, 'mutation'>;
+
+    export const CreateChallengeComponent = (props: CreateChallengeComponentProps) => (
+      <ApolloReactComponents.Mutation<CreateChallengeMutation, CreateChallengeMutationVariables> mutation={CreateChallengeDocument} {...props} />
+    );
+    
+export type CreateChallengeProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<CreateChallengeMutation, CreateChallengeMutationVariables>
+    } & TChildProps;
+export function withCreateChallenge<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  CreateChallengeMutation,
+  CreateChallengeMutationVariables,
+  CreateChallengeProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, CreateChallengeMutation, CreateChallengeMutationVariables, CreateChallengeProps<TChildProps, TDataName>>(CreateChallengeDocument, {
+      alias: 'createChallenge',
+      ...operationOptions
+    });
+};
+
+/**
+ * __useCreateChallengeMutation__
+ *
+ * To run a mutation, you first call `useCreateChallengeMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateChallengeMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createChallengeMutation, { data, loading, error }] = useCreateChallengeMutation({
+ *   variables: {
+ *      lessonId: // value for 'lessonId'
+ *      order: // value for 'order'
+ *      description: // value for 'description'
+ *      title: // value for 'title'
+ *   },
+ * });
+ */
+export function useCreateChallengeMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateChallengeMutation, CreateChallengeMutationVariables>) {
+        return ApolloReactHooks.useMutation<CreateChallengeMutation, CreateChallengeMutationVariables>(CreateChallengeDocument, baseOptions);
+      }
+export type CreateChallengeMutationHookResult = ReturnType<typeof useCreateChallengeMutation>;
+export type CreateChallengeMutationResult = ApolloReactCommon.MutationResult<CreateChallengeMutation>;
+export type CreateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateChallengeMutation, CreateChallengeMutationVariables>;
 export const GetAppDocument = gql`
-  query getApp {
-    lessons {
+    query getApp {
+  lessons {
+    id
+    title
+    description
+    docUrl
+    githubUrl
+    videoUrl
+    order
+    challenges {
       id
       title
       description
-      docUrl
-      githubUrl
-      videoUrl
       order
-      challenges {
-        id
-        title
-        description
-        order
-      }
-      chatUrl
     }
-    session {
-      user {
+    chatUrl
+  }
+  session {
+    user {
+      id
+      username
+      name
+    }
+    submissions {
+      id
+      status
+      mrUrl
+      diff
+      viewCount
+      comment
+      order
+      challengeId
+      lessonId
+      reviewer {
         id
         username
-        name
       }
-      submissions {
-        id
-        status
-        mrUrl
-        diff
-        viewCount
-        comment
-        order
-        challengeId
-        lessonId
-        reviewer {
-          id
-          username
-        }
-        createdAt
-        updatedAt
-      }
-      lessonStatus {
-        lessonId
-        isPassed
-        isTeaching
-        isEnrolled
-      }
+      createdAt
+      updatedAt
     }
-    alerts {
-      id
-      text
-      type
-      url
-      urlCaption
+    lessonStatus {
+      lessonId
+      isPassed
+      isTeaching
+      isEnrolled
     }
   }
-`
-export type GetAppComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >,
-  'query'
->
-
-export const GetAppComponent = (props: GetAppComponentProps) => (
-  <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables>
-    query={GetAppDocument}
-    {...props}
-  />
-)
-
-export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
-  [key in TDataName]: ApolloReactHoc.DataValue<
-    GetAppQuery,
-    GetAppQueryVariables
-  >
-} &
-  TChildProps
-export function withGetApp<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'data'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    GetAppQuery,
-    GetAppQueryVariables,
-    GetAppProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withQuery<
-    TProps,
-    GetAppQuery,
-    GetAppQueryVariables,
-    GetAppProps<TChildProps, TDataName>
-  >(GetAppDocument, {
-    alias: 'getApp',
-    ...operationOptions
-  })
+  alerts {
+    id
+    text
+    type
+    url
+    urlCaption
+  }
 }
+    `;
+export type GetAppComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<GetAppQuery, GetAppQueryVariables>, 'query'>;
+
+    export const GetAppComponent = (props: GetAppComponentProps) => (
+      <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables> query={GetAppDocument} {...props} />
+    );
+    
+export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
+      [key in TDataName]: ApolloReactHoc.DataValue<GetAppQuery, GetAppQueryVariables>
+    } & TChildProps;
+export function withGetApp<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  GetAppQuery,
+  GetAppQueryVariables,
+  GetAppProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withQuery<TProps, GetAppQuery, GetAppQueryVariables, GetAppProps<TChildProps, TDataName>>(GetAppDocument, {
+      alias: 'getApp',
+      ...operationOptions
+    });
+};
 
 /**
  * __useGetAppQuery__
@@ -1358,102 +1057,54 @@ export function withGetApp<
  *   },
  * });
  */
-export function useGetAppQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(
-    GetAppDocument,
-    baseOptions
-  )
-}
-export function useGetAppLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(
-    GetAppDocument,
-    baseOptions
-  )
-}
-export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>
-export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>
-export type GetAppQueryResult = ApolloReactCommon.QueryResult<
-  GetAppQuery,
-  GetAppQueryVariables
->
+export function useGetAppQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
+        return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
+      }
+export function useGetAppLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
+        }
+export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>;
+export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>;
+export type GetAppQueryResult = ApolloReactCommon.QueryResult<GetAppQuery, GetAppQueryVariables>;
 export const SubmissionsDocument = gql`
-  query submissions($lessonId: String!) {
-    submissions(lessonId: $lessonId) {
-      id
-      status
-      diff
-      comment
-      challenge {
-        title
-      }
-      challengeId
-      user {
-        id
-        username
-      }
-      createdAt
-      updatedAt
+    query submissions($lessonId: String!) {
+  submissions(lessonId: $lessonId) {
+    id
+    status
+    diff
+    comment
+    challenge {
+      title
     }
+    challengeId
+    user {
+      id
+      username
+    }
+    createdAt
+    updatedAt
   }
-`
-export type SubmissionsComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >,
-  'query'
-> &
-  ({ variables: SubmissionsQueryVariables; skip?: boolean } | { skip: boolean })
-
-export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
-  <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables>
-    query={SubmissionsDocument}
-    {...props}
-  />
-)
-
-export type SubmissionsProps<
-  TChildProps = {},
-  TDataName extends string = 'data'
-> = {
-  [key in TDataName]: ApolloReactHoc.DataValue<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >
-} &
-  TChildProps
-export function withSubmissions<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'data'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    SubmissionsQuery,
-    SubmissionsQueryVariables,
-    SubmissionsProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withQuery<
-    TProps,
-    SubmissionsQuery,
-    SubmissionsQueryVariables,
-    SubmissionsProps<TChildProps, TDataName>
-  >(SubmissionsDocument, {
-    alias: 'submissions',
-    ...operationOptions
-  })
 }
+    `;
+export type SubmissionsComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<SubmissionsQuery, SubmissionsQueryVariables>, 'query'> & ({ variables: SubmissionsQueryVariables; skip?: boolean; } | { skip: boolean; });
+
+    export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
+      <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables> query={SubmissionsDocument} {...props} />
+    );
+    
+export type SubmissionsProps<TChildProps = {}, TDataName extends string = 'data'> = {
+      [key in TDataName]: ApolloReactHoc.DataValue<SubmissionsQuery, SubmissionsQueryVariables>
+    } & TChildProps;
+export function withSubmissions<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  SubmissionsQuery,
+  SubmissionsQueryVariables,
+  SubmissionsProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withQuery<TProps, SubmissionsQuery, SubmissionsQueryVariables, SubmissionsProps<TChildProps, TDataName>>(SubmissionsDocument, {
+      alias: 'submissions',
+      ...operationOptions
+    });
+};
 
 /**
  * __useSubmissionsQuery__
@@ -1471,97 +1122,45 @@ export function withSubmissions<
  *   },
  * });
  */
-export function useSubmissionsQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(
-    SubmissionsDocument,
-    baseOptions
-  )
-}
-export function useSubmissionsLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >(SubmissionsDocument, baseOptions)
-}
-export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>
-export type SubmissionsLazyQueryHookResult = ReturnType<
-  typeof useSubmissionsLazyQuery
->
-export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<
-  SubmissionsQuery,
-  SubmissionsQueryVariables
->
+export function useSubmissionsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
+        return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
+      }
+export function useSubmissionsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
+        }
+export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>;
+export type SubmissionsLazyQueryHookResult = ReturnType<typeof useSubmissionsLazyQuery>;
+export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<SubmissionsQuery, SubmissionsQueryVariables>;
 export const LoginDocument = gql`
-  mutation login($username: String!, $password: String!) {
-    login(username: $username, password: $password) {
-      success
-      username
-      cliToken
-      error
-    }
+    mutation login($username: String!, $password: String!) {
+  login(username: $username, password: $password) {
+    success
+    username
+    cliToken
+    error
   }
-`
-export type LoginMutationFn = ApolloReactCommon.MutationFunction<
-  LoginMutation,
-  LoginMutationVariables
->
-export type LoginComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    LoginMutation,
-    LoginMutationVariables
-  >,
-  'mutation'
->
-
-export const LoginComponent = (props: LoginComponentProps) => (
-  <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables>
-    mutation={LoginDocument}
-    {...props}
-  />
-)
-
-export type LoginProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    LoginMutation,
-    LoginMutationVariables
-  >
-} &
-  TChildProps
-export function withLogin<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    LoginMutation,
-    LoginMutationVariables,
-    LoginProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    LoginMutation,
-    LoginMutationVariables,
-    LoginProps<TChildProps, TDataName>
-  >(LoginDocument, {
-    alias: 'login',
-    ...operationOptions
-  })
 }
+    `;
+export type LoginMutationFn = ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>;
+export type LoginComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LoginMutation, LoginMutationVariables>, 'mutation'>;
+
+    export const LoginComponent = (props: LoginComponentProps) => (
+      <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables> mutation={LoginDocument} {...props} />
+    );
+    
+export type LoginProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>
+    } & TChildProps;
+export function withLogin<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  LoginMutation,
+  LoginMutationVariables,
+  LoginProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, LoginMutation, LoginMutationVariables, LoginProps<TChildProps, TDataName>>(LoginDocument, {
+      alias: 'login',
+      ...operationOptions
+    });
+};
 
 /**
  * __useLoginMutation__
@@ -1581,85 +1180,41 @@ export function withLogin<
  *   },
  * });
  */
-export function useLoginMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    LoginMutation,
-    LoginMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(
-    LoginDocument,
-    baseOptions
-  )
-}
-export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>
-export type LoginMutationResult = ApolloReactCommon.MutationResult<
-  LoginMutation
->
-export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  LoginMutation,
-  LoginMutationVariables
->
+export function useLoginMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
+        return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, baseOptions);
+      }
+export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
+export type LoginMutationResult = ApolloReactCommon.MutationResult<LoginMutation>;
+export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
 export const LogoutDocument = gql`
-  mutation logout {
-    logout {
-      success
-      username
-      error
-    }
+    mutation logout {
+  logout {
+    success
+    username
+    error
   }
-`
-export type LogoutMutationFn = ApolloReactCommon.MutationFunction<
-  LogoutMutation,
-  LogoutMutationVariables
->
-export type LogoutComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    LogoutMutation,
-    LogoutMutationVariables
-  >,
-  'mutation'
->
-
-export const LogoutComponent = (props: LogoutComponentProps) => (
-  <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables>
-    mutation={LogoutDocument}
-    {...props}
-  />
-)
-
-export type LogoutProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    LogoutMutation,
-    LogoutMutationVariables
-  >
-} &
-  TChildProps
-export function withLogout<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    LogoutMutation,
-    LogoutMutationVariables,
-    LogoutProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    LogoutMutation,
-    LogoutMutationVariables,
-    LogoutProps<TChildProps, TDataName>
-  >(LogoutDocument, {
-    alias: 'logout',
-    ...operationOptions
-  })
 }
+    `;
+export type LogoutMutationFn = ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>;
+export type LogoutComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LogoutMutation, LogoutMutationVariables>, 'mutation'>;
+
+    export const LogoutComponent = (props: LogoutComponentProps) => (
+      <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables> mutation={LogoutDocument} {...props} />
+    );
+    
+export type LogoutProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>
+    } & TChildProps;
+export function withLogout<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  LogoutMutation,
+  LogoutMutationVariables,
+  LogoutProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, LogoutMutation, LogoutMutationVariables, LogoutProps<TChildProps, TDataName>>(LogoutDocument, {
+      alias: 'logout',
+      ...operationOptions
+    });
+};
 
 /**
  * __useLogoutMutation__
@@ -1677,90 +1232,41 @@ export function withLogout<
  *   },
  * });
  */
-export function useLogoutMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    LogoutMutation,
-    LogoutMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(
-    LogoutDocument,
-    baseOptions
-  )
-}
-export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>
-export type LogoutMutationResult = ApolloReactCommon.MutationResult<
-  LogoutMutation
->
-export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  LogoutMutation,
-  LogoutMutationVariables
->
+export function useLogoutMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
+        return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, baseOptions);
+      }
+export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
+export type LogoutMutationResult = ApolloReactCommon.MutationResult<LogoutMutation>;
+export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<LogoutMutation, LogoutMutationVariables>;
 export const RejectSubmissionDocument = gql`
-  mutation rejectSubmission($submissionId: String!, $comment: String!) {
-    rejectSubmission(id: $submissionId, comment: $comment) {
-      id
-      comment
-      status
-    }
+    mutation rejectSubmission($submissionId: String!, $comment: String!) {
+  rejectSubmission(id: $submissionId, comment: $comment) {
+    id
+    comment
+    status
   }
-`
-export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<
-  RejectSubmissionMutation,
-  RejectSubmissionMutationVariables
->
-export type RejectSubmissionComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >,
-  'mutation'
->
-
-export const RejectSubmissionComponent = (
-  props: RejectSubmissionComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >
-    mutation={RejectSubmissionDocument}
-    {...props}
-  />
-)
-
-export type RejectSubmissionProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >
-} &
-  TChildProps
-export function withRejectSubmission<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables,
-    RejectSubmissionProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables,
-    RejectSubmissionProps<TChildProps, TDataName>
-  >(RejectSubmissionDocument, {
-    alias: 'rejectSubmission',
-    ...operationOptions
-  })
 }
+    `;
+export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
+export type RejectSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>, 'mutation'>;
+
+    export const RejectSubmissionComponent = (props: RejectSubmissionComponentProps) => (
+      <ApolloReactComponents.Mutation<RejectSubmissionMutation, RejectSubmissionMutationVariables> mutation={RejectSubmissionDocument} {...props} />
+    );
+    
+export type RejectSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>
+    } & TChildProps;
+export function withRejectSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  RejectSubmissionMutation,
+  RejectSubmissionMutationVariables,
+  RejectSubmissionProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, RejectSubmissionMutation, RejectSubmissionMutationVariables, RejectSubmissionProps<TChildProps, TDataName>>(RejectSubmissionDocument, {
+      alias: 'rejectSubmission',
+      ...operationOptions
+    });
+};
 
 /**
  * __useRejectSubmissionMutation__
@@ -1780,89 +1286,40 @@ export function withRejectSubmission<
  *   },
  * });
  */
-export function useRejectSubmissionMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >(RejectSubmissionDocument, baseOptions)
-}
-export type RejectSubmissionMutationHookResult = ReturnType<
-  typeof useRejectSubmissionMutation
->
-export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<
-  RejectSubmissionMutation
->
-export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  RejectSubmissionMutation,
-  RejectSubmissionMutationVariables
->
+export function useRejectSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>) {
+        return ApolloReactHooks.useMutation<RejectSubmissionMutation, RejectSubmissionMutationVariables>(RejectSubmissionDocument, baseOptions);
+      }
+export type RejectSubmissionMutationHookResult = ReturnType<typeof useRejectSubmissionMutation>;
+export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<RejectSubmissionMutation>;
+export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
 export const ReqPwResetDocument = gql`
-  mutation reqPwReset($userOrEmail: String!) {
-    reqPwReset(userOrEmail: $userOrEmail) {
-      success
-      token
-    }
+    mutation reqPwReset($userOrEmail: String!) {
+  reqPwReset(userOrEmail: $userOrEmail) {
+    success
+    token
   }
-`
-export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<
-  ReqPwResetMutation,
-  ReqPwResetMutationVariables
->
-export type ReqPwResetComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >,
-  'mutation'
->
-
-export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
-  <ApolloReactComponents.Mutation<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >
-    mutation={ReqPwResetDocument}
-    {...props}
-  />
-)
-
-export type ReqPwResetProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >
-} &
-  TChildProps
-export function withReqPwReset<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables,
-    ReqPwResetProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables,
-    ReqPwResetProps<TChildProps, TDataName>
-  >(ReqPwResetDocument, {
-    alias: 'reqPwReset',
-    ...operationOptions
-  })
 }
+    `;
+export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>;
+export type ReqPwResetComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ReqPwResetMutation, ReqPwResetMutationVariables>, 'mutation'>;
+
+    export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
+      <ApolloReactComponents.Mutation<ReqPwResetMutation, ReqPwResetMutationVariables> mutation={ReqPwResetDocument} {...props} />
+    );
+    
+export type ReqPwResetProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>
+    } & TChildProps;
+export function withReqPwReset<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  ReqPwResetMutation,
+  ReqPwResetMutationVariables,
+  ReqPwResetProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, ReqPwResetMutation, ReqPwResetMutationVariables, ReqPwResetProps<TChildProps, TDataName>>(ReqPwResetDocument, {
+      alias: 'reqPwReset',
+      ...operationOptions
+    });
+};
 
 /**
  * __useReqPwResetMutation__
@@ -1881,97 +1338,41 @@ export function withReqPwReset<
  *   },
  * });
  */
-export function useReqPwResetMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >(ReqPwResetDocument, baseOptions)
-}
-export type ReqPwResetMutationHookResult = ReturnType<
-  typeof useReqPwResetMutation
->
-export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<
-  ReqPwResetMutation
->
-export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  ReqPwResetMutation,
-  ReqPwResetMutationVariables
->
+export function useReqPwResetMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ReqPwResetMutation, ReqPwResetMutationVariables>) {
+        return ApolloReactHooks.useMutation<ReqPwResetMutation, ReqPwResetMutationVariables>(ReqPwResetDocument, baseOptions);
+      }
+export type ReqPwResetMutationHookResult = ReturnType<typeof useReqPwResetMutation>;
+export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<ReqPwResetMutation>;
+export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<ReqPwResetMutation, ReqPwResetMutationVariables>;
 export const SignupDocument = gql`
-  mutation signup(
-    $firstName: String!
-    $lastName: String!
-    $email: String!
-    $username: String!
-  ) {
-    signup(
-      firstName: $firstName
-      lastName: $lastName
-      email: $email
-      username: $username
-    ) {
-      success
-      username
-      error
-    }
+    mutation signup($firstName: String!, $lastName: String!, $email: String!, $username: String!) {
+  signup(firstName: $firstName, lastName: $lastName, email: $email, username: $username) {
+    success
+    username
+    error
   }
-`
-export type SignupMutationFn = ApolloReactCommon.MutationFunction<
-  SignupMutation,
-  SignupMutationVariables
->
-export type SignupComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    SignupMutation,
-    SignupMutationVariables
-  >,
-  'mutation'
->
-
-export const SignupComponent = (props: SignupComponentProps) => (
-  <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables>
-    mutation={SignupDocument}
-    {...props}
-  />
-)
-
-export type SignupProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    SignupMutation,
-    SignupMutationVariables
-  >
-} &
-  TChildProps
-export function withSignup<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    SignupMutation,
-    SignupMutationVariables,
-    SignupProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    SignupMutation,
-    SignupMutationVariables,
-    SignupProps<TChildProps, TDataName>
-  >(SignupDocument, {
-    alias: 'signup',
-    ...operationOptions
-  })
 }
+    `;
+export type SignupMutationFn = ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>;
+export type SignupComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<SignupMutation, SignupMutationVariables>, 'mutation'>;
+
+    export const SignupComponent = (props: SignupComponentProps) => (
+      <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables> mutation={SignupDocument} {...props} />
+    );
+    
+export type SignupProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>
+    } & TChildProps;
+export function withSignup<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  SignupMutation,
+  SignupMutationVariables,
+  SignupProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, SignupMutation, SignupMutationVariables, SignupProps<TChildProps, TDataName>>(SignupDocument, {
+      alias: 'signup',
+      ...operationOptions
+    });
+};
 
 /**
  * __useSignupMutation__
@@ -1993,83 +1394,108 @@ export function withSignup<
  *   },
  * });
  */
-export function useSignupMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    SignupMutation,
-    SignupMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(
-    SignupDocument,
-    baseOptions
-  )
-}
-export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>
-export type SignupMutationResult = ApolloReactCommon.MutationResult<
-  SignupMutation
->
-export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  SignupMutation,
-  SignupMutationVariables
->
-export const ChangePwDocument = gql`
-  mutation changePw($token: String!, $password: String!) {
-    changePw(token: $token, password: $password) {
-      success
+export function useSignupMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SignupMutation, SignupMutationVariables>) {
+        return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(SignupDocument, baseOptions);
+      }
+export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>;
+export type SignupMutationResult = ApolloReactCommon.MutationResult<SignupMutation>;
+export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<SignupMutation, SignupMutationVariables>;
+export const UpdateChallengeDocument = gql`
+    mutation updateChallenge($lessonId: Int!, $order: Int, $description: String, $title: String, $id: Int!) {
+  updateChallenge(id: $id, lessonId: $lessonId, order: $order, description: $description, title: $title) {
+    id
+    docUrl
+    githubUrl
+    videoUrl
+    chatUrl
+    order
+    description
+    title
+    challenges {
+      id
+      description
+      lessonId
+      title
+      order
     }
   }
-`
-export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<
-  ChangePwMutation,
-  ChangePwMutationVariables
->
-export type ChangePwComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >,
-  'mutation'
->
-
-export const ChangePwComponent = (props: ChangePwComponentProps) => (
-  <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables>
-    mutation={ChangePwDocument}
-    {...props}
-  />
-)
-
-export type ChangePwProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >
-} &
-  TChildProps
-export function withChangePw<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    ChangePwMutation,
-    ChangePwMutationVariables,
-    ChangePwProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    ChangePwMutation,
-    ChangePwMutationVariables,
-    ChangePwProps<TChildProps, TDataName>
-  >(ChangePwDocument, {
-    alias: 'changePw',
-    ...operationOptions
-  })
 }
+    `;
+export type UpdateChallengeMutationFn = ApolloReactCommon.MutationFunction<UpdateChallengeMutation, UpdateChallengeMutationVariables>;
+export type UpdateChallengeComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>, 'mutation'>;
+
+    export const UpdateChallengeComponent = (props: UpdateChallengeComponentProps) => (
+      <ApolloReactComponents.Mutation<UpdateChallengeMutation, UpdateChallengeMutationVariables> mutation={UpdateChallengeDocument} {...props} />
+    );
+    
+export type UpdateChallengeProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<UpdateChallengeMutation, UpdateChallengeMutationVariables>
+    } & TChildProps;
+export function withUpdateChallenge<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  UpdateChallengeMutation,
+  UpdateChallengeMutationVariables,
+  UpdateChallengeProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, UpdateChallengeMutation, UpdateChallengeMutationVariables, UpdateChallengeProps<TChildProps, TDataName>>(UpdateChallengeDocument, {
+      alias: 'updateChallenge',
+      ...operationOptions
+    });
+};
+
+/**
+ * __useUpdateChallengeMutation__
+ *
+ * To run a mutation, you first call `useUpdateChallengeMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateChallengeMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateChallengeMutation, { data, loading, error }] = useUpdateChallengeMutation({
+ *   variables: {
+ *      lessonId: // value for 'lessonId'
+ *      order: // value for 'order'
+ *      description: // value for 'description'
+ *      title: // value for 'title'
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useUpdateChallengeMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>) {
+        return ApolloReactHooks.useMutation<UpdateChallengeMutation, UpdateChallengeMutationVariables>(UpdateChallengeDocument, baseOptions);
+      }
+export type UpdateChallengeMutationHookResult = ReturnType<typeof useUpdateChallengeMutation>;
+export type UpdateChallengeMutationResult = ApolloReactCommon.MutationResult<UpdateChallengeMutation>;
+export type UpdateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>;
+export const ChangePwDocument = gql`
+    mutation changePw($token: String!, $password: String!) {
+  changePw(token: $token, password: $password) {
+    success
+  }
+}
+    `;
+export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>;
+export type ChangePwComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ChangePwMutation, ChangePwMutationVariables>, 'mutation'>;
+
+    export const ChangePwComponent = (props: ChangePwComponentProps) => (
+      <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables> mutation={ChangePwDocument} {...props} />
+    );
+    
+export type ChangePwProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
+      [key in TDataName]: ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>
+    } & TChildProps;
+export function withChangePw<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  ChangePwMutation,
+  ChangePwMutationVariables,
+  ChangePwProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withMutation<TProps, ChangePwMutation, ChangePwMutationVariables, ChangePwProps<TChildProps, TDataName>>(ChangePwDocument, {
+      alias: 'changePw',
+      ...operationOptions
+    });
+};
 
 /**
  * __useChangePwMutation__
@@ -2089,123 +1515,81 @@ export function withChangePw<
  *   },
  * });
  */
-export function useChangePwMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >
-) {
-  return ApolloReactHooks.useMutation<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >(ChangePwDocument, baseOptions)
-}
-export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>
-export type ChangePwMutationResult = ApolloReactCommon.MutationResult<
-  ChangePwMutation
->
-export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<
-  ChangePwMutation,
-  ChangePwMutationVariables
->
+export function useChangePwMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ChangePwMutation, ChangePwMutationVariables>) {
+        return ApolloReactHooks.useMutation<ChangePwMutation, ChangePwMutationVariables>(ChangePwDocument, baseOptions);
+      }
+export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>;
+export type ChangePwMutationResult = ApolloReactCommon.MutationResult<ChangePwMutation>;
+export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<ChangePwMutation, ChangePwMutationVariables>;
 export const UserInfoDocument = gql`
-  query userInfo($username: String!) {
-    lessons {
+    query userInfo($username: String!) {
+  lessons {
+    id
+    title
+    description
+    docUrl
+    githubUrl
+    videoUrl
+    order
+    challenges {
       id
       title
       description
-      docUrl
-      githubUrl
-      videoUrl
       order
-      challenges {
-        id
-        title
-        description
-        order
-      }
-      chatUrl
     }
-    userInfo(username: $username) {
-      user {
+    chatUrl
+  }
+  userInfo(username: $username) {
+    user {
+      id
+      username
+      name
+    }
+    submissions {
+      id
+      status
+      mrUrl
+      diff
+      viewCount
+      comment
+      order
+      challengeId
+      lessonId
+      reviewer {
         id
         username
-        name
       }
-      submissions {
-        id
-        status
-        mrUrl
-        diff
-        viewCount
-        comment
-        order
-        challengeId
-        lessonId
-        reviewer {
-          id
-          username
-        }
-        createdAt
-        updatedAt
-      }
-      lessonStatus {
-        lessonId
-        isPassed
-        isTeaching
-        isEnrolled
-      }
+      createdAt
+      updatedAt
+    }
+    lessonStatus {
+      lessonId
+      isPassed
+      isTeaching
+      isEnrolled
     }
   }
-`
-export type UserInfoComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >,
-  'query'
-> &
-  ({ variables: UserInfoQueryVariables; skip?: boolean } | { skip: boolean })
-
-export const UserInfoComponent = (props: UserInfoComponentProps) => (
-  <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables>
-    query={UserInfoDocument}
-    {...props}
-  />
-)
-
-export type UserInfoProps<
-  TChildProps = {},
-  TDataName extends string = 'data'
-> = {
-  [key in TDataName]: ApolloReactHoc.DataValue<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >
-} &
-  TChildProps
-export function withUserInfo<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'data'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    UserInfoQuery,
-    UserInfoQueryVariables,
-    UserInfoProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withQuery<
-    TProps,
-    UserInfoQuery,
-    UserInfoQueryVariables,
-    UserInfoProps<TChildProps, TDataName>
-  >(UserInfoDocument, {
-    alias: 'userInfo',
-    ...operationOptions
-  })
 }
+    `;
+export type UserInfoComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<UserInfoQuery, UserInfoQueryVariables>, 'query'> & ({ variables: UserInfoQueryVariables; skip?: boolean; } | { skip: boolean; });
+
+    export const UserInfoComponent = (props: UserInfoComponentProps) => (
+      <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables> query={UserInfoDocument} {...props} />
+    );
+    
+export type UserInfoProps<TChildProps = {}, TDataName extends string = 'data'> = {
+      [key in TDataName]: ApolloReactHoc.DataValue<UserInfoQuery, UserInfoQueryVariables>
+    } & TChildProps;
+export function withUserInfo<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  TProps,
+  UserInfoQuery,
+  UserInfoQueryVariables,
+  UserInfoProps<TChildProps, TDataName>>) {
+    return ApolloReactHoc.withQuery<TProps, UserInfoQuery, UserInfoQueryVariables, UserInfoProps<TChildProps, TDataName>>(UserInfoDocument, {
+      alias: 'userInfo',
+      ...operationOptions
+    });
+};
 
 /**
  * __useUserInfoQuery__
@@ -2223,33 +1607,12 @@ export function withUserInfo<
  *   },
  * });
  */
-export function useUserInfoQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(
-    UserInfoDocument,
-    baseOptions
-  )
-}
-export function useUserInfoLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(
-    UserInfoDocument,
-    baseOptions
-  )
-}
-export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>
-export type UserInfoLazyQueryHookResult = ReturnType<
-  typeof useUserInfoLazyQuery
->
-export type UserInfoQueryResult = ApolloReactCommon.QueryResult<
-  UserInfoQuery,
-  UserInfoQueryVariables
->
+export function useUserInfoQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
+        return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
+      }
+export function useUserInfoLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
+        }
+export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>;
+export type UserInfoLazyQueryHookResult = ReturnType<typeof useUserInfoLazyQuery>;
+export type UserInfoQueryResult = ApolloReactCommon.QueryResult<UserInfoQuery, UserInfoQueryVariables>;

--- a/graphql/queries/createChallenge.ts
+++ b/graphql/queries/createChallenge.ts
@@ -1,0 +1,35 @@
+import { gql } from 'apollo-boost'
+
+const CREATE_CHALLENGE = gql`
+  mutation createChallenge(
+    $lessonId: Int!
+    $order: Int!
+    $description: String!
+    $title: String!
+  ) {
+    createChallenge(
+      lessonId: $lessonId
+      order: $order
+      description: $description
+      title: $title
+    ) {
+      id
+      docUrl
+      githubUrl
+      videoUrl
+      chatUrl
+      order
+      description
+      title
+      challenges {
+        id
+        description
+        lessonId
+        title
+        order
+      }
+    }
+  }
+`
+
+export default CREATE_CHALLENGE

--- a/graphql/queries/updateChallenge.ts
+++ b/graphql/queries/updateChallenge.ts
@@ -1,0 +1,37 @@
+import { gql } from 'apollo-boost'
+
+const UPDATE_CHALLENGE = gql`
+  mutation updateChallenge(
+    $lessonId: Int!
+    $order: Int
+    $description: String
+    $title: String
+    $id: Int!
+  ) {
+    updateChallenge(
+      id: $id
+      lessonId: $lessonId
+      order: $order
+      description: $description
+      title: $title
+    ) {
+      id
+      docUrl
+      githubUrl
+      videoUrl
+      chatUrl
+      order
+      description
+      title
+      challenges {
+        id
+        description
+        lessonId
+        title
+        order
+      }
+    }
+  }
+`
+
+export default UPDATE_CHALLENGE

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -66,16 +66,16 @@ export default gql`
     createChallenge(
       lessonId: Int!
       order: Int!
-      description: String
-      title: String
-    ): SuccessResponse
+      description: String!
+      title: String!
+    ): [Lesson]
     updateChallenge(
       lessonId: Int!
       id: Int!
-      order: Int!
+      order: Int
       description: String
       title: String
-    ): SuccessResponse
+    ): [Lesson]
   }
 
   type AuthResponse {

--- a/helpers/controllers/challengesController.test.js
+++ b/helpers/controllers/challengesController.test.js
@@ -3,7 +3,7 @@ jest.mock('../mattermost')
 import db from '../dbload'
 import { createChallenge, updateChallenge } from './challengesController'
 
-const { Challenge } = db
+const { Challenge, Lesson } = db
 
 const mockChallengeData = {
   lessonId: 5,
@@ -12,6 +12,8 @@ const mockChallengeData = {
   description: 'lolz',
   title: 'potato'
 }
+
+Lesson.findAll = jest.fn().mockReturnValue({ success: true })
 
 describe('Challenges controller tests', () => {
   const ctx = {

--- a/helpers/controllers/challengesController.test.js
+++ b/helpers/controllers/challengesController.test.js
@@ -2,7 +2,7 @@ jest.mock('../dbload')
 jest.mock('../mattermost')
 import db from '../dbload'
 import { createChallenge, updateChallenge } from './challengesController'
-
+import lessonData from '../../__dummy__/lessonData'
 const { Challenge, Lesson } = db
 
 const mockChallengeData = {
@@ -13,7 +13,7 @@ const mockChallengeData = {
   title: 'potato'
 }
 
-Lesson.findAll = jest.fn().mockReturnValue({ success: true })
+Lesson.findAll = jest.fn().mockReturnValue(lessonData)
 
 describe('Challenges controller tests', () => {
   const ctx = {
@@ -25,15 +25,15 @@ describe('Challenges controller tests', () => {
   Challenge.build = jest.fn().mockReturnValue({ save: () => {} })
 
   test('Should create new challenge', async () => {
-    expect(createChallenge(null, mockChallengeData, ctx)).resolves.toEqual({
-      success: true
-    })
+    expect(createChallenge(null, mockChallengeData, ctx)).resolves.toEqual(
+      lessonData
+    )
   })
 
   test('Should update challenge', async () => {
-    expect(updateChallenge(null, mockChallengeData, ctx)).resolves.toEqual({
-      success: true
-    })
+    expect(updateChallenge(null, mockChallengeData, ctx)).resolves.toEqual(
+      lessonData
+    )
   })
 
   test('Should throw Error when user is not an admin when updating challenge', async () => {

--- a/helpers/controllers/challengesController.ts
+++ b/helpers/controllers/challengesController.ts
@@ -20,7 +20,6 @@ export const createChallenge = async (
   ctx: Context
 ) => {
   const { req } = ctx
-  console.log(req.user)
   try {
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')

--- a/helpers/controllers/challengesController.ts
+++ b/helpers/controllers/challengesController.ts
@@ -2,6 +2,7 @@ import db from '../dbload'
 import { Context } from '../../@types/helpers'
 import _ from 'lodash'
 import { isAdmin } from '../isAdmin'
+import { lessons } from '../../graphql/queryResolvers/lessons'
 
 const { Challenge } = db
 
@@ -19,6 +20,7 @@ export const createChallenge = async (
   ctx: Context
 ) => {
   const { req } = ctx
+  console.log(req.user)
   try {
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
@@ -28,9 +30,7 @@ export const createChallenge = async (
 
     await newChallenge.save()
 
-    return {
-      success: true
-    }
+    return lessons()
   } catch (err) {
     throw new Error(err)
   }
@@ -46,14 +46,11 @@ export const updateChallenge = async (
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
-
     const { id } = arg
 
     await Challenge.update(arg, { where: { id } })
 
-    return {
-      success: true
-    }
+    return lessons()
   } catch (err) {
     throw new Error(err)
   }


### PR DESCRIPTION
A return response of `{ success: true `} is not meaningful when the front-end sends graphql requests to update or create a new challenge.

The front-end needs to receive the updated list lessons and challenges instead of a { success: true } object. Making this change will remove the need for the front-end to send another graphql query to retrieve updated data after sending a createChallenge/updateChallenge mutation request.

This PR will:

* Change the response of the updateChallenge and createChallenge resolvers to return updated list of lessons and challenges
* Update the createChallenge and updateChallenge queries in order to reflect the changes from their respective resolvers