### PR TITLE
closes #344 Update getApp graphql query

### DIFF
--- a/__dummy__/sessionData.js
+++ b/__dummy__/sessionData.js
@@ -2,7 +2,8 @@ export default {
   user: {
     id: 1,
     username: 'fakeusername',
-    name: 'fake user'
+    name: 'fake user',
+    isAdmin: 'true'
   },
   submissions: [],
   lessonStatus: []

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -360,7 +360,10 @@ export type GetAppQuery = { __typename?: 'Query' } & {
   session?: Maybe<
     { __typename?: 'Session' } & {
       user?: Maybe<
-        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
+        { __typename?: 'User' } & Pick<
+          User,
+          'id' | 'username' | 'name' | 'isAdmin'
+        >
       >
       submissions?: Maybe<
         Array<
@@ -1473,6 +1476,7 @@ export const GetAppDocument = gql`
         id
         username
         name
+        isAdmin
       }
       submissions {
         id

--- a/graphql/queries/getApp.ts
+++ b/graphql/queries/getApp.ts
@@ -23,6 +23,7 @@ const GET_APP = gql`
         id
         username
         name
+        isAdmin
       }
       submissions {
         id


### PR DESCRIPTION
The getApp query needs to be updated so that it returns the `isAdmin` property. This update is need so that so that pages and/or components can determine what to render based on whether the user is an admin or non-admin.

The ` __dummy__/sessionData.js` file also needs to include an `isAdmin` property. This is in case any current/future test files need to be updated to check if an admin is a user or not.

This PR will:
* Update the getApp query to return the `isAdmin property`
* Change the` __dummy__/sessionData.js` file to include an `isAdmin` property 