### PR TITLE
closes #352 - Fix DropdownMenu to properly take values from props

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1574,6 +1574,29 @@ Array [
       <button
         aria-expanded={false}
         aria-haspopup={true}
+        className="dropdown-toggle btn btn-danger"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Danger
+      </button>
+    </div>
+  </div>,
+  <div
+    style={
+      Object {
+        "display": "inline-block",
+      }
+    }
+  >
+    <div
+      className="dropdown"
+      onKeyDown={[Function]}
+    >
+      <button
+        aria-expanded={false}
+        aria-haspopup={true}
         className="dropdown-toggle btn btn-info"
         disabled={false}
         onClick={[Function]}
@@ -1603,29 +1626,6 @@ Array [
         type="button"
       >
         Warning
-      </button>
-    </div>
-  </div>,
-  <div
-    style={
-      Object {
-        "display": "inline-block",
-      }
-    }
-  >
-    <div
-      className="dropdown"
-      onKeyDown={[Function]}
-    >
-      <button
-        aria-expanded={false}
-        aria-haspopup={true}
-        className="dropdown-toggle btn btn-danger"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-      >
-        Danger
       </button>
     </div>
   </div>,
@@ -1678,7 +1678,7 @@ exports[`Storyshots Components/DropdownMenu Directions 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={true}
-        className="dropdown-toggle btn btn-none"
+        className="dropdown-toggle btn btn-primary"
         disabled={false}
         onClick={[Function]}
         type="button"
@@ -1701,7 +1701,7 @@ exports[`Storyshots Components/DropdownMenu Directions 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={true}
-        className="dropdown-toggle btn btn-none"
+        className="dropdown-toggle btn btn-success"
         disabled={false}
         onClick={[Function]}
         type="button"
@@ -1724,7 +1724,7 @@ exports[`Storyshots Components/DropdownMenu Directions 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={true}
-        className="dropdown-toggle btn btn-none"
+        className="dropdown-toggle btn btn-danger"
         disabled={false}
         onClick={[Function]}
         type="button"
@@ -1747,7 +1747,7 @@ exports[`Storyshots Components/DropdownMenu Directions 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={true}
-        className="dropdown-toggle btn btn-none"
+        className="dropdown-toggle btn btn-info"
         disabled={false}
         onClick={[Function]}
         type="button"

--- a/components/DropdownMenu.tsx
+++ b/components/DropdownMenu.tsx
@@ -8,7 +8,7 @@ import noop from '../helpers/noop'
 //a null item indicates a dropdown divider
 type Item = {
   title: string
-  path: string
+  path?: string
   as?: 'a' | 'button'
   onClick?: Function
 } | null
@@ -34,7 +34,7 @@ const menuItems = (items: Item[]) => {
       <Dropdown.Divider key={i} />
     ) : (
       <Dropdown.Item
-        as="button"
+        as={item.as || 'a'}
         key={i}
         href={item.path}
         onClick={(item.onClick && item.onClick()) || noop()}

--- a/stories/components/DropdownMenu.stories.tsx
+++ b/stories/components/DropdownMenu.stories.tsx
@@ -23,6 +23,15 @@ const separatedMenu = [
   { title: 'Alerts', path: '/admin/alerts' }
 ]
 
+const variants: any[] = [
+  'Primary',
+  'Success',
+  'Danger',
+  'Info',
+  'Warning',
+  'None'
+]
+
 export const Basic: React.FC = () => (
   <DropdownMenu title="Admin" items={dropdownMenuItems} />
 )
@@ -32,7 +41,6 @@ export const _WithSeparators: React.FC = () => (
 )
 
 export const Colors = () => {
-  const variants = ['Primary', 'Success', 'Info', 'Warning', 'Danger', 'None']
   return variants.map((variant: any, i: number) => (
     <div key={i} style={{ display: 'inline-block' }}>
       <DropdownMenu
@@ -49,6 +57,7 @@ export const Directions = () => {
     (direction: any, i: number) => (
       <div key={i} style={{ display: 'inline-block' }}>
         <DropdownMenu
+          variant={variants[i].toLowerCase()}
           drop={direction.toLowerCase()}
           title={direction}
           items={dropdownMenuItems}


### PR DESCRIPTION
The `Dropdown.Item` is used in our internal `DropdownMenu` component, but the internal component does not pass in proper prop values to the `Dropdown.Item` component it uses.

The `as` prop in the react-bootstrap component `Dropdown.Item` needs to have its value set to the input. This `Dropdown.Item` is used in our internal `DropdownMenu` component.

In our `DropdownMenu` component, the `Dropdown.Item` component has its `as` property set to `button`. Therefore passing in any `as` prop to the internal DropdownMenu component would have no effect at all.