### PR TITLE
closes #360 - Add lesson challenges to admin lessons page

### DIFF
--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -93,7 +93,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
   )
 }
 
-const OneChallenge: React.FC<OneChallengeProps> = ({ challenge, alter }) => {
+const LessonChallenge: React.FC<OneChallengeProps> = ({ challenge, alter }) => {
   const [challengeProperties, setChallengeProperties] = useState(
     getPropertyArr(challenge, ['lessonId'])
   )
@@ -155,7 +155,7 @@ export const AdminLessonChallenges: React.FC<LessonChallengesProps> = ({
   const allChallenges = !challenges
     ? []
     : challenges.map((challenge: Challenge, key: number) => (
-        <OneChallenge challenge={challenge} alter={alter} key={key} />
+        <LessonChallenge challenge={challenge} alter={alter} key={key} />
       ))
 
   return <>{allChallenges}</>

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import updateChallenge from '../../../graphql/queries/updateChallenge'
 import { FormCard } from '../../FormCard'
 import createNewChallenge from '../../../graphql/queries/createChallenge'
-import { Lesson, Challenge } from '../../../graphql/index'
+import { Lesson, Challenge, Maybe } from '../../../graphql/index'
 import {
   getPropertyArr,
   checkForErrors,
@@ -19,8 +19,8 @@ const challengeAttributes = {
   id: ''
 }
 
-type OneChallengeProps = {
-  challenge: Challenge
+type LessonChallengeProps = {
+  challenge: Maybe<Challenge>
   alter: (options: any) => Promise<void>
 }
 
@@ -30,7 +30,7 @@ type NewChallengeProps = {
 }
 type LessonChallengesProps = {
   setLessons: React.Dispatch<React.SetStateAction<Lesson[] | null>>
-  challenges?: any
+  challenges: Maybe<Challenge>[] | null | undefined
   lessonId?: number
 }
 
@@ -93,7 +93,10 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
   )
 }
 
-const LessonChallenge: React.FC<OneChallengeProps> = ({ challenge, alter }) => {
+const LessonChallenge: React.FC<LessonChallengeProps> = ({
+  challenge,
+  alter
+}) => {
   const [challengeProperties, setChallengeProperties] = useState(
     getPropertyArr(challenge, ['lessonId'])
   )
@@ -122,7 +125,7 @@ const LessonChallenge: React.FC<OneChallengeProps> = ({ challenge, alter }) => {
     <div className="card" style={{ marginBottom: 20 }}>
       <FormCard
         onChange={handleChange}
-        title={challenge.title + '' || ''}
+        title={(challenge && challenge.title + '') || ''}
         values={challengeProperties}
         onSubmit={handleSubmit}
       />
@@ -154,7 +157,7 @@ export const AdminLessonChallenges: React.FC<LessonChallengesProps> = ({
   }
   const allChallenges = !challenges
     ? []
-    : challenges.map((challenge: Challenge, key: number) => (
+    : challenges.map((challenge: Maybe<Challenge>, key: number) => (
         <LessonChallenge challenge={challenge} alter={alter} key={key} />
       ))
 

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -11,6 +11,7 @@ import {
   checkForAllErrors,
   makeGraphqlVariable
 } from '../../../helpers/admin/lessonHelpers'
+import { titleStyle } from './AdminLessonInfo'
 
 const challengeAttributes = {
   title: '',
@@ -76,10 +77,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
 
   return (
     <div style={{ textAlign: 'center', marginBottom: 20, marginTop: 10 }}>
-      <span
-        className="text-primary"
-        style={{ fontSize: '4rem', fontWeight: 'bold' }}
-      >
+      <span className="text-primary" style={titleStyle}>
         Create New Challenge
       </span>
       <div className="card">

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -14,9 +14,8 @@ import { titleStyle } from './AdminLessonInfo'
 
 const challengeAttributes = {
   title: '',
-  order: '',
   description: '',
-  id: ''
+  order: ''
 }
 
 type LessonChallengeProps = {

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -57,10 +57,12 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
       setChallengeProperties(newProperties)
       return
     }
+
     try {
       await createChallenge(
         makeGraphqlVariable(challengeProperties, { lessonId })
       )
+
       window.location.reload()
     } catch (err) {
       throw new Error(err)
@@ -152,6 +154,7 @@ export const AdminLessonChallenges: React.FC<LessonChallengesProps> = ({
       throw new Error(err)
     }
   }
+
   const allChallenges = !challenges
     ? []
     : challenges.map((challenge: Maybe<Challenge>, key: number) => (

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { useMutation } from '@apollo/react-hooks'
-import _ from 'lodash'
 import updateChallenge from '../../../graphql/queries/updateChallenge'
 import { FormCard } from '../../FormCard'
 import createNewChallenge from '../../../graphql/queries/createChallenge'

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useState } from 'react'
+import { useMutation } from '@apollo/react-hooks'
+import _ from 'lodash'
+import updateChallenge from '../../../graphql/queries/updateChallenge'
+import { FormCard } from '../../FormCard'
+import createNewChallenge from '../../../graphql/queries/createChallenge'
+import { Lesson, Challenge } from '../../../graphql/index'
+import {
+  getPropertyArr,
+  checkForErrors,
+  checkForAllErrors,
+  makeGraphqlVariable
+} from '../../../helpers/admin/lessonHelpers'
+
+const challengeAttributes = {
+  title: '',
+  order: '',
+  description: '',
+  id: ''
+}
+
+type OneChallengeProps = {
+  challenge: Challenge
+  alter: (options: any) => Promise<void>
+}
+
+type NewChallengeProps = {
+  setLessons: React.Dispatch<React.SetStateAction<Lesson[] | null>>
+  lessonId: number
+}
+type LessonChallengesProps = {
+  setLessons: React.Dispatch<React.SetStateAction<Lesson[] | null>>
+  challenges?: any
+  lessonId?: number
+}
+
+// Renders when someone clicks on `create new button` on the sidebar
+export const NewChallenge: React.FC<NewChallengeProps> = ({
+  // challenge,
+  setLessons,
+  lessonId
+}) => {
+  const [createChallenge, { loading, data }] = useMutation(createNewChallenge)
+  const [challengeProperties, setChallengeProperties] = useState(
+    getPropertyArr(challengeAttributes)
+  )
+  // when data is fully loaded after sending mutation request, update front-end lessons info
+  useEffect(() => {
+    !loading && data && setLessons(data.createChallenge)
+  }, [data])
+
+  // alter gets called when someone clicks button to create a lesson
+  const alter = async () => {
+    const newProperties = [...challengeProperties]
+    const errors = checkForAllErrors(newProperties)
+    if (errors) {
+      setChallengeProperties(newProperties)
+      return
+    }
+    try {
+      await createChallenge(
+        makeGraphqlVariable(challengeProperties, { lessonId })
+      )
+      window.location.reload()
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+
+  const handleChange = (value: string, propertyIndex: number) => {
+    const newChallengeProperties = [...challengeProperties]
+    newChallengeProperties[propertyIndex].value = value
+    checkForErrors(newChallengeProperties[propertyIndex])
+    setChallengeProperties(newChallengeProperties)
+  }
+
+  return (
+    <div style={{ textAlign: 'center', marginBottom: 20, marginTop: 10 }}>
+      <span
+        className="text-primary"
+        style={{ fontSize: '4rem', textAlign: 'center', fontWeight: 'bold' }}
+      >
+        Create New Challenge
+      </span>
+      <div className="card">
+        <FormCard
+          onChange={handleChange}
+          values={challengeProperties}
+          onSubmit={{ title: 'Create Challenge', onClick: alter }}
+        />
+      </div>
+    </div>
+  )
+}
+
+const OneChallenge: React.FC<OneChallengeProps> = ({ challenge, alter }) => {
+  const [challengeProperties, setChallengeProperties] = useState(
+    getPropertyArr(challenge, ['lessonId'])
+  )
+
+  const handleChange = (value: string, propertyIndex: number) => {
+    const newChallengeProperties = [...challengeProperties]
+    newChallengeProperties[propertyIndex].value = value
+    checkForErrors(newChallengeProperties[propertyIndex])
+    setChallengeProperties(newChallengeProperties)
+  }
+
+  const handleSubmit = {
+    title: 'Update Challenge',
+    onClick: () => {
+      const newProperties = [...challengeProperties]
+      const errors = checkForAllErrors(newProperties)
+      if (errors) {
+        setChallengeProperties(newProperties)
+        return
+      }
+      alter(challengeProperties)
+    }
+  }
+
+  return (
+    <div className="card" style={{ marginBottom: 20 }}>
+      <FormCard
+        onChange={handleChange}
+        title={challenge.title + '' || ''}
+        values={challengeProperties}
+        onSubmit={handleSubmit}
+      />
+    </div>
+  )
+}
+
+// creates list of cards to update challenges
+export const AdminLessonChallenges: React.FC<LessonChallengesProps> = ({
+  setLessons,
+  challenges,
+  lessonId
+}) => {
+  const [alterChallenge, { loading, data }] = useMutation(updateChallenge)
+
+  // when data is fully loaded after sending mutation request, update front-end lessons info
+  useEffect(() => {
+    !loading && data && setLessons(data.updateChallenge)
+  }, [data])
+
+  // alter gets called when someone clicks button to update a challenge
+  const alter = async (options: any) => {
+    try {
+      await alterChallenge(makeGraphqlVariable(options, { lessonId }))
+      window.location.reload()
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+  const allChallenges = !challenges
+    ? []
+    : challenges.map((challenge: Challenge, key: number) => (
+        <OneChallenge challenge={challenge} alter={alter} key={key} />
+      ))
+
+  return <>{allChallenges}</>
+}

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -37,7 +37,6 @@ type LessonChallengesProps = {
 
 // Renders when someone clicks on `create new button` on the sidebar
 export const NewChallenge: React.FC<NewChallengeProps> = ({
-  // challenge,
   setLessons,
   lessonId
 }) => {

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -78,7 +78,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
     <div style={{ textAlign: 'center', marginBottom: 20, marginTop: 10 }}>
       <span
         className="text-primary"
-        style={{ fontSize: '4rem', textAlign: 'center', fontWeight: 'bold' }}
+        style={{ fontSize: '4rem', fontWeight: 'bold' }}
       >
         Create New Challenge
       </span>

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -155,6 +155,7 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
   if (lessons && selectedLesson === lessons.length - 1) {
     return <NewLesson setLessons={setLessons} />
   }
+
   // set currently selected lesson
   const lesson = lessons && lessons[selectedLesson]
   return (
@@ -170,7 +171,6 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
       {newChallengeView ? (
         <NewChallenge
           setLessons={setLessons}
-          // challenge={challengeAttributes}
           lessonId={parseInt(lesson ? lesson.id + '' : '')}
         />
       ) : (

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -14,7 +14,7 @@ import { Lesson } from '../../../graphql/index'
 import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
 import { Button } from '../../theme/Button'
 
-const titleStyle: React.CSSProperties | undefined = {
+export const titleStyle: React.CSSProperties | undefined = {
   fontSize: '4rem',
   fontWeight: 'bold'
 }

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -160,6 +160,7 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
   return (
     <div style={{ textAlign: 'center' }} className="col-8" key={_.uniqueId()}>
       <EditLesson setLessons={setLessons} lesson={lesson} />
+      <hr />
       <NewChallenge setLessons={setLessons} lessonId={lessonId} />
       <hr />
       <span className="text-primary" style={titleStyle}>

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -6,11 +6,13 @@ import { FormCard } from '../../FormCard'
 import _ from 'lodash'
 import {
   getPropertyArr,
-  makeLessonVariable,
+  makeGraphqlVariable,
   checkForErrors,
   checkForAllErrors
 } from '../../../helpers/admin/lessonHelpers'
 import { Lesson } from '../../../graphql/index'
+import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
+import { Button } from '../../theme/Button'
 
 type LessonInfoProps = {
   lessons: Lesson[] | undefined
@@ -47,7 +49,7 @@ const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
       return
     }
     try {
-      await alterLesson(makeLessonVariable(lessonProperties))
+      await alterLesson(makeGraphqlVariable(lessonProperties))
     } catch (err) {
       throw new Error(err)
     }
@@ -111,7 +113,7 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
       return
     }
     try {
-      await createLesson(makeLessonVariable(lessonProperties))
+      await createLesson(makeGraphqlVariable(lessonProperties))
       window.location.reload()
     } catch (err) {
       throw new Error(err)
@@ -147,6 +149,8 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
   lessons,
   selectedLesson
 }) => {
+  const [newChallengeView, setNewChallengeView] = useState(false)
+
   // true when user clicks on `create new lesson` button
   if (lessons && selectedLesson === lessons.length - 1) {
     return <NewLesson setLessons={setLessons} />
@@ -155,7 +159,42 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
   const lesson = lessons && lessons[selectedLesson]
   return (
     <div style={{ textAlign: 'center' }} className="col-8" key={_.uniqueId()}>
-      <EditLesson setLessons={setLessons} lesson={lesson} />
+      <div style={{ position: 'absolute', right: 0, top: 0 }}>
+        <Button
+          onClick={() => setNewChallengeView(!newChallengeView)}
+          type="success"
+        >
+          {newChallengeView ? 'Back to Lesson Info' : 'Create New Challenge'}
+        </Button>
+      </div>
+      {newChallengeView ? (
+        <NewChallenge
+          setLessons={setLessons}
+          // challenge={challengeAttributes}
+          lessonId={parseInt(lesson ? lesson.id + '' : '')}
+        />
+      ) : (
+        <>
+          <EditLesson setLessons={setLessons} lesson={lesson} />
+          <hr />
+          <span
+            className="text-primary"
+            style={{
+              fontSize: '4rem',
+              textAlign: 'center',
+              fontWeight: 'bold'
+            }}
+          >
+            Lesson Challenges
+          </span>
+
+          <AdminLessonChallenges
+            challenges={lesson && lesson.challenges}
+            lessonId={parseInt(lesson ? lesson.id + '' : '')}
+            setLessons={setLessons}
+          />
+        </>
+      )}
     </div>
   )
 }

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../../helpers/admin/lessonHelpers'
 import { Lesson } from '../../../graphql/index'
 import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
-import { Button } from '../../theme/Button'
 
 export const titleStyle: React.CSSProperties | undefined = {
   fontSize: '4rem',
@@ -148,8 +147,6 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
   lessons,
   selectedLesson
 }) => {
-  const [newChallengeView, setNewChallengeView] = useState(false)
-
   // true when user clicks on `create new lesson` button
   if (lessons && selectedLesson === lessons.length - 1) {
     return <NewLesson setLessons={setLessons} />
@@ -160,13 +157,10 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
 
   const lessonId = parseInt(lesson ? lesson.id + '' : '')
 
-  const newChallengeClick = () => setNewChallengeView(!newChallengeView)
-
-  const viewOption = newChallengeView ? (
-    <NewChallenge setLessons={setLessons} lessonId={lessonId} />
-  ) : (
-    <>
+  return (
+    <div style={{ textAlign: 'center' }} className="col-8" key={_.uniqueId()}>
       <EditLesson setLessons={setLessons} lesson={lesson} />
+      <NewChallenge setLessons={setLessons} lessonId={lessonId} />
       <hr />
       <span className="text-primary" style={titleStyle}>
         Lesson Challenges
@@ -177,17 +171,6 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
         lessonId={lessonId}
         setLessons={setLessons}
       />
-    </>
-  )
-
-  return (
-    <div style={{ textAlign: 'center' }} className="col-8" key={_.uniqueId()}>
-      <div style={{ position: 'absolute', right: 0, top: 0 }}>
-        <Button onClick={newChallengeClick} type="success">
-          {newChallengeView ? 'Back to Lesson Info' : 'Create New Challenge'}
-        </Button>
-      </div>
-      {viewOption}
     </div>
   )
 }

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -14,6 +14,11 @@ import { Lesson } from '../../../graphql/index'
 import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
 import { Button } from '../../theme/Button'
 
+const titleStyle: React.CSSProperties | undefined = {
+  fontSize: '4rem',
+  fontWeight: 'bold'
+}
+
 type LessonInfoProps = {
   lessons: Lesson[] | undefined
   setLessons: React.Dispatch<React.SetStateAction<Lesson[] | null>>
@@ -64,10 +69,7 @@ const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
 
   return (
     <>
-      <span
-        className="text-primary"
-        style={{ fontSize: '4rem', textAlign: 'center', fontWeight: 'bold' }}
-      >
+      <span className="text-primary" style={titleStyle}>
         Lesson Info
       </span>
       <div style={{ textAlign: 'center' }} className="card">
@@ -129,10 +131,7 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
 
   return (
     <div style={{ textAlign: 'center', marginBottom: 20 }} className="col-8">
-      <span
-        className="text-primary"
-        style={{ fontSize: '4rem', textAlign: 'center', fontWeight: 'bold' }}
-      >
+      <span className="text-primary" style={titleStyle}>
         Create New Lesson
       </span>
       <FormCard
@@ -158,43 +157,37 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
 
   // set currently selected lesson
   const lesson = lessons && lessons[selectedLesson]
+
+  const lessonId = parseInt(lesson ? lesson.id + '' : '')
+
+  const newChallengeClick = () => setNewChallengeView(!newChallengeView)
+
+  const viewOption = newChallengeView ? (
+    <NewChallenge setLessons={setLessons} lessonId={lessonId} />
+  ) : (
+    <>
+      <EditLesson setLessons={setLessons} lesson={lesson} />
+      <hr />
+      <span className="text-primary" style={titleStyle}>
+        Lesson Challenges
+      </span>
+
+      <AdminLessonChallenges
+        challenges={lesson && lesson.challenges}
+        lessonId={lessonId}
+        setLessons={setLessons}
+      />
+    </>
+  )
+
   return (
     <div style={{ textAlign: 'center' }} className="col-8" key={_.uniqueId()}>
       <div style={{ position: 'absolute', right: 0, top: 0 }}>
-        <Button
-          onClick={() => setNewChallengeView(!newChallengeView)}
-          type="success"
-        >
+        <Button onClick={newChallengeClick} type="success">
           {newChallengeView ? 'Back to Lesson Info' : 'Create New Challenge'}
         </Button>
       </div>
-      {newChallengeView ? (
-        <NewChallenge
-          setLessons={setLessons}
-          lessonId={parseInt(lesson ? lesson.id + '' : '')}
-        />
-      ) : (
-        <>
-          <EditLesson setLessons={setLessons} lesson={lesson} />
-          <hr />
-          <span
-            className="text-primary"
-            style={{
-              fontSize: '4rem',
-              textAlign: 'center',
-              fontWeight: 'bold'
-            }}
-          >
-            Lesson Challenges
-          </span>
-
-          <AdminLessonChallenges
-            challenges={lesson && lesson.challenges}
-            lessonId={parseInt(lesson ? lesson.id + '' : '')}
-            setLessons={setLessons}
-          />
-        </>
-      )}
+      {viewOption}
     </div>
   )
 }

--- a/helpers/admin/lessonHelpers.ts
+++ b/helpers/admin/lessonHelpers.ts
@@ -18,7 +18,7 @@ export const getPropertyArr = (options: any, deleteProps?: string[]) => {
 }
 
 // turns the array used in FormCard component into an object, to be used when making mutation requests
-export const makeLessonVariable = (options: any) => {
+export const makeGraphqlVariable = (options: any, addProp?: any) => {
   const res = options.reduce((acc: any, option: any) => {
     acc[option.title] = option.value
     return acc
@@ -28,6 +28,13 @@ export const makeLessonVariable = (options: any) => {
 
   if (res.hasOwnProperty('id')) {
     res.id = parseInt(res.id ? res.id + '' : '')
+  }
+
+  if (addProp) {
+    const keys = Object.keys(addProp)
+    keys.forEach((propertyName: string) => {
+      res[propertyName] = addProp[propertyName]
+    })
   }
 
   return { variables: res }


### PR DESCRIPTION
Each lesson needs to display the challenges that it has. These displayed challenges need to be able to be updated.

This PR will:
* Display lesson challenges of each lesson
* Enable users to update any current challenges
* Enable users to create new challenges for any lesson
* Change name of `makeLessonVariable` into `makeGraphqlVariable` since it is used for challenges as well.
* Added an `addProp` optional parameter to the `makeGraphqlVariable` function, in order to make it work with challenges

# Create New Challenge:
<img width="953" alt="Screen Shot 2020-08-03 at 6 39 52 PM" src="https://user-images.githubusercontent.com/45890848/89243571-25ea4e80-d5b9-11ea-95a6-95e40f6c0695.png">

# Edit Challenge: 
<img width="534" alt="Screen Shot 2020-08-02 at 8 57 04 PM" src="https://user-images.githubusercontent.com/45890848/89144509-d8aba580-d502-11ea-9f9c-fcd327648dad.png">
