### PR TITLE
closes #357 Lesson Info for the admin lessons page

### DIFF
--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -162,7 +162,7 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
     setLessonInfo(newLessonInfo)
   }
   return (
-    <div style={{ textAlign: 'center', marginBottom: 20 }} className=" col-8">
+    <div style={{ textAlign: 'center', marginBottom: 20 }} className="col-8">
       <span
         className="text-primary"
         style={{ fontSize: '4rem', textAlign: 'center', fontWeight: 'bold' }}

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -113,9 +113,7 @@ const newLessonAttributes = {
 // Renders when someone clicks on `create new button` on the sidebar
 const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
   const [createLesson, { loading, data }] = useMutation(createNewLesson)
-  const [lessonInfo, setLessonInfo] = useState(
-    inputValues(newLessonAttributes, 'challenges')
-  )
+  const [lessonInfo, setLessonInfo] = useState(inputValues(newLessonAttributes))
 
   // when data is fully loaded after sending mutation request, update front-end lessons info
   useEffect(() => {

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -40,7 +40,7 @@ const LessonBase: React.FC<LessonBaseProps> = ({ setLessons, lesson }) => {
 
   // alter gets called when someone clicks button to update a lesson
   const alter = async () => {
-    const newOptions = [lessonInfo]
+    const newOptions = [...lessonInfo]
     const errors = checkForAllErrors(newOptions)
     if (errors) {
       setLessonInfo(newOptions)

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -30,7 +30,9 @@ type NewLessonProps = {
 // Creates card for a lessons's information to update
 const LessonBase: React.FC<LessonBaseProps> = ({ setLessons, lesson }) => {
   const [alterLesson, { loading, data }] = useMutation(updateLesson)
-  const [lessonInfo, setLessonInfo] = useState(inputValues(lesson))
+  const [lessonInfo, setLessonInfo] = useState(
+    inputValues(lesson, 'challenges')
+  )
   // when data is fully loaded after sending mutation request, update front-end lessons info
   useEffect(() => {
     !loading && data && setLessons(data.updateLessons)
@@ -111,7 +113,9 @@ const newLessonAttributes = {
 // Renders when someone clicks on `create new button` on the sidebar
 const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
   const [createLesson, { loading, data }] = useMutation(createNewLesson)
-  const [lessonInfo, setLessonInfo] = useState(inputValues(newLessonAttributes))
+  const [lessonInfo, setLessonInfo] = useState(
+    inputValues(newLessonAttributes, 'challenges')
+  )
 
   // when data is fully loaded after sending mutation request, update front-end lessons info
   useEffect(() => {

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useState } from 'react'
+import { useMutation } from '@apollo/react-hooks'
+import createNewLesson from '../../../graphql/queries/createLesson'
+import updateLesson from '../../../graphql/queries/updateLesson'
+import { FormCard } from '../../FormCard'
+import _ from 'lodash'
+import {
+  inputValues,
+  outputValues,
+  checkForErrors,
+  checkForAllErrors
+} from '../../../helpers/admin/lessonHelpers'
+import { Lesson } from '../../../graphql/index'
+
+type LessonInfoProps = {
+  lessons: Lesson[] | undefined
+  setLessons: React.Dispatch<React.SetStateAction<Lesson[] | null>>
+  selectedLesson: number
+}
+
+type LessonBaseProps = {
+  setLessons: React.Dispatch<React.SetStateAction<Lesson[] | null>>
+  lesson: Lesson | undefined
+}
+
+type NewLessonProps = {
+  setLessons: React.Dispatch<React.SetStateAction<Lesson[] | null>>
+}
+
+// Creates card for a lessons's information to update
+const LessonBase: React.FC<LessonBaseProps> = ({ setLessons, lesson }) => {
+  const [alterLesson, { loading, data }] = useMutation(updateLesson)
+  const [lessonInfo, setLessonInfo] = useState(inputValues(lesson))
+  // when data is fully loaded after sending mutation request, update front-end lessons info
+  useEffect(() => {
+    !loading && data && setLessons(data.updateLessons)
+  }, [data])
+
+  // alter gets called when someone clicks button to update a lesson
+  const alter = async () => {
+    const newOptions = [lessonInfo]
+    const errors = checkForAllErrors(newOptions)
+    if (errors) {
+      setLessonInfo(newOptions)
+      return
+    }
+    const {
+      title,
+      description,
+      docUrl,
+      githubUrl,
+      videoUrl,
+      order,
+      chatUrl
+    } = outputValues(lessonInfo)
+    try {
+      await alterLesson({
+        variables: {
+          id: parseInt(lesson ? lesson.id + '' : ''),
+          title,
+          description,
+          docUrl,
+          githubUrl,
+          videoUrl,
+          order: parseInt(order),
+          chatUrl
+        }
+      })
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+
+  const handleChange = (value: string, propertyIndex: number) => {
+    const newLessonInfo = [...lessonInfo]
+    newLessonInfo[propertyIndex].value = value
+    checkForErrors(newLessonInfo[propertyIndex])
+    setLessonInfo(newLessonInfo)
+  }
+
+  return (
+    <>
+      <span
+        className="text-primary"
+        style={{ fontSize: '4rem', textAlign: 'center', fontWeight: 'bold' }}
+      >
+        Lesson Info
+      </span>
+      <div style={{ textAlign: 'center' }} className="card">
+        <FormCard
+          onChange={handleChange}
+          values={lessonInfo}
+          onSubmit={{ title: 'Update Lesson', onClick: alter }}
+          title={lesson && lesson.title + ''}
+        />
+      </div>
+    </>
+  )
+}
+
+const newLessonAttributes = {
+  title: '',
+  description: '',
+  docUrl: '',
+  githubUrl: '',
+  videoUrl: '',
+  order: '',
+  chatUrl: ''
+}
+
+// Renders when someone clicks on `create new button` on the sidebar
+const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
+  const [createLesson, { loading, data }] = useMutation(createNewLesson)
+  const [lessonInfo, setLessonInfo] = useState(inputValues(newLessonAttributes))
+
+  // when data is fully loaded after sending mutation request, update front-end lessons info
+  useEffect(() => {
+    !loading && data && setLessons(data.createLesson)
+  }, [data])
+
+  // alter gets called when someone clicks button to create a lesson
+  const alter = async () => {
+    const newOptions = [...lessonInfo]
+    const errors = checkForAllErrors(newOptions)
+    if (errors) {
+      setLessonInfo(newOptions)
+      return
+    }
+    const {
+      title,
+      description,
+      docUrl,
+      githubUrl,
+      videoUrl,
+      order,
+      chatUrl
+    } = outputValues(lessonInfo)
+    try {
+      await createLesson({
+        variables: {
+          title,
+          description,
+          docUrl,
+          githubUrl,
+          videoUrl,
+          order: parseInt(order),
+          chatUrl
+        }
+      })
+      window.location.reload()
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+
+  const handleChange = (value: string, propertyIndex: number) => {
+    const newLessonInfo = [...lessonInfo]
+    newLessonInfo[propertyIndex].value = value
+    checkForErrors(newLessonInfo[propertyIndex])
+    setLessonInfo(newLessonInfo)
+  }
+  return (
+    <div style={{ textAlign: 'center', marginBottom: 20 }} className=" col-8">
+      <span
+        className="text-primary"
+        style={{ fontSize: '4rem', textAlign: 'center', fontWeight: 'bold' }}
+      >
+        Create New Lesson
+      </span>
+      <FormCard
+        onChange={handleChange}
+        values={lessonInfo}
+        onSubmit={{ title: 'Create Lesson', onClick: alter }}
+      />
+    </div>
+  )
+}
+
+export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
+  setLessons,
+  lessons,
+  selectedLesson
+}) => {
+  // true when user clicks on `create new lesson` button
+  if (lessons && selectedLesson === lessons.length - 1) {
+    return <NewLesson setLessons={setLessons} />
+  }
+  // set currently selected lesson
+  const lesson = lessons && lessons[selectedLesson]
+  return (
+    <div style={{ textAlign: 'center' }} className="col-8" key={_.uniqueId()}>
+      <LessonBase setLessons={setLessons} lesson={lesson} />
+    </div>
+  )
+}

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -6,7 +6,7 @@ import { FormCard } from '../../FormCard'
 import _ from 'lodash'
 import {
   inputValues,
-  outputValues,
+  makeLessonVariable,
   checkForErrors,
   checkForAllErrors
 } from '../../../helpers/admin/lessonHelpers'
@@ -18,7 +18,7 @@ type LessonInfoProps = {
   selectedLesson: number
 }
 
-type LessonBaseProps = {
+type EditLessonProps = {
   setLessons: React.Dispatch<React.SetStateAction<Lesson[] | null>>
   lesson: Lesson | undefined
 }
@@ -28,9 +28,9 @@ type NewLessonProps = {
 }
 
 // Creates card for a lessons's information to update
-const LessonBase: React.FC<LessonBaseProps> = ({ setLessons, lesson }) => {
+const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
   const [alterLesson, { loading, data }] = useMutation(updateLesson)
-  const [lessonInfo, setLessonInfo] = useState(
+  const [lessonProperties, setLessonProperties] = useState(
     inputValues(lesson, 'challenges')
   )
   // when data is fully loaded after sending mutation request, update front-end lessons info
@@ -40,44 +40,24 @@ const LessonBase: React.FC<LessonBaseProps> = ({ setLessons, lesson }) => {
 
   // alter gets called when someone clicks button to update a lesson
   const alter = async () => {
-    const newOptions = [...lessonInfo]
-    const errors = checkForAllErrors(newOptions)
+    const newProperties = [...lessonProperties]
+    const errors = checkForAllErrors(newProperties)
     if (errors) {
-      setLessonInfo(newOptions)
+      setLessonProperties(newProperties)
       return
     }
-    const {
-      title,
-      description,
-      docUrl,
-      githubUrl,
-      videoUrl,
-      order,
-      chatUrl
-    } = outputValues(lessonInfo)
     try {
-      await alterLesson({
-        variables: {
-          id: parseInt(lesson ? lesson.id + '' : ''),
-          title,
-          description,
-          docUrl,
-          githubUrl,
-          videoUrl,
-          order: parseInt(order),
-          chatUrl
-        }
-      })
+      await alterLesson(makeLessonVariable(lessonProperties))
     } catch (err) {
       throw new Error(err)
     }
   }
 
   const handleChange = (value: string, propertyIndex: number) => {
-    const newLessonInfo = [...lessonInfo]
-    newLessonInfo[propertyIndex].value = value
-    checkForErrors(newLessonInfo[propertyIndex])
-    setLessonInfo(newLessonInfo)
+    const newLessonProperties = [...lessonProperties]
+    newLessonProperties[propertyIndex].value = value
+    checkForErrors(newLessonProperties[propertyIndex])
+    setLessonProperties(newLessonProperties)
   }
 
   return (
@@ -91,7 +71,7 @@ const LessonBase: React.FC<LessonBaseProps> = ({ setLessons, lesson }) => {
       <div style={{ textAlign: 'center' }} className="card">
         <FormCard
           onChange={handleChange}
-          values={lessonInfo}
+          values={lessonProperties}
           onSubmit={{ title: 'Update Lesson', onClick: alter }}
           title={lesson && lesson.title + ''}
         />
@@ -113,7 +93,9 @@ const newLessonAttributes = {
 // Renders when someone clicks on `create new button` on the sidebar
 const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
   const [createLesson, { loading, data }] = useMutation(createNewLesson)
-  const [lessonInfo, setLessonInfo] = useState(inputValues(newLessonAttributes))
+  const [lessonProperties, setLessonProperties] = useState(
+    inputValues(newLessonAttributes)
+  )
 
   // when data is fully loaded after sending mutation request, update front-end lessons info
   useEffect(() => {
@@ -122,33 +104,14 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
 
   // alter gets called when someone clicks button to create a lesson
   const alter = async () => {
-    const newOptions = [...lessonInfo]
-    const errors = checkForAllErrors(newOptions)
+    const newProperties = [...lessonProperties]
+    const errors = checkForAllErrors(newProperties)
     if (errors) {
-      setLessonInfo(newOptions)
+      setLessonProperties(newProperties)
       return
     }
-    const {
-      title,
-      description,
-      docUrl,
-      githubUrl,
-      videoUrl,
-      order,
-      chatUrl
-    } = outputValues(lessonInfo)
     try {
-      await createLesson({
-        variables: {
-          title,
-          description,
-          docUrl,
-          githubUrl,
-          videoUrl,
-          order: parseInt(order),
-          chatUrl
-        }
-      })
+      await createLesson(makeLessonVariable(lessonProperties))
       window.location.reload()
     } catch (err) {
       throw new Error(err)
@@ -156,11 +119,12 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
   }
 
   const handleChange = (value: string, propertyIndex: number) => {
-    const newLessonInfo = [...lessonInfo]
-    newLessonInfo[propertyIndex].value = value
-    checkForErrors(newLessonInfo[propertyIndex])
-    setLessonInfo(newLessonInfo)
+    const newLessonProperties = [...lessonProperties]
+    newLessonProperties[propertyIndex].value = value
+    checkForErrors(newLessonProperties[propertyIndex])
+    setLessonProperties(newLessonProperties)
   }
+
   return (
     <div style={{ textAlign: 'center', marginBottom: 20 }} className="col-8">
       <span
@@ -171,7 +135,7 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
       </span>
       <FormCard
         onChange={handleChange}
-        values={lessonInfo}
+        values={lessonProperties}
         onSubmit={{ title: 'Create Lesson', onClick: alter }}
       />
     </div>
@@ -191,7 +155,7 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
   const lesson = lessons && lessons[selectedLesson]
   return (
     <div style={{ textAlign: 'center' }} className="col-8" key={_.uniqueId()}>
-      <LessonBase setLessons={setLessons} lesson={lesson} />
+      <EditLesson setLessons={setLessons} lesson={lesson} />
     </div>
   )
 }

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -5,7 +5,7 @@ import updateLesson from '../../../graphql/queries/updateLesson'
 import { FormCard } from '../../FormCard'
 import _ from 'lodash'
 import {
-  inputValues,
+  getPropertyArr,
   makeLessonVariable,
   checkForErrors,
   checkForAllErrors
@@ -31,7 +31,7 @@ type NewLessonProps = {
 const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
   const [alterLesson, { loading, data }] = useMutation(updateLesson)
   const [lessonProperties, setLessonProperties] = useState(
-    inputValues(lesson, 'challenges')
+    getPropertyArr(lesson, ['challenges'])
   )
   // when data is fully loaded after sending mutation request, update front-end lessons info
   useEffect(() => {
@@ -94,7 +94,7 @@ const newLessonAttributes = {
 const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
   const [createLesson, { loading, data }] = useMutation(createNewLesson)
   const [lessonProperties, setLessonProperties] = useState(
-    inputValues(newLessonAttributes)
+    getPropertyArr(newLessonAttributes)
   )
 
   // when data is fully loaded after sending mutation request, update front-end lessons info

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -3,15 +3,14 @@ export const inputValues = (options: any, deleteProp?: string) => {
   deleteProp && options.hasOwnProperty(deleteProp) && delete options[deleteProp]
   options.hasOwnProperty('__typename') && delete options['__typename']
   const keys = Object.keys(options)
-  const res = keys.reduce((acc: any, type: any) => {
+  const res = keys.map((type: any) => {
     const value = options[type] === 0 ? '0' : `${options[type] || ''}`
-    acc.push({
+    return {
       title: type,
       value,
       type: type === 'description' ? 'MD_INPUT' : 'TEXT_AREA'
-    })
-    return acc
-  }, [])
+    }
+  })
   return res
 }
 
@@ -25,30 +24,30 @@ export const outputValues = (options: any) => {
 }
 
 //checks for error for one element in the `inputvalues` array
-export const checkForErrors = (newChallengeInfo: {
+export const checkForErrors = (option: {
   title: string
   value: string
   error: string
   hasOwnProperty: (arg0: string) => any
 }) => {
   let errorSeen = false
-  const { title, value } = newChallengeInfo
+  const { title, value } = option
   if (title === 'order') {
     if (!value) {
-      newChallengeInfo.error = 'Required'
+      option.error = 'Required'
       errorSeen = true
     } else if (!value.match(/^[0-9]+$/)) {
-      newChallengeInfo.error = 'Numbers only'
+      option.error = 'Numbers only'
       errorSeen = true
     } else {
-      newChallengeInfo.hasOwnProperty('error') && delete newChallengeInfo.error
+      option.hasOwnProperty('error') && delete option.error
     }
   } else if (title === 'title' || title === 'description') {
     if (!value) {
-      newChallengeInfo.error = 'Required'
+      option.error = 'Required'
       errorSeen = true
     } else {
-      newChallengeInfo.hasOwnProperty('error') && delete newChallengeInfo.error
+      option.hasOwnProperty('error') && delete option.error
     }
   }
   return errorSeen
@@ -57,8 +56,11 @@ export const checkForErrors = (newChallengeInfo: {
 //checks for error for each element in the `inputvalues` array
 export const checkForAllErrors = (options: any) => {
   let error = false
-  options.forEach((option: any) => {
-    if (checkForErrors(option)) error = true
+  options.some((option: any) => {
+    if (checkForErrors(option)) {
+      error = true
+      return true
+    }
   })
   return error
 }

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -24,12 +24,7 @@ export const outputValues = (options: any) => {
 }
 
 //checks for error for one element in the `inputvalues` array
-export const checkForErrors = (option: {
-  title: string
-  value: string
-  error: string
-  hasOwnProperty: (arg0: string) => any
-}) => {
+export const checkForErrors = (option: any) => {
   let errorSeen = false
   const { title, value } = option
   if (title === 'order') {

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -2,7 +2,9 @@
 export const inputValues = (options: any, deleteProp?: string) => {
   deleteProp && options.hasOwnProperty(deleteProp) && delete options[deleteProp]
   options.hasOwnProperty('__typename') && delete options['__typename']
+
   const keys = Object.keys(options)
+
   const res = keys.map((type: any) => {
     const value = options[type] === 0 ? '0' : `${options[type] || ''}`
     return {
@@ -11,41 +13,44 @@ export const inputValues = (options: any, deleteProp?: string) => {
       type: type === 'description' ? 'MD_INPUT' : 'TEXT_AREA'
     }
   })
+
   return res
 }
 
 // turns the array used in FormCard component into an object, to be used when making mutation requests
-export const outputValues = (options: any) => {
+export const makeLessonVariable = (options: any) => {
   const res = options.reduce((acc: any, option: any) => {
     acc[option.title] = option.value
     return acc
   }, {})
-  return res
+
+  res.order = parseInt(res.order)
+
+  if (res.hasOwnProperty('id')) {
+    res.id = parseInt(res.id ? res.id + '' : '')
+  }
+
+  return { variables: res }
 }
 
 //checks for error for one element in the `inputvalues` array
 export const checkForErrors = (option: any) => {
-  let errorSeen = false
   const { title, value } = option
-  if (title === 'order') {
-    if (!value) {
-      option.error = 'Required'
-      errorSeen = true
-    } else if (!value.match(/^[0-9]+$/)) {
-      option.error = 'Numbers only'
-      errorSeen = true
-    } else {
-      option.hasOwnProperty('error') && delete option.error
-    }
-  } else if (title === 'title' || title === 'description') {
-    if (!value) {
-      option.error = 'Required'
-      errorSeen = true
-    } else {
-      option.hasOwnProperty('error') && delete option.error
-    }
+  const required = ['title', 'description', 'order']
+
+  if (required.includes(title) && !value) {
+    option.error = 'Required'
+    return true
   }
-  return errorSeen
+
+  if (title === 'order' && isNaN(parseInt(value))) {
+    option.error = 'Numbers only'
+    return true
+  }
+
+  option.hasOwnProperty('error') && delete option.error
+
+  return false
 }
 
 //checks for error for each element in the `inputvalues` array

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -56,11 +56,8 @@ export const checkForErrors = (option: {
 //checks for error for each element in the `inputvalues` array
 export const checkForAllErrors = (options: any) => {
   let error = false
-  options.some((option: any) => {
-    if (checkForErrors(option)) {
-      error = true
-      return true
-    }
+  options.forEach((option: any) => {
+    if (checkForErrors(option)) error = true
   })
   return error
 }

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -1,18 +1,10 @@
-//add error to here. for title, order and description
-export const inputValues = (options: any) => {
-  //if lessons are passed in, then challenges property must be deleted
-  options.hasOwnProperty('lessonId') && delete options['lessonId']
-  options.hasOwnProperty('challenges') && delete options['challenges']
+// creates usuable array from graphql data to use as a prop when using FormCard component
+export const inputValues = (options: any, deleteProp: string) => {
+  options.hasOwnProperty(deleteProp) && delete options[deleteProp]
   options.hasOwnProperty('__typename') && delete options['__typename']
   const keys = Object.keys(options)
   const res = keys.reduce((acc: any, type: any) => {
-    let value
-
-    if (options[type] === 0) {
-      value = '0'
-    } else {
-      value = `${options[type] || ''}`
-    }
+    const value = options[type] === 0 ? '0' : `${options[type] || ''}`
     acc.push({
       title: type,
       value,
@@ -23,7 +15,7 @@ export const inputValues = (options: any) => {
   return res
 }
 
-//have to check for errors in here
+// turns the array used in FormCard component into an object, to be used when making mutation requests
 export const outputValues = (options: any) => {
   const res = options.reduce((acc: any, option: any) => {
     acc[option.title] = option.value
@@ -32,6 +24,7 @@ export const outputValues = (options: any) => {
   return res
 }
 
+//checks for error for one element in the `inputvalues` array
 export const checkForErrors = (newChallengeInfo: {
   title: string
   value: string
@@ -61,6 +54,7 @@ export const checkForErrors = (newChallengeInfo: {
   return errorSeen
 }
 
+//checks for error for each element in the `inputvalues` array
 export const checkForAllErrors = (options: any) => {
   let error = false
   options.forEach((option: any) => {

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -1,6 +1,6 @@
 // creates usuable array from graphql data to use as a prop when using FormCard component
-export const inputValues = (options: any, deleteProp: string) => {
-  options.hasOwnProperty(deleteProp) && delete options[deleteProp]
+export const inputValues = (options: any, deleteProp?: string) => {
+  deleteProp && options.hasOwnProperty(deleteProp) && delete options[deleteProp]
   options.hasOwnProperty('__typename') && delete options['__typename']
   const keys = Object.keys(options)
   const res = keys.reduce((acc: any, type: any) => {

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -1,0 +1,70 @@
+//add error to here. for title, order and description
+export const inputValues = (options: any) => {
+  //if lessons are passed in, then challenges property must be deleted
+  options.hasOwnProperty('lessonId') && delete options['lessonId']
+  options.hasOwnProperty('challenges') && delete options['challenges']
+  options.hasOwnProperty('__typename') && delete options['__typename']
+  const keys = Object.keys(options)
+  const res = keys.reduce((acc: any, type: any) => {
+    let value
+
+    if (options[type] === 0) {
+      value = '0'
+    } else {
+      value = `${options[type] || ''}`
+    }
+    acc.push({
+      title: type,
+      value,
+      type: type === 'description' ? 'MD_INPUT' : 'TEXT_AREA'
+    })
+    return acc
+  }, [])
+  return res
+}
+
+//have to check for errors in here
+export const outputValues = (options: any) => {
+  const res = options.reduce((acc: any, option: any) => {
+    acc[option.title] = option.value
+    return acc
+  }, {})
+  return res
+}
+
+export const checkForErrors = (newChallengeInfo: {
+  title: string
+  value: string
+  error: string
+  hasOwnProperty: (arg0: string) => any
+}) => {
+  let errorSeen = false
+  let { title, value } = newChallengeInfo
+  if (title === 'order') {
+    if (!value) {
+      newChallengeInfo.error = 'Required'
+      errorSeen = true
+    } else if (!value.match(/^[0-9]+$/)) {
+      newChallengeInfo.error = 'Numbers only'
+      errorSeen = true
+    } else {
+      newChallengeInfo.hasOwnProperty('error') && delete newChallengeInfo.error
+    }
+  } else if (title === 'title' || title === 'description') {
+    if (!value) {
+      newChallengeInfo.error = 'Required'
+      errorSeen = true
+    } else {
+      newChallengeInfo.hasOwnProperty('error') && delete newChallengeInfo.error
+    }
+  }
+  return errorSeen
+}
+
+export const checkForAllErrors = (options: any) => {
+  let error = false
+  options.forEach((option: any) => {
+    if (checkForErrors(option)) error = true
+  })
+  return error
+}

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -1,7 +1,7 @@
 // creates usuable array from graphql data to use as a prop when using FormCard component
-export const inputValues = (options: any, deleteProp?: string) => {
-  deleteProp && options.hasOwnProperty(deleteProp) && delete options[deleteProp]
-  options.hasOwnProperty('__typename') && delete options['__typename']
+export const getPropertyArr = (options: any, deleteProps?: string[]) => {
+  options.hasOwnProperty('__typename') && delete options.__typename
+  ;(deleteProps || []).forEach(prop => delete options[prop])
 
   const keys = Object.keys(options)
 

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -32,7 +32,7 @@ export const checkForErrors = (newChallengeInfo: {
   hasOwnProperty: (arg0: string) => any
 }) => {
   let errorSeen = false
-  let { title, value } = newChallengeInfo
+  const { title, value } = newChallengeInfo
   if (title === 'order') {
     if (!value) {
       newChallengeInfo.error = 'Required'

--- a/pages/admin/lessons.tsx
+++ b/pages/admin/lessons.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { AdminLessonInfo } from '../../components/admin/lessons/AdminLessonInfo'
 import { AdminLessonsSideBar } from '../../components/admin/lessons/AdminLessonsSideBar'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import Layout from '../../components/Layout'
@@ -20,9 +21,11 @@ const AdminLessons: React.FC<AdminLessonsProps> = ({ lessons, setLessons }) => {
         lessons={lessons}
         setSelectedLesson={setSelectedLesson}
       />
-      <div key={_.uniqueId()} style={{ textAlign: 'center' }} className="col-8">
-        <h1>{selectedLesson}</h1>
-      </div>
+      <AdminLessonInfo
+        setLessons={setLessons}
+        lessons={lessons}
+        selectedLesson={selectedLesson}
+      />
     </div>
   )
 }


### PR DESCRIPTION
The Admin Lessons page needs to display information about a lesson when a lesson title on the sidebar of the lessons page is clicked on. It also needs to be able to create a new lesson.

This PR will:
* Display lesson title when person clicks a `lesson title in the sidebar`
* Ability to create new Lesson by clicking on `create new lesson` button located in the sidebar

# Lesson Info
<img width="819" alt="Screen Shot 2020-08-01 at 7 10 17 PM" src="https://user-images.githubusercontent.com/45890848/89113826-b6deef80-d42a-11ea-9ddb-082ed83a08db.png">

# Create New Lesson
<img width="870" alt="Screen Shot 2020-08-01 at 7 10 35 PM" src="https://user-images.githubusercontent.com/45890848/89113836-c4947500-d42a-11ea-8871-e34806422ce8.png">
