### PR TITLE
closes #372 - Add allUsers query

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -205,7 +205,10 @@ exports[`Storyshots Components/AppNav Logged In 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -237,7 +240,10 @@ exports[`Storyshots Components/AppNav Logged Out 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -2695,7 +2701,10 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
+        "bottom": 0,
         "minHeight": "100vh",
+        "position": "fixed",
+        "top": 0,
       }
     }
   >
@@ -2773,7 +2782,10 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
+        "bottom": 0,
         "minHeight": "100vh",
+        "position": "fixed",
+        "top": 0,
       }
     }
   >
@@ -3240,7 +3252,10 @@ exports[`Storyshots Components/LoadingSpinner Basic 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -4803,7 +4818,10 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
+        "bottom": 0,
         "minHeight": "100vh",
+        "position": "fixed",
+        "top": 0,
       }
     }
   >
@@ -4991,7 +5009,10 @@ exports[`Storyshots Pages/Curriculum Basic 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -5023,7 +5044,10 @@ exports[`Storyshots Pages/Curriculum Completed Lessons 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -5055,7 +5079,10 @@ exports[`Storyshots Pages/Curriculum With Alerts 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -5088,7 +5115,10 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
+        "bottom": 0,
         "minHeight": "100vh",
+        "position": "fixed",
+        "top": 0,
       }
     }
   >
@@ -5562,7 +5592,10 @@ exports[`Storyshots Pages/Lesson Basic 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -5594,7 +5627,10 @@ exports[`Storyshots Pages/Lesson Completed Challenges 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -5626,7 +5662,10 @@ exports[`Storyshots Pages/Lesson With Alerts 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
+      "bottom": 0,
       "minHeight": "100vh",
+      "position": "fixed",
+      "top": 0,
     }
   }
 >
@@ -5659,7 +5698,10 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
+        "bottom": 0,
         "minHeight": "100vh",
+        "position": "fixed",
+        "top": 0,
       }
     }
   >
@@ -5929,7 +5971,10 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
+        "bottom": 0,
         "minHeight": "100vh",
+        "position": "fixed",
+        "top": 0,
       }
     }
   >
@@ -6037,7 +6082,10 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
+        "bottom": 0,
         "minHeight": "100vh",
+        "position": "fixed",
+        "top": 0,
       }
     }
   >

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -205,7 +205,7 @@ exports[`Storyshots Components/AppNav Logged In 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -240,7 +240,7 @@ exports[`Storyshots Components/AppNav Logged Out 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -2701,7 +2701,7 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
-        "bottom": 0,
+        "left": 0,
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
@@ -2782,7 +2782,7 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
-        "bottom": 0,
+        "left": 0,
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
@@ -3252,7 +3252,7 @@ exports[`Storyshots Components/LoadingSpinner Basic 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -4818,7 +4818,7 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
-        "bottom": 0,
+        "left": 0,
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
@@ -5009,7 +5009,7 @@ exports[`Storyshots Pages/Curriculum Basic 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -5044,7 +5044,7 @@ exports[`Storyshots Pages/Curriculum Completed Lessons 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -5079,7 +5079,7 @@ exports[`Storyshots Pages/Curriculum With Alerts 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -5115,7 +5115,7 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
-        "bottom": 0,
+        "left": 0,
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
@@ -5592,7 +5592,7 @@ exports[`Storyshots Pages/Lesson Basic 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -5627,7 +5627,7 @@ exports[`Storyshots Pages/Lesson Completed Challenges 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -5662,7 +5662,7 @@ exports[`Storyshots Pages/Lesson With Alerts 1`] = `
   className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
   style={
     Object {
-      "bottom": 0,
+      "left": 0,
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
@@ -5698,7 +5698,7 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
-        "bottom": 0,
+        "left": 0,
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
@@ -5971,7 +5971,7 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
-        "bottom": 0,
+        "left": 0,
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
@@ -6082,7 +6082,7 @@ Array [
     className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     style={
       Object {
-        "bottom": 0,
+        "left": 0,
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 const LoadingSpinner = () => {
   return (
     <div
-      style={{ minHeight: '100vh', position: 'fixed', top: 0, bottom: 0 }}
+      style={{ minHeight: '100vh', position: 'fixed', top: 0, left: 0 }}
       className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     >
       <h1

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 const LoadingSpinner = () => {
   return (
     <div
-      style={{ minHeight: '100vh' }}
+      style={{ minHeight: '100vh', position: 'fixed', top: 0, bottom: 0 }}
       className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     >
       <h1

--- a/components/admin/users/AdminUsersTable.tsx
+++ b/components/admin/users/AdminUsersTable.tsx
@@ -6,28 +6,28 @@ import changeAdminRights from '../../../graphql/queries/changeAdminRights'
 import { User } from '../../../graphql'
 
 type UsersListProps = {
-  users: User[] | null
-  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+  users: User[]
+  setUsers: React.Dispatch<React.SetStateAction<User[]>>
 }
 
 type RowDataProps = {
   user: any
-  users: User[] | null
-  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+  users: User[]
+  setUsers: React.Dispatch<React.SetStateAction<User[]>>
   index: number
 }
 
 type AdminOptionProps = {
   isAdmin: boolean
-  users: User[] | null
-  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+  users: User[]
+  setUsers: React.Dispatch<React.SetStateAction<User[]>>
   index: number
   id: string | null | undefined
 }
 
 type UsersTableProps = {
-  users: User[] | null
-  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+  users: User[]
+  setUsers: React.Dispatch<React.SetStateAction<User[]>>
 }
 
 export const headerValues = ['ID', 'Username', 'Name', 'Email', 'Admin']

--- a/components/admin/users/AdminUsersTable.tsx
+++ b/components/admin/users/AdminUsersTable.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import { useMutation } from '@apollo/react-hooks'
+import _ from 'lodash'
+import { Button } from '../../theme/Button'
+import changeAdminRights from '../../../graphql/queries/changeAdminRights'
+import { User } from '../../../graphql'
+
+type UsersListProps = {
+  users: User[] | null
+  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+}
+
+type RowDataProps = {
+  user: any
+  users: User[] | null
+  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+  index: number
+}
+
+type AdminOptionProps = {
+  isAdmin: boolean
+  users: User[] | null
+  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+  index: number
+  id: string | null | undefined
+}
+
+type UsersTableProps = {
+  users: User[] | null
+  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+}
+
+export const headerValues = ['ID', 'Username', 'Name', 'Email', 'Admin']
+export const userProperties = ['id', 'username', 'name', 'email', 'isAdmin']
+
+const TableHeaders: React.FC = () => {
+  const head = headerValues.map((property, key) => (
+    <th key={key} style={{ fontSize: '1.5rem' }}>
+      {property}
+    </th>
+  ))
+
+  return (
+    <thead>
+      <tr style={{ textAlign: 'center' }}>{head}</tr>
+    </thead>
+  )
+}
+
+const AdminOption: React.FC<AdminOptionProps> = ({
+  isAdmin,
+  setUsers,
+  index,
+  users,
+  id
+}) => {
+  const [changeRights] = useMutation(changeAdminRights)
+
+  const mutationVariable = {
+    variables: {
+      id: parseInt(id + ''),
+      status: isAdmin ? 'false' : 'true'
+    }
+  }
+
+  const changeButton = async () => {
+    await changeRights(mutationVariable)
+    const newUsers = users && [...users]
+    if (newUsers) {
+      newUsers[index].isAdmin = isAdmin ? 'false' : 'true'
+    }
+    setUsers(newUsers)
+  }
+
+  return (
+    <Button type={isAdmin ? 'danger' : 'success'} onClick={changeButton}>
+      {(isAdmin ? 'Remove' : 'Grant') + ' Admin Rights'}
+    </Button>
+  )
+}
+
+const RowData: React.FC<RowDataProps> = ({ user, users, setUsers, index }) => {
+  const data = userProperties.map((property: string, key: number) => {
+    let value = user[property]
+
+    const displayOption =
+      property !== 'isAdmin' ? (
+        value
+      ) : (
+        <AdminOption
+          isAdmin={user[property] === 'true'}
+          setUsers={setUsers}
+          index={index}
+          users={users}
+          id={users && users[index].id}
+        />
+      )
+
+    return (
+      <td style={{ verticalAlign: 'middle' }} key={key}>
+        {displayOption}
+      </td>
+    )
+  })
+
+  return <>{data}</>
+}
+
+const UsersList: React.FC<UsersListProps> = ({ users, setUsers }) => {
+  const list =
+    users &&
+    users.reduce((acc: any[], user: any, usersIndex: number) => {
+      acc.push(
+        <tr key={usersIndex} style={{ textAlign: 'center' }}>
+          <RowData
+            user={user}
+            setUsers={setUsers}
+            index={usersIndex}
+            users={users}
+          />
+        </tr>
+      )
+
+      return acc
+    }, [])
+
+  return <tbody>{list}</tbody>
+}
+
+export const UsersTable: React.FC<UsersTableProps> = ({ users, setUsers }) => (
+  <table className="table table-striped">
+    <TableHeaders />
+    <UsersList users={users} setUsers={setUsers} />
+  </table>
+)

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -1,41 +1,48 @@
-import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
-import gql from 'graphql-tag';
-import * as ApolloReactCommon from '@apollo/react-common';
-import * as React from 'react';
-import * as ApolloReactComponents from '@apollo/react-components';
-import * as ApolloReactHoc from '@apollo/react-hoc';
-import * as ApolloReactHooks from '@apollo/react-hooks';
-export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
-export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+import {
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLScalarTypeConfig
+} from 'graphql'
+import gql from 'graphql-tag'
+import * as ApolloReactCommon from '@apollo/react-common'
+import * as React from 'react'
+import * as ApolloReactComponents from '@apollo/react-components'
+import * as ApolloReactHoc from '@apollo/react-hoc'
+import * as ApolloReactHooks from '@apollo/react-hooks'
+export type Maybe<T> = T | null
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] }
+export type RequireFields<T, K extends keyof T> = {
+  [X in Exclude<keyof T, K>]?: T[X]
+} &
+  { [P in K]-?: NonNullable<T[P]> }
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
+  ID: string
+  String: string
+  Boolean: boolean
+  Int: number
+  Float: number
   /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
-};
+  Upload: any
+}
 
 export type Alert = {
-  __typename?: 'Alert';
-  id: Scalars['String'];
-  text?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
-  urlCaption?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Alert'
+  id: Scalars['String']
+  text?: Maybe<Scalars['String']>
+  type?: Maybe<Scalars['String']>
+  url?: Maybe<Scalars['String']>
+  urlCaption?: Maybe<Scalars['String']>
+}
 
 export type AuthResponse = {
-  __typename?: 'AuthResponse';
-  success?: Maybe<Scalars['Boolean']>;
-  username?: Maybe<Scalars['String']>;
-  error?: Maybe<Scalars['String']>;
-  cliToken?: Maybe<Scalars['String']>;
-};
+  __typename?: 'AuthResponse'
+  success?: Maybe<Scalars['Boolean']>
+  username?: Maybe<Scalars['String']>
+  error?: Maybe<Scalars['String']>
+  cliToken?: Maybe<Scalars['String']>
+}
 
 export enum CacheControlScope {
   Public = 'PUBLIC',
@@ -43,853 +50,1283 @@ export enum CacheControlScope {
 }
 
 export type Challenge = {
-  __typename?: 'Challenge';
-  id?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  lessonId?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-};
+  __typename?: 'Challenge'
+  id?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>
+  lessonId?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+}
 
 export type Lesson = {
-  __typename?: 'Lesson';
-  id?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  title?: Maybe<Scalars['String']>;
-  challenges?: Maybe<Array<Maybe<Challenge>>>;
-  users?: Maybe<Array<Maybe<User>>>;
-  currentUser?: Maybe<User>;
-  chatUrl?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Lesson'
+  id?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+  title?: Maybe<Scalars['String']>
+  challenges?: Maybe<Array<Maybe<Challenge>>>
+  users?: Maybe<Array<Maybe<User>>>
+  currentUser?: Maybe<User>
+  chatUrl?: Maybe<Scalars['String']>
+}
 
 export type Mutation = {
-  __typename?: 'Mutation';
-  login?: Maybe<AuthResponse>;
-  logout?: Maybe<AuthResponse>;
-  reqPwReset?: Maybe<TokenResponse>;
-  changePw?: Maybe<AuthResponse>;
-  changeAdminRights?: Maybe<SuccessResponse>;
-  signup?: Maybe<AuthResponse>;
-  addAlert?: Maybe<SuccessResponse>;
-  removeAlert?: Maybe<SuccessResponse>;
-  createSubmission?: Maybe<Submission>;
-  acceptSubmission?: Maybe<Submission>;
-  rejectSubmission?: Maybe<Submission>;
-  createLesson?: Maybe<Array<Maybe<Lesson>>>;
-  updateLesson?: Maybe<Array<Maybe<Lesson>>>;
-  createChallenge?: Maybe<Array<Maybe<Lesson>>>;
-  updateChallenge?: Maybe<Array<Maybe<Lesson>>>;
-};
-
+  __typename?: 'Mutation'
+  login?: Maybe<AuthResponse>
+  logout?: Maybe<AuthResponse>
+  reqPwReset?: Maybe<TokenResponse>
+  changePw?: Maybe<AuthResponse>
+  changeAdminRights?: Maybe<SuccessResponse>
+  signup?: Maybe<AuthResponse>
+  addAlert?: Maybe<SuccessResponse>
+  removeAlert?: Maybe<SuccessResponse>
+  createSubmission?: Maybe<Submission>
+  acceptSubmission?: Maybe<Submission>
+  rejectSubmission?: Maybe<Submission>
+  createLesson?: Maybe<Array<Maybe<Lesson>>>
+  updateLesson?: Maybe<Array<Maybe<Lesson>>>
+  createChallenge?: Maybe<Array<Maybe<Lesson>>>
+  updateChallenge?: Maybe<Array<Maybe<Lesson>>>
+}
 
 export type MutationLoginArgs = {
-  username: Scalars['String'];
-  password: Scalars['String'];
-};
-
+  username: Scalars['String']
+  password: Scalars['String']
+}
 
 export type MutationReqPwResetArgs = {
-  userOrEmail: Scalars['String'];
-};
-
+  userOrEmail: Scalars['String']
+}
 
 export type MutationChangePwArgs = {
-  token: Scalars['String'];
-  password: Scalars['String'];
-};
-
+  token: Scalars['String']
+  password: Scalars['String']
+}
 
 export type MutationChangeAdminRightsArgs = {
-  id: Scalars['Int'];
-  status: Scalars['String'];
-};
-
+  id: Scalars['Int']
+  status: Scalars['String']
+}
 
 export type MutationSignupArgs = {
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  email: Scalars['String'];
-  username: Scalars['String'];
-  password?: Maybe<Scalars['String']>;
-};
-
+  firstName: Scalars['String']
+  lastName: Scalars['String']
+  email: Scalars['String']
+  username: Scalars['String']
+  password?: Maybe<Scalars['String']>
+}
 
 export type MutationAddAlertArgs = {
-  text: Scalars['String'];
-  type: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
-  urlCaption?: Maybe<Scalars['String']>;
-};
-
+  text: Scalars['String']
+  type: Scalars['String']
+  url?: Maybe<Scalars['String']>
+  urlCaption?: Maybe<Scalars['String']>
+}
 
 export type MutationRemoveAlertArgs = {
-  id: Scalars['String'];
-};
-
+  id: Scalars['String']
+}
 
 export type MutationCreateSubmissionArgs = {
-  lessonId: Scalars['String'];
-  challengeId: Scalars['String'];
-  cliToken: Scalars['String'];
-  diff: Scalars['String'];
-};
-
+  lessonId: Scalars['String']
+  challengeId: Scalars['String']
+  cliToken: Scalars['String']
+  diff: Scalars['String']
+}
 
 export type MutationAcceptSubmissionArgs = {
-  id: Scalars['String'];
-  comment: Scalars['String'];
-};
-
+  id: Scalars['String']
+  comment: Scalars['String']
+}
 
 export type MutationRejectSubmissionArgs = {
-  id: Scalars['String'];
-  comment: Scalars['String'];
-};
-
+  id: Scalars['String']
+  comment: Scalars['String']
+}
 
 export type MutationCreateLessonArgs = {
-  description: Scalars['String'];
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
-  chatUrl?: Maybe<Scalars['String']>;
-  order: Scalars['Int'];
-};
-
+  description: Scalars['String']
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  title: Scalars['String']
+  chatUrl?: Maybe<Scalars['String']>
+  order: Scalars['Int']
+}
 
 export type MutationUpdateLessonArgs = {
-  id: Scalars['Int'];
-  description?: Maybe<Scalars['String']>;
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  chatUrl?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-};
-
+  id: Scalars['Int']
+  description?: Maybe<Scalars['String']>
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+  chatUrl?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+}
 
 export type MutationCreateChallengeArgs = {
-  lessonId: Scalars['Int'];
-  order: Scalars['Int'];
-  description: Scalars['String'];
-  title: Scalars['String'];
-};
-
+  lessonId: Scalars['Int']
+  order: Scalars['Int']
+  description: Scalars['String']
+  title: Scalars['String']
+}
 
 export type MutationUpdateChallengeArgs = {
-  lessonId: Scalars['Int'];
-  id: Scalars['Int'];
-  order?: Maybe<Scalars['Int']>;
-  description?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-};
+  lessonId: Scalars['Int']
+  id: Scalars['Int']
+  order?: Maybe<Scalars['Int']>
+  description?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+}
 
 export type Query = {
-  __typename?: 'Query';
-  lessons: Array<Lesson>;
-  session?: Maybe<Session>;
-  allUsers?: Maybe<Array<Maybe<User>>>;
-  userInfo?: Maybe<Session>;
-  isTokenValid: Scalars['Boolean'];
-  submissions?: Maybe<Array<Maybe<Submission>>>;
-  alerts: Array<Alert>;
-};
-
+  __typename?: 'Query'
+  lessons: Array<Lesson>
+  session?: Maybe<Session>
+  allUsers?: Maybe<Array<Maybe<User>>>
+  userInfo?: Maybe<Session>
+  isTokenValid: Scalars['Boolean']
+  submissions?: Maybe<Array<Maybe<Submission>>>
+  alerts: Array<Alert>
+}
 
 export type QueryUserInfoArgs = {
-  username: Scalars['String'];
-};
-
+  username: Scalars['String']
+}
 
 export type QueryIsTokenValidArgs = {
-  cliToken: Scalars['String'];
-};
-
+  cliToken: Scalars['String']
+}
 
 export type QuerySubmissionsArgs = {
-  lessonId: Scalars['String'];
-};
+  lessonId: Scalars['String']
+}
 
 export type Session = {
-  __typename?: 'Session';
-  user?: Maybe<User>;
-  submissions?: Maybe<Array<Maybe<Submission>>>;
-  lessonStatus: Array<UserLesson>;
-};
+  __typename?: 'Session'
+  user?: Maybe<User>
+  submissions?: Maybe<Array<Maybe<Submission>>>
+  lessonStatus: Array<UserLesson>
+}
 
 export type Star = {
-  __typename?: 'Star';
-  id: Scalars['String'];
-  studentId?: Maybe<Scalars['Int']>;
-  mentorId?: Maybe<Scalars['Int']>;
-  lessonId?: Maybe<Scalars['Int']>;
-  comment?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Star'
+  id: Scalars['String']
+  studentId?: Maybe<Scalars['Int']>
+  mentorId?: Maybe<Scalars['Int']>
+  lessonId?: Maybe<Scalars['Int']>
+  comment?: Maybe<Scalars['String']>
+}
 
 export type Submission = {
-  __typename?: 'Submission';
-  id?: Maybe<Scalars['String']>;
-  status?: Maybe<Scalars['String']>;
-  mrUrl?: Maybe<Scalars['String']>;
-  diff?: Maybe<Scalars['String']>;
-  viewCount?: Maybe<Scalars['Int']>;
-  comment?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  lessonId?: Maybe<Scalars['String']>;
-  challengeId?: Maybe<Scalars['String']>;
-  challenge?: Maybe<Challenge>;
-  reviewer?: Maybe<User>;
-  user?: Maybe<User>;
-  reviewerId?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['String']>;
-};
+  __typename?: 'Submission'
+  id?: Maybe<Scalars['String']>
+  status?: Maybe<Scalars['String']>
+  mrUrl?: Maybe<Scalars['String']>
+  diff?: Maybe<Scalars['String']>
+  viewCount?: Maybe<Scalars['Int']>
+  comment?: Maybe<Scalars['String']>
+  userId?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+  lessonId?: Maybe<Scalars['String']>
+  challengeId?: Maybe<Scalars['String']>
+  challenge?: Maybe<Challenge>
+  reviewer?: Maybe<User>
+  user?: Maybe<User>
+  reviewerId?: Maybe<Scalars['String']>
+  createdAt?: Maybe<Scalars['String']>
+  updatedAt?: Maybe<Scalars['String']>
+}
 
 export type SuccessResponse = {
-  __typename?: 'SuccessResponse';
-  success?: Maybe<Scalars['Boolean']>;
-};
+  __typename?: 'SuccessResponse'
+  success?: Maybe<Scalars['Boolean']>
+}
 
 export type TokenResponse = {
-  __typename?: 'TokenResponse';
-  success?: Maybe<Scalars['Boolean']>;
-  token?: Maybe<Scalars['String']>;
-};
-
+  __typename?: 'TokenResponse'
+  success?: Maybe<Scalars['Boolean']>
+  token?: Maybe<Scalars['String']>
+}
 
 export type User = {
-  __typename?: 'User';
-  id?: Maybe<Scalars['String']>;
-  username?: Maybe<Scalars['String']>;
-  userLesson?: Maybe<UserLesson>;
-  email?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  isAdmin?: Maybe<Scalars['String']>;
-  cliToken?: Maybe<Scalars['String']>;
-};
+  __typename?: 'User'
+  id?: Maybe<Scalars['String']>
+  username?: Maybe<Scalars['String']>
+  userLesson?: Maybe<UserLesson>
+  email?: Maybe<Scalars['String']>
+  name?: Maybe<Scalars['String']>
+  isAdmin?: Maybe<Scalars['String']>
+  cliToken?: Maybe<Scalars['String']>
+}
 
 export type UserLesson = {
-  __typename?: 'UserLesson';
-  id?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['String']>;
-  lessonId?: Maybe<Scalars['String']>;
-  isPassed?: Maybe<Scalars['String']>;
-  isTeaching?: Maybe<Scalars['String']>;
-  isEnrolled?: Maybe<Scalars['String']>;
-  starsReceived?: Maybe<Array<Maybe<Star>>>;
-};
+  __typename?: 'UserLesson'
+  id?: Maybe<Scalars['String']>
+  userId?: Maybe<Scalars['String']>
+  lessonId?: Maybe<Scalars['String']>
+  isPassed?: Maybe<Scalars['String']>
+  isTeaching?: Maybe<Scalars['String']>
+  isEnrolled?: Maybe<Scalars['String']>
+  starsReceived?: Maybe<Array<Maybe<Star>>>
+}
 
 export type AcceptSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String'];
-  comment: Scalars['String'];
-}>;
+  submissionId: Scalars['String']
+  comment: Scalars['String']
+}>
 
-
-export type AcceptSubmissionMutation = (
-  { __typename?: 'Mutation' }
-  & { acceptSubmission?: Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'comment' | 'status'>
-  )> }
-);
+export type AcceptSubmissionMutation = { __typename?: 'Mutation' } & {
+  acceptSubmission?: Maybe<
+    { __typename?: 'Submission' } & Pick<
+      Submission,
+      'id' | 'comment' | 'status'
+    >
+  >
+}
 
 export type AddAlertMutationVariables = Exact<{
-  text: Scalars['String'];
-  type: Scalars['String'];
-}>;
+  text: Scalars['String']
+  type: Scalars['String']
+}>
 
+export type AddAlertMutation = { __typename?: 'Mutation' } & {
+  addAlert?: Maybe<
+    { __typename?: 'SuccessResponse' } & Pick<SuccessResponse, 'success'>
+  >
+}
 
-export type AddAlertMutation = (
-  { __typename?: 'Mutation' }
-  & { addAlert?: Maybe<(
-    { __typename?: 'SuccessResponse' }
-    & Pick<SuccessResponse, 'success'>
-  )> }
-);
+export type UsersQueryVariables = Exact<{ [key: string]: never }>
+
+export type UsersQuery = { __typename?: 'Query' } & {
+  allUsers?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'User' } & Pick<
+          User,
+          'id' | 'username' | 'name' | 'isAdmin' | 'email' | 'cliToken'
+        >
+      >
+    >
+  >
+}
+
+export type ChangeAdminRightsMutationVariables = Exact<{
+  id: Scalars['Int']
+  status: Scalars['String']
+}>
+
+export type ChangeAdminRightsMutation = { __typename?: 'Mutation' } & {
+  changeAdminRights?: Maybe<
+    { __typename?: 'SuccessResponse' } & Pick<SuccessResponse, 'success'>
+  >
+}
 
 export type CreateChallengeMutationVariables = Exact<{
-  lessonId: Scalars['Int'];
-  order: Scalars['Int'];
-  description: Scalars['String'];
-  title: Scalars['String'];
-}>;
+  lessonId: Scalars['Int']
+  order: Scalars['Int']
+  description: Scalars['String']
+  title: Scalars['String']
+}>
 
-
-export type CreateChallengeMutation = (
-  { __typename?: 'Mutation' }
-  & { createChallenge?: Maybe<Array<Maybe<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'chatUrl' | 'order' | 'description' | 'title'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'description' | 'lessonId' | 'title' | 'order'>
-    )>>> }
-  )>>> }
-);
+export type CreateChallengeMutation = { __typename?: 'Mutation' } & {
+  createChallenge?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Lesson' } & Pick<
+          Lesson,
+          | 'id'
+          | 'docUrl'
+          | 'githubUrl'
+          | 'videoUrl'
+          | 'chatUrl'
+          | 'order'
+          | 'description'
+          | 'title'
+        > & {
+            challenges?: Maybe<
+              Array<
+                Maybe<
+                  { __typename?: 'Challenge' } & Pick<
+                    Challenge,
+                    'id' | 'description' | 'lessonId' | 'title' | 'order'
+                  >
+                >
+              >
+            >
+          }
+      >
+    >
+  >
+}
 
 export type CreateLessonMutationVariables = Exact<{
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  chatUrl?: Maybe<Scalars['String']>;
-  order: Scalars['Int'];
-  description: Scalars['String'];
-  title: Scalars['String'];
-}>;
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  chatUrl?: Maybe<Scalars['String']>
+  order: Scalars['Int']
+  description: Scalars['String']
+  title: Scalars['String']
+}>
 
+export type CreateLessonMutation = { __typename?: 'Mutation' } & {
+  createLesson?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Lesson' } & Pick<
+          Lesson,
+          | 'id'
+          | 'docUrl'
+          | 'githubUrl'
+          | 'videoUrl'
+          | 'chatUrl'
+          | 'order'
+          | 'description'
+          | 'title'
+        > & {
+            challenges?: Maybe<
+              Array<
+                Maybe<
+                  { __typename?: 'Challenge' } & Pick<
+                    Challenge,
+                    'id' | 'description' | 'lessonId' | 'title' | 'order'
+                  >
+                >
+              >
+            >
+          }
+      >
+    >
+  >
+}
 
-export type CreateLessonMutation = (
-  { __typename?: 'Mutation' }
-  & { createLesson?: Maybe<Array<Maybe<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'chatUrl' | 'order' | 'description' | 'title'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'description' | 'lessonId' | 'title' | 'order'>
-    )>>> }
-  )>>> }
-);
+export type GetAppQueryVariables = Exact<{ [key: string]: never }>
 
-export type GetAppQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetAppQuery = (
-  { __typename?: 'Query' }
-  & { lessons: Array<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
-    )>>> }
-  )>, session?: Maybe<(
-    { __typename?: 'Session' }
-    & { user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username' | 'name' | 'isAdmin'>
-    )>, submissions?: Maybe<Array<Maybe<(
-      { __typename?: 'Submission' }
-      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
-      & { reviewer?: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'username'>
-      )> }
-    )>>>, lessonStatus: Array<(
-      { __typename?: 'UserLesson' }
-      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
-    )> }
-  )>, alerts: Array<(
-    { __typename?: 'Alert' }
-    & Pick<Alert, 'id' | 'text' | 'type' | 'url' | 'urlCaption'>
-  )> }
-);
+export type GetAppQuery = { __typename?: 'Query' } & {
+  lessons: Array<
+    { __typename?: 'Lesson' } & Pick<
+      Lesson,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'docUrl'
+      | 'githubUrl'
+      | 'videoUrl'
+      | 'order'
+      | 'chatUrl'
+    > & {
+        challenges?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Challenge' } & Pick<
+                Challenge,
+                'id' | 'title' | 'description' | 'order'
+              >
+            >
+          >
+        >
+      }
+  >
+  session?: Maybe<
+    { __typename?: 'Session' } & {
+      user?: Maybe<
+        { __typename?: 'User' } & Pick<
+          User,
+          'id' | 'username' | 'name' | 'isAdmin'
+        >
+      >
+      submissions?: Maybe<
+        Array<
+          Maybe<
+            { __typename?: 'Submission' } & Pick<
+              Submission,
+              | 'id'
+              | 'status'
+              | 'mrUrl'
+              | 'diff'
+              | 'viewCount'
+              | 'comment'
+              | 'order'
+              | 'challengeId'
+              | 'lessonId'
+              | 'createdAt'
+              | 'updatedAt'
+            > & {
+                reviewer?: Maybe<
+                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+                >
+              }
+          >
+        >
+      >
+      lessonStatus: Array<
+        { __typename?: 'UserLesson' } & Pick<
+          UserLesson,
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
+        >
+      >
+    }
+  >
+  alerts: Array<
+    { __typename?: 'Alert' } & Pick<
+      Alert,
+      'id' | 'text' | 'type' | 'url' | 'urlCaption'
+    >
+  >
+}
 
 export type SubmissionsQueryVariables = Exact<{
-  lessonId: Scalars['String'];
-}>;
+  lessonId: Scalars['String']
+}>
 
-
-export type SubmissionsQuery = (
-  { __typename?: 'Query' }
-  & { submissions?: Maybe<Array<Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'status' | 'diff' | 'comment' | 'challengeId' | 'createdAt' | 'updatedAt'>
-    & { challenge?: Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'title'>
-    )>, user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username'>
-    )> }
-  )>>> }
-);
+export type SubmissionsQuery = { __typename?: 'Query' } & {
+  submissions?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Submission' } & Pick<
+          Submission,
+          | 'id'
+          | 'status'
+          | 'diff'
+          | 'comment'
+          | 'challengeId'
+          | 'createdAt'
+          | 'updatedAt'
+        > & {
+            challenge?: Maybe<
+              { __typename?: 'Challenge' } & Pick<Challenge, 'title'>
+            >
+            user?: Maybe<
+              { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+            >
+          }
+      >
+    >
+  >
+}
 
 export type LoginMutationVariables = Exact<{
-  username: Scalars['String'];
-  password: Scalars['String'];
-}>;
+  username: Scalars['String']
+  password: Scalars['String']
+}>
 
+export type LoginMutation = { __typename?: 'Mutation' } & {
+  login?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'cliToken' | 'error'
+    >
+  >
+}
 
-export type LoginMutation = (
-  { __typename?: 'Mutation' }
-  & { login?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'cliToken' | 'error'>
-  )> }
-);
+export type LogoutMutationVariables = Exact<{ [key: string]: never }>
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
-
-
-export type LogoutMutation = (
-  { __typename?: 'Mutation' }
-  & { logout?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'error'>
-  )> }
-);
+export type LogoutMutation = { __typename?: 'Mutation' } & {
+  logout?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'error'
+    >
+  >
+}
 
 export type RejectSubmissionMutationVariables = Exact<{
-  submissionId: Scalars['String'];
-  comment: Scalars['String'];
-}>;
+  submissionId: Scalars['String']
+  comment: Scalars['String']
+}>
 
-
-export type RejectSubmissionMutation = (
-  { __typename?: 'Mutation' }
-  & { rejectSubmission?: Maybe<(
-    { __typename?: 'Submission' }
-    & Pick<Submission, 'id' | 'comment' | 'status'>
-  )> }
-);
+export type RejectSubmissionMutation = { __typename?: 'Mutation' } & {
+  rejectSubmission?: Maybe<
+    { __typename?: 'Submission' } & Pick<
+      Submission,
+      'id' | 'comment' | 'status'
+    >
+  >
+}
 
 export type ReqPwResetMutationVariables = Exact<{
-  userOrEmail: Scalars['String'];
-}>;
+  userOrEmail: Scalars['String']
+}>
 
-
-export type ReqPwResetMutation = (
-  { __typename?: 'Mutation' }
-  & { reqPwReset?: Maybe<(
-    { __typename?: 'TokenResponse' }
-    & Pick<TokenResponse, 'success' | 'token'>
-  )> }
-);
+export type ReqPwResetMutation = { __typename?: 'Mutation' } & {
+  reqPwReset?: Maybe<
+    { __typename?: 'TokenResponse' } & Pick<TokenResponse, 'success' | 'token'>
+  >
+}
 
 export type SignupMutationVariables = Exact<{
-  firstName: Scalars['String'];
-  lastName: Scalars['String'];
-  email: Scalars['String'];
-  username: Scalars['String'];
-}>;
+  firstName: Scalars['String']
+  lastName: Scalars['String']
+  email: Scalars['String']
+  username: Scalars['String']
+}>
 
-
-export type SignupMutation = (
-  { __typename?: 'Mutation' }
-  & { signup?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success' | 'username' | 'error'>
-  )> }
-);
+export type SignupMutation = { __typename?: 'Mutation' } & {
+  signup?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<
+      AuthResponse,
+      'success' | 'username' | 'error'
+    >
+  >
+}
 
 export type UpdateChallengeMutationVariables = Exact<{
-  lessonId: Scalars['Int'];
-  order?: Maybe<Scalars['Int']>;
-  description?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  id: Scalars['Int'];
-}>;
+  lessonId: Scalars['Int']
+  order?: Maybe<Scalars['Int']>
+  description?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+  id: Scalars['Int']
+}>
 
-
-export type UpdateChallengeMutation = (
-  { __typename?: 'Mutation' }
-  & { updateChallenge?: Maybe<Array<Maybe<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'chatUrl' | 'order' | 'description' | 'title'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'description' | 'lessonId' | 'title' | 'order'>
-    )>>> }
-  )>>> }
-);
+export type UpdateChallengeMutation = { __typename?: 'Mutation' } & {
+  updateChallenge?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Lesson' } & Pick<
+          Lesson,
+          | 'id'
+          | 'docUrl'
+          | 'githubUrl'
+          | 'videoUrl'
+          | 'chatUrl'
+          | 'order'
+          | 'description'
+          | 'title'
+        > & {
+            challenges?: Maybe<
+              Array<
+                Maybe<
+                  { __typename?: 'Challenge' } & Pick<
+                    Challenge,
+                    'id' | 'description' | 'lessonId' | 'title' | 'order'
+                  >
+                >
+              >
+            >
+          }
+      >
+    >
+  >
+}
 
 export type UpdateLessonMutationVariables = Exact<{
-  id: Scalars['Int'];
-  docUrl?: Maybe<Scalars['String']>;
-  githubUrl?: Maybe<Scalars['String']>;
-  videoUrl?: Maybe<Scalars['String']>;
-  chatUrl?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  description?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-}>;
+  id: Scalars['Int']
+  docUrl?: Maybe<Scalars['String']>
+  githubUrl?: Maybe<Scalars['String']>
+  videoUrl?: Maybe<Scalars['String']>
+  chatUrl?: Maybe<Scalars['String']>
+  order?: Maybe<Scalars['Int']>
+  description?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+}>
 
-
-export type UpdateLessonMutation = (
-  { __typename?: 'Mutation' }
-  & { updateLesson?: Maybe<Array<Maybe<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'chatUrl' | 'order' | 'description' | 'title'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'description' | 'lessonId' | 'title' | 'order'>
-    )>>> }
-  )>>> }
-);
+export type UpdateLessonMutation = { __typename?: 'Mutation' } & {
+  updateLesson?: Maybe<
+    Array<
+      Maybe<
+        { __typename?: 'Lesson' } & Pick<
+          Lesson,
+          | 'id'
+          | 'docUrl'
+          | 'githubUrl'
+          | 'videoUrl'
+          | 'chatUrl'
+          | 'order'
+          | 'description'
+          | 'title'
+        > & {
+            challenges?: Maybe<
+              Array<
+                Maybe<
+                  { __typename?: 'Challenge' } & Pick<
+                    Challenge,
+                    'id' | 'description' | 'lessonId' | 'title' | 'order'
+                  >
+                >
+              >
+            >
+          }
+      >
+    >
+  >
+}
 
 export type ChangePwMutationVariables = Exact<{
-  token: Scalars['String'];
-  password: Scalars['String'];
-}>;
+  token: Scalars['String']
+  password: Scalars['String']
+}>
 
-
-export type ChangePwMutation = (
-  { __typename?: 'Mutation' }
-  & { changePw?: Maybe<(
-    { __typename?: 'AuthResponse' }
-    & Pick<AuthResponse, 'success'>
-  )> }
-);
+export type ChangePwMutation = { __typename?: 'Mutation' } & {
+  changePw?: Maybe<
+    { __typename?: 'AuthResponse' } & Pick<AuthResponse, 'success'>
+  >
+}
 
 export type UserInfoQueryVariables = Exact<{
-  username: Scalars['String'];
-}>;
+  username: Scalars['String']
+}>
 
+export type UserInfoQuery = { __typename?: 'Query' } & {
+  lessons: Array<
+    { __typename?: 'Lesson' } & Pick<
+      Lesson,
+      | 'id'
+      | 'title'
+      | 'description'
+      | 'docUrl'
+      | 'githubUrl'
+      | 'videoUrl'
+      | 'order'
+      | 'chatUrl'
+    > & {
+        challenges?: Maybe<
+          Array<
+            Maybe<
+              { __typename?: 'Challenge' } & Pick<
+                Challenge,
+                'id' | 'title' | 'description' | 'order'
+              >
+            >
+          >
+        >
+      }
+  >
+  userInfo?: Maybe<
+    { __typename?: 'Session' } & {
+      user?: Maybe<
+        { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
+      >
+      submissions?: Maybe<
+        Array<
+          Maybe<
+            { __typename?: 'Submission' } & Pick<
+              Submission,
+              | 'id'
+              | 'status'
+              | 'mrUrl'
+              | 'diff'
+              | 'viewCount'
+              | 'comment'
+              | 'order'
+              | 'challengeId'
+              | 'lessonId'
+              | 'createdAt'
+              | 'updatedAt'
+            > & {
+                reviewer?: Maybe<
+                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+                >
+              }
+          >
+        >
+      >
+      lessonStatus: Array<
+        { __typename?: 'UserLesson' } & Pick<
+          UserLesson,
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
+        > & {
+            starsReceived?: Maybe<
+              Array<
+                Maybe<
+                  { __typename?: 'Star' } & Pick<Star, 'lessonId' | 'comment'>
+                >
+              >
+            >
+          }
+      >
+    }
+  >
+}
 
-export type UserInfoQuery = (
-  { __typename?: 'Query' }
-  & { lessons: Array<(
-    { __typename?: 'Lesson' }
-    & Pick<Lesson, 'id' | 'title' | 'description' | 'docUrl' | 'githubUrl' | 'videoUrl' | 'order' | 'chatUrl'>
-    & { challenges?: Maybe<Array<Maybe<(
-      { __typename?: 'Challenge' }
-      & Pick<Challenge, 'id' | 'title' | 'description' | 'order'>
-    )>>> }
-  )>, userInfo?: Maybe<(
-    { __typename?: 'Session' }
-    & { user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'username' | 'name'>
-    )>, submissions?: Maybe<Array<Maybe<(
-      { __typename?: 'Submission' }
-      & Pick<Submission, 'id' | 'status' | 'mrUrl' | 'diff' | 'viewCount' | 'comment' | 'order' | 'challengeId' | 'lessonId' | 'createdAt' | 'updatedAt'>
-      & { reviewer?: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'username'>
-      )> }
-    )>>>, lessonStatus: Array<(
-      { __typename?: 'UserLesson' }
-      & Pick<UserLesson, 'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'>
-      & { starsReceived?: Maybe<Array<Maybe<(
-        { __typename?: 'Star' }
-        & Pick<Star, 'lessonId' | 'comment'>
-      )>>> }
-    )> }
-  )> }
-);
-
-
-
-export type ResolverTypeWrapper<T> = Promise<T> | T;
-
+export type ResolverTypeWrapper<T> = Promise<T> | T
 
 export type LegacyStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  fragment: string;
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-};
+  fragment: string
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
+}
 
 export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
-  selectionSet: string;
-  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
-};
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+  selectionSet: string
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>
+}
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
-  | StitchingResolver<TResult, TParent, TContext, TArgs>;
+  | StitchingResolver<TResult, TParent, TContext, TArgs>
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => Promise<TResult> | TResult;
+) => Promise<TResult> | TResult
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult>
 
-export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
-  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+export interface SubscriptionSubscriberObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> {
+  subscribe: SubscriptionSubscribeFn<
+    { [key in TKey]: TResult },
+    TParent,
+    TContext,
+    TArgs
+  >
+  resolve?: SubscriptionResolveFn<
+    TResult,
+    { [key in TKey]: TResult },
+    TContext,
+    TArgs
+  >
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
-  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
-  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>
 }
 
-export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+export type SubscriptionObject<
+  TResult,
+  TKey extends string,
+  TParent,
+  TContext,
+  TArgs
+> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
-  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
-  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
-  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> =
+  | ((
+      ...args: any[]
+    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
   info: GraphQLResolveInfo
-) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>
 
-export type IsTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}> = (
+  obj: T,
+  info: GraphQLResolveInfo
+) => boolean | Promise<boolean>
 
-export type NextResolverFn<T> = () => Promise<T>;
+export type NextResolverFn<T> = () => Promise<T>
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = {},
+  TParent = {},
+  TContext = {},
+  TArgs = {}
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo
-) => TResult | Promise<TResult>;
+) => TResult | Promise<TResult>
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Query: ResolverTypeWrapper<{}>;
-  Lesson: ResolverTypeWrapper<Lesson>;
-  String: ResolverTypeWrapper<Scalars['String']>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
-  Challenge: ResolverTypeWrapper<Challenge>;
-  User: ResolverTypeWrapper<User>;
-  UserLesson: ResolverTypeWrapper<UserLesson>;
-  Star: ResolverTypeWrapper<Star>;
-  Session: ResolverTypeWrapper<Session>;
-  Submission: ResolverTypeWrapper<Submission>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  Alert: ResolverTypeWrapper<Alert>;
-  Mutation: ResolverTypeWrapper<{}>;
-  AuthResponse: ResolverTypeWrapper<AuthResponse>;
-  TokenResponse: ResolverTypeWrapper<TokenResponse>;
-  SuccessResponse: ResolverTypeWrapper<SuccessResponse>;
-  CacheControlScope: CacheControlScope;
-  Upload: ResolverTypeWrapper<Scalars['Upload']>;
-};
+  Query: ResolverTypeWrapper<{}>
+  Lesson: ResolverTypeWrapper<Lesson>
+  String: ResolverTypeWrapper<Scalars['String']>
+  Int: ResolverTypeWrapper<Scalars['Int']>
+  Challenge: ResolverTypeWrapper<Challenge>
+  User: ResolverTypeWrapper<User>
+  UserLesson: ResolverTypeWrapper<UserLesson>
+  Star: ResolverTypeWrapper<Star>
+  Session: ResolverTypeWrapper<Session>
+  Submission: ResolverTypeWrapper<Submission>
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>
+  Alert: ResolverTypeWrapper<Alert>
+  Mutation: ResolverTypeWrapper<{}>
+  AuthResponse: ResolverTypeWrapper<AuthResponse>
+  TokenResponse: ResolverTypeWrapper<TokenResponse>
+  SuccessResponse: ResolverTypeWrapper<SuccessResponse>
+  CacheControlScope: CacheControlScope
+  Upload: ResolverTypeWrapper<Scalars['Upload']>
+}
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Query: {};
-  Lesson: Lesson;
-  String: Scalars['String'];
-  Int: Scalars['Int'];
-  Challenge: Challenge;
-  User: User;
-  UserLesson: UserLesson;
-  Star: Star;
-  Session: Session;
-  Submission: Submission;
-  Boolean: Scalars['Boolean'];
-  Alert: Alert;
-  Mutation: {};
-  AuthResponse: AuthResponse;
-  TokenResponse: TokenResponse;
-  SuccessResponse: SuccessResponse;
-  Upload: Scalars['Upload'];
-};
-
-export type AlertResolvers<ContextType = any, ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']> = {
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  urlCaption?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type AuthResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type ChallengeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type LessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challenges?: Resolver<Maybe<Array<Maybe<ResolversTypes['Challenge']>>>, ParentType, ContextType>;
-  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
-  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
-  login?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationLoginArgs, 'username' | 'password'>>;
-  logout?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType>;
-  reqPwReset?: Resolver<Maybe<ResolversTypes['TokenResponse']>, ParentType, ContextType, RequireFields<MutationReqPwResetArgs, 'userOrEmail'>>;
-  changePw?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationChangePwArgs, 'token' | 'password'>>;
-  changeAdminRights?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationChangeAdminRightsArgs, 'id' | 'status'>>;
-  signup?: Resolver<Maybe<ResolversTypes['AuthResponse']>, ParentType, ContextType, RequireFields<MutationSignupArgs, 'firstName' | 'lastName' | 'email' | 'username'>>;
-  addAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationAddAlertArgs, 'text' | 'type'>>;
-  removeAlert?: Resolver<Maybe<ResolversTypes['SuccessResponse']>, ParentType, ContextType, RequireFields<MutationRemoveAlertArgs, 'id'>>;
-  createSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationCreateSubmissionArgs, 'lessonId' | 'challengeId' | 'cliToken' | 'diff'>>;
-  acceptSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>>;
-  rejectSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>>;
-  createLesson?: Resolver<Maybe<Array<Maybe<ResolversTypes['Lesson']>>>, ParentType, ContextType, RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>>;
-  updateLesson?: Resolver<Maybe<Array<Maybe<ResolversTypes['Lesson']>>>, ParentType, ContextType, RequireFields<MutationUpdateLessonArgs, 'id'>>;
-  createChallenge?: Resolver<Maybe<Array<Maybe<ResolversTypes['Lesson']>>>, ParentType, ContextType, RequireFields<MutationCreateChallengeArgs, 'lessonId' | 'order' | 'description' | 'title'>>;
-  updateChallenge?: Resolver<Maybe<Array<Maybe<ResolversTypes['Lesson']>>>, ParentType, ContextType, RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id'>>;
-};
-
-export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>;
-  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>;
-  allUsers?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
-  userInfo?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType, RequireFields<QueryUserInfoArgs, 'username'>>;
-  isTokenValid?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<QueryIsTokenValidArgs, 'cliToken'>>;
-  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType, RequireFields<QuerySubmissionsArgs, 'lessonId'>>;
-  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>;
-};
-
-export type SessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']> = {
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType>;
-  lessonStatus?: Resolver<Array<ResolversTypes['UserLesson']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type StarResolvers<ContextType = any, ParentType extends ResolversParentTypes['Star'] = ResolversParentTypes['Star']> = {
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  studentId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  mentorId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challengeId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  challenge?: Resolver<Maybe<ResolversTypes['Challenge']>, ParentType, ContextType>;
-  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  reviewerId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type SuccessResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export type TokenResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']> = {
-  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
-
-export interface UploadScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
-  name: 'Upload';
+  Query: {}
+  Lesson: Lesson
+  String: Scalars['String']
+  Int: Scalars['Int']
+  Challenge: Challenge
+  User: User
+  UserLesson: UserLesson
+  Star: Star
+  Session: Session
+  Submission: Submission
+  Boolean: Scalars['Boolean']
+  Alert: Alert
+  Mutation: {}
+  AuthResponse: AuthResponse
+  TokenResponse: TokenResponse
+  SuccessResponse: SuccessResponse
+  Upload: Scalars['Upload']
 }
 
-export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userLesson?: Resolver<Maybe<ResolversTypes['UserLesson']>, ParentType, ContextType>;
-  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
+export type AlertResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']
+> = {
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  urlCaption?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
 
-export type UserLessonResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']> = {
-  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isTeaching?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  isEnrolled?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  starsReceived?: Resolver<Maybe<Array<Maybe<ResolversTypes['Star']>>>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>;
-};
+export type AuthResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['AuthResponse'] = ResolversParentTypes['AuthResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type ChallengeResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Challenge'] = ResolversParentTypes['Challenge']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  description?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type LessonResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Lesson'] = ResolversParentTypes['Lesson']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  description?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  challenges?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Challenge']>>>,
+    ParentType,
+    ContextType
+  >
+  users?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['User']>>>,
+    ParentType,
+    ContextType
+  >
+  currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type MutationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
+> = {
+  login?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationLoginArgs, 'username' | 'password'>
+  >
+  logout?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType
+  >
+  reqPwReset?: Resolver<
+    Maybe<ResolversTypes['TokenResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationReqPwResetArgs, 'userOrEmail'>
+  >
+  changePw?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationChangePwArgs, 'token' | 'password'>
+  >
+  changeAdminRights?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationChangeAdminRightsArgs, 'id' | 'status'>
+  >
+  signup?: Resolver<
+    Maybe<ResolversTypes['AuthResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationSignupArgs,
+      'firstName' | 'lastName' | 'email' | 'username'
+    >
+  >
+  addAlert?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationAddAlertArgs, 'text' | 'type'>
+  >
+  removeAlert?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationRemoveAlertArgs, 'id'>
+  >
+  createSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationCreateSubmissionArgs,
+      'lessonId' | 'challengeId' | 'cliToken' | 'diff'
+    >
+  >
+  acceptSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationAcceptSubmissionArgs, 'id' | 'comment'>
+  >
+  rejectSubmission?: Resolver<
+    Maybe<ResolversTypes['Submission']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationRejectSubmissionArgs, 'id' | 'comment'>
+  >
+  createLesson?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>
+  >
+  updateLesson?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateLessonArgs, 'id'>
+  >
+  createChallenge?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationCreateChallengeArgs,
+      'lessonId' | 'order' | 'description' | 'title'
+    >
+  >
+  updateChallenge?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id'>
+  >
+}
+
+export type QueryResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
+> = {
+  lessons?: Resolver<Array<ResolversTypes['Lesson']>, ParentType, ContextType>
+  session?: Resolver<Maybe<ResolversTypes['Session']>, ParentType, ContextType>
+  allUsers?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['User']>>>,
+    ParentType,
+    ContextType
+  >
+  userInfo?: Resolver<
+    Maybe<ResolversTypes['Session']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryUserInfoArgs, 'username'>
+  >
+  isTokenValid?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryIsTokenValidArgs, 'cliToken'>
+  >
+  submissions?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySubmissionsArgs, 'lessonId'>
+  >
+  alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>
+}
+
+export type SessionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Session'] = ResolversParentTypes['Session']
+> = {
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  submissions?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Submission']>>>,
+    ParentType,
+    ContextType
+  >
+  lessonStatus?: Resolver<
+    Array<ResolversTypes['UserLesson']>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type StarResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Star'] = ResolversParentTypes['Star']
+> = {
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  studentId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  mentorId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  lessonId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type SubmissionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  challengeId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  challenge?: Resolver<
+    Maybe<ResolversTypes['Challenge']>,
+    ParentType,
+    ContextType
+  >
+  reviewer?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  reviewerId?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type SuccessResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type TokenResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['TokenResponse'] = ResolversParentTypes['TokenResponse']
+> = {
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export interface UploadScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
+  name: 'Upload'
+}
+
+export type UserResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userLesson?: Resolver<
+    Maybe<ResolversTypes['UserLesson']>,
+    ParentType,
+    ContextType
+  >
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type UserLessonResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UserLesson'] = ResolversParentTypes['UserLesson']
+> = {
+  id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  userId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isPassed?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isTeaching?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  isEnrolled?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >
+  starsReceived?: Resolver<
+    Maybe<Array<Maybe<ResolversTypes['Star']>>>,
+    ParentType,
+    ContextType
+  >
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
 
 export type Resolvers<ContextType = any> = {
-  Alert?: AlertResolvers<ContextType>;
-  AuthResponse?: AuthResponseResolvers<ContextType>;
-  Challenge?: ChallengeResolvers<ContextType>;
-  Lesson?: LessonResolvers<ContextType>;
-  Mutation?: MutationResolvers<ContextType>;
-  Query?: QueryResolvers<ContextType>;
-  Session?: SessionResolvers<ContextType>;
-  Star?: StarResolvers<ContextType>;
-  Submission?: SubmissionResolvers<ContextType>;
-  SuccessResponse?: SuccessResponseResolvers<ContextType>;
-  TokenResponse?: TokenResponseResolvers<ContextType>;
-  Upload?: GraphQLScalarType;
-  User?: UserResolvers<ContextType>;
-  UserLesson?: UserLessonResolvers<ContextType>;
-};
-
+  Alert?: AlertResolvers<ContextType>
+  AuthResponse?: AuthResponseResolvers<ContextType>
+  Challenge?: ChallengeResolvers<ContextType>
+  Lesson?: LessonResolvers<ContextType>
+  Mutation?: MutationResolvers<ContextType>
+  Query?: QueryResolvers<ContextType>
+  Session?: SessionResolvers<ContextType>
+  Star?: StarResolvers<ContextType>
+  Submission?: SubmissionResolvers<ContextType>
+  SuccessResponse?: SuccessResponseResolvers<ContextType>
+  TokenResponse?: TokenResponseResolvers<ContextType>
+  Upload?: GraphQLScalarType
+  User?: UserResolvers<ContextType>
+  UserLesson?: UserLessonResolvers<ContextType>
+}
 
 /**
  * @deprecated
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
  */
-export type IResolvers<ContextType = any> = Resolvers<ContextType>;
-
+export type IResolvers<ContextType = any> = Resolvers<ContextType>
 
 export const AcceptSubmissionDocument = gql`
-    mutation acceptSubmission($submissionId: String!, $comment: String!) {
-  acceptSubmission(id: $submissionId, comment: $comment) {
-    id
-    comment
-    status
+  mutation acceptSubmission($submissionId: String!, $comment: String!) {
+    acceptSubmission(id: $submissionId, comment: $comment) {
+      id
+      comment
+      status
+    }
   }
-}
-    `;
-export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
-export type AcceptSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>, 'mutation'>;
-
-    export const AcceptSubmissionComponent = (props: AcceptSubmissionComponentProps) => (
-      <ApolloReactComponents.Mutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables> mutation={AcceptSubmissionDocument} {...props} />
-    );
-    
-export type AcceptSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>
-    } & TChildProps;
-export function withAcceptSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+`
+export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<
   AcceptSubmissionMutation,
-  AcceptSubmissionMutationVariables,
-  AcceptSubmissionProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, AcceptSubmissionMutation, AcceptSubmissionMutationVariables, AcceptSubmissionProps<TChildProps, TDataName>>(AcceptSubmissionDocument, {
-      alias: 'acceptSubmission',
-      ...operationOptions
-    });
-};
+  AcceptSubmissionMutationVariables
+>
+export type AcceptSubmissionComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >,
+  'mutation'
+>
+
+export const AcceptSubmissionComponent = (
+  props: AcceptSubmissionComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+    mutation={AcceptSubmissionDocument}
+    {...props}
+  />
+)
+
+export type AcceptSubmissionProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+} &
+  TChildProps
+export function withAcceptSubmission<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables,
+    AcceptSubmissionProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables,
+    AcceptSubmissionProps<TChildProps, TDataName>
+  >(AcceptSubmissionDocument, {
+    alias: 'acceptSubmission',
+    ...operationOptions
+  })
+}
 
 /**
  * __useAcceptSubmissionMutation__
@@ -909,39 +1346,85 @@ export function withAcceptSubmission<TProps, TChildProps = {}, TDataName extends
  *   },
  * });
  */
-export function useAcceptSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>) {
-        return ApolloReactHooks.useMutation<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>(AcceptSubmissionDocument, baseOptions);
-      }
-export type AcceptSubmissionMutationHookResult = ReturnType<typeof useAcceptSubmissionMutation>;
-export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<AcceptSubmissionMutation>;
-export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<AcceptSubmissionMutation, AcceptSubmissionMutationVariables>;
-export const AddAlertDocument = gql`
-    mutation addAlert($text: String!, $type: String!) {
-  addAlert(text: $text, type: $type) {
-    success
-  }
+export function useAcceptSubmissionMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    AcceptSubmissionMutation,
+    AcceptSubmissionMutationVariables
+  >(AcceptSubmissionDocument, baseOptions)
 }
-    `;
-export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>;
-export type AddAlertComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<AddAlertMutation, AddAlertMutationVariables>, 'mutation'>;
-
-    export const AddAlertComponent = (props: AddAlertComponentProps) => (
-      <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables> mutation={AddAlertDocument} {...props} />
-    );
-    
-export type AddAlertProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<AddAlertMutation, AddAlertMutationVariables>
-    } & TChildProps;
-export function withAddAlert<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type AcceptSubmissionMutationHookResult = ReturnType<
+  typeof useAcceptSubmissionMutation
+>
+export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<
+  AcceptSubmissionMutation
+>
+export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  AcceptSubmissionMutation,
+  AcceptSubmissionMutationVariables
+>
+export const AddAlertDocument = gql`
+  mutation addAlert($text: String!, $type: String!) {
+    addAlert(text: $text, type: $type) {
+      success
+    }
+  }
+`
+export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<
   AddAlertMutation,
-  AddAlertMutationVariables,
-  AddAlertProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, AddAlertMutation, AddAlertMutationVariables, AddAlertProps<TChildProps, TDataName>>(AddAlertDocument, {
-      alias: 'addAlert',
-      ...operationOptions
-    });
-};
+  AddAlertMutationVariables
+>
+export type AddAlertComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >,
+  'mutation'
+>
+
+export const AddAlertComponent = (props: AddAlertComponentProps) => (
+  <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables>
+    mutation={AddAlertDocument}
+    {...props}
+  />
+)
+
+export type AddAlertProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >
+} &
+  TChildProps
+export function withAddAlert<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    AddAlertMutation,
+    AddAlertMutationVariables,
+    AddAlertProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    AddAlertMutation,
+    AddAlertMutationVariables,
+    AddAlertProps<TChildProps, TDataName>
+  >(AddAlertDocument, {
+    alias: 'addAlert',
+    ...operationOptions
+  })
+}
 
 /**
  * __useAddAlertMutation__
@@ -961,53 +1444,309 @@ export function withAddAlert<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useAddAlertMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AddAlertMutation, AddAlertMutationVariables>) {
-        return ApolloReactHooks.useMutation<AddAlertMutation, AddAlertMutationVariables>(AddAlertDocument, baseOptions);
-      }
-export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>;
-export type AddAlertMutationResult = ApolloReactCommon.MutationResult<AddAlertMutation>;
-export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<AddAlertMutation, AddAlertMutationVariables>;
-export const CreateChallengeDocument = gql`
-    mutation createChallenge($lessonId: Int!, $order: Int!, $description: String!, $title: String!) {
-  createChallenge(lessonId: $lessonId, order: $order, description: $description, title: $title) {
-    id
-    docUrl
-    githubUrl
-    videoUrl
-    chatUrl
-    order
-    description
-    title
-    challenges {
+export function useAddAlertMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    AddAlertMutation,
+    AddAlertMutationVariables
+  >(AddAlertDocument, baseOptions)
+}
+export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>
+export type AddAlertMutationResult = ApolloReactCommon.MutationResult<
+  AddAlertMutation
+>
+export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  AddAlertMutation,
+  AddAlertMutationVariables
+>
+export const UsersDocument = gql`
+  query users {
+    allUsers {
       id
-      description
-      lessonId
-      title
-      order
+      username
+      name
+      isAdmin
+      email
+      cliToken
     }
   }
-}
-    `;
-export type CreateChallengeMutationFn = ApolloReactCommon.MutationFunction<CreateChallengeMutation, CreateChallengeMutationVariables>;
-export type CreateChallengeComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<CreateChallengeMutation, CreateChallengeMutationVariables>, 'mutation'>;
+`
+export type UsersComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<UsersQuery, UsersQueryVariables>,
+  'query'
+>
 
-    export const CreateChallengeComponent = (props: CreateChallengeComponentProps) => (
-      <ApolloReactComponents.Mutation<CreateChallengeMutation, CreateChallengeMutationVariables> mutation={CreateChallengeDocument} {...props} />
-    );
-    
-export type CreateChallengeProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<CreateChallengeMutation, CreateChallengeMutationVariables>
-    } & TChildProps;
-export function withCreateChallenge<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
+export const UsersComponent = (props: UsersComponentProps) => (
+  <ApolloReactComponents.Query<UsersQuery, UsersQueryVariables>
+    query={UsersDocument}
+    {...props}
+  />
+)
+
+export type UsersProps<TChildProps = {}, TDataName extends string = 'data'> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<UsersQuery, UsersQueryVariables>
+} &
+  TChildProps
+export function withUsers<
   TProps,
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UsersQuery,
+    UsersQueryVariables,
+    UsersProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    UsersQuery,
+    UsersQueryVariables,
+    UsersProps<TChildProps, TDataName>
+  >(UsersDocument, {
+    alias: 'users',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useUsersQuery__
+ *
+ * To run a query within a React component, call `useUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useUsersQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useUsersQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    UsersQuery,
+    UsersQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<UsersQuery, UsersQueryVariables>(
+    UsersDocument,
+    baseOptions
+  )
+}
+export function useUsersLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    UsersQuery,
+    UsersQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<UsersQuery, UsersQueryVariables>(
+    UsersDocument,
+    baseOptions
+  )
+}
+export type UsersQueryHookResult = ReturnType<typeof useUsersQuery>
+export type UsersLazyQueryHookResult = ReturnType<typeof useUsersLazyQuery>
+export type UsersQueryResult = ApolloReactCommon.QueryResult<
+  UsersQuery,
+  UsersQueryVariables
+>
+export const ChangeAdminRightsDocument = gql`
+  mutation changeAdminRights($id: Int!, $status: String!) {
+    changeAdminRights(id: $id, status: $status) {
+      success
+    }
+  }
+`
+export type ChangeAdminRightsMutationFn = ApolloReactCommon.MutationFunction<
+  ChangeAdminRightsMutation,
+  ChangeAdminRightsMutationVariables
+>
+export type ChangeAdminRightsComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    ChangeAdminRightsMutation,
+    ChangeAdminRightsMutationVariables
+  >,
+  'mutation'
+>
+
+export const ChangeAdminRightsComponent = (
+  props: ChangeAdminRightsComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    ChangeAdminRightsMutation,
+    ChangeAdminRightsMutationVariables
+  >
+    mutation={ChangeAdminRightsDocument}
+    {...props}
+  />
+)
+
+export type ChangeAdminRightsProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    ChangeAdminRightsMutation,
+    ChangeAdminRightsMutationVariables
+  >
+} &
+  TChildProps
+export function withChangeAdminRights<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    ChangeAdminRightsMutation,
+    ChangeAdminRightsMutationVariables,
+    ChangeAdminRightsProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    ChangeAdminRightsMutation,
+    ChangeAdminRightsMutationVariables,
+    ChangeAdminRightsProps<TChildProps, TDataName>
+  >(ChangeAdminRightsDocument, {
+    alias: 'changeAdminRights',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useChangeAdminRightsMutation__
+ *
+ * To run a mutation, you first call `useChangeAdminRightsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useChangeAdminRightsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [changeAdminRightsMutation, { data, loading, error }] = useChangeAdminRightsMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      status: // value for 'status'
+ *   },
+ * });
+ */
+export function useChangeAdminRightsMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    ChangeAdminRightsMutation,
+    ChangeAdminRightsMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    ChangeAdminRightsMutation,
+    ChangeAdminRightsMutationVariables
+  >(ChangeAdminRightsDocument, baseOptions)
+}
+export type ChangeAdminRightsMutationHookResult = ReturnType<
+  typeof useChangeAdminRightsMutation
+>
+export type ChangeAdminRightsMutationResult = ApolloReactCommon.MutationResult<
+  ChangeAdminRightsMutation
+>
+export type ChangeAdminRightsMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  ChangeAdminRightsMutation,
+  ChangeAdminRightsMutationVariables
+>
+export const CreateChallengeDocument = gql`
+  mutation createChallenge(
+    $lessonId: Int!
+    $order: Int!
+    $description: String!
+    $title: String!
+  ) {
+    createChallenge(
+      lessonId: $lessonId
+      order: $order
+      description: $description
+      title: $title
+    ) {
+      id
+      docUrl
+      githubUrl
+      videoUrl
+      chatUrl
+      order
+      description
+      title
+      challenges {
+        id
+        description
+        lessonId
+        title
+        order
+      }
+    }
+  }
+`
+export type CreateChallengeMutationFn = ApolloReactCommon.MutationFunction<
   CreateChallengeMutation,
-  CreateChallengeMutationVariables,
-  CreateChallengeProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, CreateChallengeMutation, CreateChallengeMutationVariables, CreateChallengeProps<TChildProps, TDataName>>(CreateChallengeDocument, {
-      alias: 'createChallenge',
-      ...operationOptions
-    });
-};
+  CreateChallengeMutationVariables
+>
+export type CreateChallengeComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >,
+  'mutation'
+>
+
+export const CreateChallengeComponent = (
+  props: CreateChallengeComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >
+    mutation={CreateChallengeDocument}
+    {...props}
+  />
+)
+
+export type CreateChallengeProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >
+} &
+  TChildProps
+export function withCreateChallenge<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables,
+    CreateChallengeProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables,
+    CreateChallengeProps<TChildProps, TDataName>
+  >(CreateChallengeDocument, {
+    alias: 'createChallenge',
+    ...operationOptions
+  })
+}
 
 /**
  * __useCreateChallengeMutation__
@@ -1029,53 +1768,118 @@ export function withCreateChallenge<TProps, TChildProps = {}, TDataName extends 
  *   },
  * });
  */
-export function useCreateChallengeMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateChallengeMutation, CreateChallengeMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateChallengeMutation, CreateChallengeMutationVariables>(CreateChallengeDocument, baseOptions);
-      }
-export type CreateChallengeMutationHookResult = ReturnType<typeof useCreateChallengeMutation>;
-export type CreateChallengeMutationResult = ApolloReactCommon.MutationResult<CreateChallengeMutation>;
-export type CreateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateChallengeMutation, CreateChallengeMutationVariables>;
+export function useCreateChallengeMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    CreateChallengeMutation,
+    CreateChallengeMutationVariables
+  >(CreateChallengeDocument, baseOptions)
+}
+export type CreateChallengeMutationHookResult = ReturnType<
+  typeof useCreateChallengeMutation
+>
+export type CreateChallengeMutationResult = ApolloReactCommon.MutationResult<
+  CreateChallengeMutation
+>
+export type CreateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  CreateChallengeMutation,
+  CreateChallengeMutationVariables
+>
 export const CreateLessonDocument = gql`
-    mutation createLesson($docUrl: String, $githubUrl: String, $videoUrl: String, $chatUrl: String, $order: Int!, $description: String!, $title: String!) {
-  createLesson(docUrl: $docUrl, githubUrl: $githubUrl, videoUrl: $videoUrl, chatUrl: $chatUrl, order: $order, description: $description, title: $title) {
-    id
-    docUrl
-    githubUrl
-    videoUrl
-    chatUrl
-    order
-    description
-    title
-    challenges {
+  mutation createLesson(
+    $docUrl: String
+    $githubUrl: String
+    $videoUrl: String
+    $chatUrl: String
+    $order: Int!
+    $description: String!
+    $title: String!
+  ) {
+    createLesson(
+      docUrl: $docUrl
+      githubUrl: $githubUrl
+      videoUrl: $videoUrl
+      chatUrl: $chatUrl
+      order: $order
+      description: $description
+      title: $title
+    ) {
       id
-      description
-      lessonId
-      title
+      docUrl
+      githubUrl
+      videoUrl
+      chatUrl
       order
+      description
+      title
+      challenges {
+        id
+        description
+        lessonId
+        title
+        order
+      }
     }
   }
-}
-    `;
-export type CreateLessonMutationFn = ApolloReactCommon.MutationFunction<CreateLessonMutation, CreateLessonMutationVariables>;
-export type CreateLessonComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<CreateLessonMutation, CreateLessonMutationVariables>, 'mutation'>;
-
-    export const CreateLessonComponent = (props: CreateLessonComponentProps) => (
-      <ApolloReactComponents.Mutation<CreateLessonMutation, CreateLessonMutationVariables> mutation={CreateLessonDocument} {...props} />
-    );
-    
-export type CreateLessonProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<CreateLessonMutation, CreateLessonMutationVariables>
-    } & TChildProps;
-export function withCreateLesson<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+`
+export type CreateLessonMutationFn = ApolloReactCommon.MutationFunction<
   CreateLessonMutation,
-  CreateLessonMutationVariables,
-  CreateLessonProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, CreateLessonMutation, CreateLessonMutationVariables, CreateLessonProps<TChildProps, TDataName>>(CreateLessonDocument, {
-      alias: 'createLesson',
-      ...operationOptions
-    });
-};
+  CreateLessonMutationVariables
+>
+export type CreateLessonComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    CreateLessonMutation,
+    CreateLessonMutationVariables
+  >,
+  'mutation'
+>
+
+export const CreateLessonComponent = (props: CreateLessonComponentProps) => (
+  <ApolloReactComponents.Mutation<
+    CreateLessonMutation,
+    CreateLessonMutationVariables
+  >
+    mutation={CreateLessonDocument}
+    {...props}
+  />
+)
+
+export type CreateLessonProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    CreateLessonMutation,
+    CreateLessonMutationVariables
+  >
+} &
+  TChildProps
+export function withCreateLesson<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    CreateLessonMutation,
+    CreateLessonMutationVariables,
+    CreateLessonProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    CreateLessonMutation,
+    CreateLessonMutationVariables,
+    CreateLessonProps<TChildProps, TDataName>
+  >(CreateLessonDocument, {
+    alias: 'createLesson',
+    ...operationOptions
+  })
+}
 
 /**
  * __useCreateLessonMutation__
@@ -1100,89 +1904,129 @@ export function withCreateLesson<TProps, TChildProps = {}, TDataName extends str
  *   },
  * });
  */
-export function useCreateLessonMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateLessonMutation, CreateLessonMutationVariables>) {
-        return ApolloReactHooks.useMutation<CreateLessonMutation, CreateLessonMutationVariables>(CreateLessonDocument, baseOptions);
-      }
-export type CreateLessonMutationHookResult = ReturnType<typeof useCreateLessonMutation>;
-export type CreateLessonMutationResult = ApolloReactCommon.MutationResult<CreateLessonMutation>;
-export type CreateLessonMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateLessonMutation, CreateLessonMutationVariables>;
+export function useCreateLessonMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    CreateLessonMutation,
+    CreateLessonMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    CreateLessonMutation,
+    CreateLessonMutationVariables
+  >(CreateLessonDocument, baseOptions)
+}
+export type CreateLessonMutationHookResult = ReturnType<
+  typeof useCreateLessonMutation
+>
+export type CreateLessonMutationResult = ApolloReactCommon.MutationResult<
+  CreateLessonMutation
+>
+export type CreateLessonMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  CreateLessonMutation,
+  CreateLessonMutationVariables
+>
 export const GetAppDocument = gql`
-    query getApp {
-  lessons {
-    id
-    title
-    description
-    docUrl
-    githubUrl
-    videoUrl
-    order
-    challenges {
+  query getApp {
+    lessons {
       id
       title
       description
+      docUrl
+      githubUrl
+      videoUrl
       order
+      challenges {
+        id
+        title
+        description
+        order
+      }
+      chatUrl
     }
-    chatUrl
-  }
-  session {
-    user {
-      id
-      username
-      name
-      isAdmin
-    }
-    submissions {
-      id
-      status
-      mrUrl
-      diff
-      viewCount
-      comment
-      order
-      challengeId
-      lessonId
-      reviewer {
+    session {
+      user {
         id
         username
+        name
+        isAdmin
       }
-      createdAt
-      updatedAt
+      submissions {
+        id
+        status
+        mrUrl
+        diff
+        viewCount
+        comment
+        order
+        challengeId
+        lessonId
+        reviewer {
+          id
+          username
+        }
+        createdAt
+        updatedAt
+      }
+      lessonStatus {
+        lessonId
+        isPassed
+        isTeaching
+        isEnrolled
+      }
     }
-    lessonStatus {
-      lessonId
-      isPassed
-      isTeaching
-      isEnrolled
+    alerts {
+      id
+      text
+      type
+      url
+      urlCaption
     }
   }
-  alerts {
-    id
-    text
-    type
-    url
-    urlCaption
-  }
-}
-    `;
-export type GetAppComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<GetAppQuery, GetAppQueryVariables>, 'query'>;
+`
+export type GetAppComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >,
+  'query'
+>
 
-    export const GetAppComponent = (props: GetAppComponentProps) => (
-      <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables> query={GetAppDocument} {...props} />
-    );
-    
+export const GetAppComponent = (props: GetAppComponentProps) => (
+  <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables>
+    query={GetAppDocument}
+    {...props}
+  />
+)
+
 export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<GetAppQuery, GetAppQueryVariables>
-    } & TChildProps;
-export function withGetApp<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+} &
+  TChildProps
+export function withGetApp<
   TProps,
-  GetAppQuery,
-  GetAppQueryVariables,
-  GetAppProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, GetAppQuery, GetAppQueryVariables, GetAppProps<TChildProps, TDataName>>(GetAppDocument, {
-      alias: 'getApp',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    GetAppQuery,
+    GetAppQueryVariables,
+    GetAppProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    GetAppQuery,
+    GetAppQueryVariables,
+    GetAppProps<TChildProps, TDataName>
+  >(GetAppDocument, {
+    alias: 'getApp',
+    ...operationOptions
+  })
+}
 
 /**
  * __useGetAppQuery__
@@ -1199,54 +2043,102 @@ export function withGetApp<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useGetAppQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
-        return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
-      }
-export function useGetAppLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<GetAppQuery, GetAppQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(GetAppDocument, baseOptions);
-        }
-export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>;
-export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>;
-export type GetAppQueryResult = ApolloReactCommon.QueryResult<GetAppQuery, GetAppQueryVariables>;
-export const SubmissionsDocument = gql`
-    query submissions($lessonId: String!) {
-  submissions(lessonId: $lessonId) {
-    id
-    status
-    diff
-    comment
-    challenge {
-      title
-    }
-    challengeId
-    user {
-      id
-      username
-    }
-    createdAt
-    updatedAt
-  }
+export function useGetAppQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(
+    GetAppDocument,
+    baseOptions
+  )
 }
-    `;
-export type SubmissionsComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<SubmissionsQuery, SubmissionsQueryVariables>, 'query'> & ({ variables: SubmissionsQueryVariables; skip?: boolean; } | { skip: boolean; });
+export function useGetAppLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    GetAppQuery,
+    GetAppQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(
+    GetAppDocument,
+    baseOptions
+  )
+}
+export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>
+export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>
+export type GetAppQueryResult = ApolloReactCommon.QueryResult<
+  GetAppQuery,
+  GetAppQueryVariables
+>
+export const SubmissionsDocument = gql`
+  query submissions($lessonId: String!) {
+    submissions(lessonId: $lessonId) {
+      id
+      status
+      diff
+      comment
+      challenge {
+        title
+      }
+      challengeId
+      user {
+        id
+        username
+      }
+      createdAt
+      updatedAt
+    }
+  }
+`
+export type SubmissionsComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >,
+  'query'
+> &
+  ({ variables: SubmissionsQueryVariables; skip?: boolean } | { skip: boolean })
 
-    export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
-      <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables> query={SubmissionsDocument} {...props} />
-    );
-    
-export type SubmissionsProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<SubmissionsQuery, SubmissionsQueryVariables>
-    } & TChildProps;
-export function withSubmissions<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
+  <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables>
+    query={SubmissionsDocument}
+    {...props}
+  />
+)
+
+export type SubmissionsProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+} &
+  TChildProps
+export function withSubmissions<
   TProps,
-  SubmissionsQuery,
-  SubmissionsQueryVariables,
-  SubmissionsProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, SubmissionsQuery, SubmissionsQueryVariables, SubmissionsProps<TChildProps, TDataName>>(SubmissionsDocument, {
-      alias: 'submissions',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    SubmissionsQuery,
+    SubmissionsQueryVariables,
+    SubmissionsProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    SubmissionsQuery,
+    SubmissionsQueryVariables,
+    SubmissionsProps<TChildProps, TDataName>
+  >(SubmissionsDocument, {
+    alias: 'submissions',
+    ...operationOptions
+  })
+}
 
 /**
  * __useSubmissionsQuery__
@@ -1264,45 +2156,97 @@ export function withSubmissions<TProps, TChildProps = {}, TDataName extends stri
  *   },
  * });
  */
-export function useSubmissionsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
-        return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
-      }
-export function useSubmissionsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<SubmissionsQuery, SubmissionsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<SubmissionsQuery, SubmissionsQueryVariables>(SubmissionsDocument, baseOptions);
-        }
-export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>;
-export type SubmissionsLazyQueryHookResult = ReturnType<typeof useSubmissionsLazyQuery>;
-export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<SubmissionsQuery, SubmissionsQueryVariables>;
-export const LoginDocument = gql`
-    mutation login($username: String!, $password: String!) {
-  login(username: $username, password: $password) {
-    success
-    username
-    cliToken
-    error
-  }
+export function useSubmissionsQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(
+    SubmissionsDocument,
+    baseOptions
+  )
 }
-    `;
-export type LoginMutationFn = ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>;
-export type LoginComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LoginMutation, LoginMutationVariables>, 'mutation'>;
-
-    export const LoginComponent = (props: LoginComponentProps) => (
-      <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables> mutation={LoginDocument} {...props} />
-    );
-    
-export type LoginProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<LoginMutation, LoginMutationVariables>
-    } & TChildProps;
-export function withLogin<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export function useSubmissionsLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<
+    SubmissionsQuery,
+    SubmissionsQueryVariables
+  >(SubmissionsDocument, baseOptions)
+}
+export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>
+export type SubmissionsLazyQueryHookResult = ReturnType<
+  typeof useSubmissionsLazyQuery
+>
+export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<
+  SubmissionsQuery,
+  SubmissionsQueryVariables
+>
+export const LoginDocument = gql`
+  mutation login($username: String!, $password: String!) {
+    login(username: $username, password: $password) {
+      success
+      username
+      cliToken
+      error
+    }
+  }
+`
+export type LoginMutationFn = ApolloReactCommon.MutationFunction<
   LoginMutation,
-  LoginMutationVariables,
-  LoginProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, LoginMutation, LoginMutationVariables, LoginProps<TChildProps, TDataName>>(LoginDocument, {
-      alias: 'login',
-      ...operationOptions
-    });
-};
+  LoginMutationVariables
+>
+export type LoginComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    LoginMutation,
+    LoginMutationVariables
+  >,
+  'mutation'
+>
+
+export const LoginComponent = (props: LoginComponentProps) => (
+  <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables>
+    mutation={LoginDocument}
+    {...props}
+  />
+)
+
+export type LoginProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    LoginMutation,
+    LoginMutationVariables
+  >
+} &
+  TChildProps
+export function withLogin<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    LoginMutation,
+    LoginMutationVariables,
+    LoginProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    LoginMutation,
+    LoginMutationVariables,
+    LoginProps<TChildProps, TDataName>
+  >(LoginDocument, {
+    alias: 'login',
+    ...operationOptions
+  })
+}
 
 /**
  * __useLoginMutation__
@@ -1322,41 +2266,85 @@ export function withLogin<TProps, TChildProps = {}, TDataName extends string = '
  *   },
  * });
  */
-export function useLoginMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
-        return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, baseOptions);
-      }
-export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
-export type LoginMutationResult = ApolloReactCommon.MutationResult<LoginMutation>;
-export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
-export const LogoutDocument = gql`
-    mutation logout {
-  logout {
-    success
-    username
-    error
-  }
+export function useLoginMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    LoginMutation,
+    LoginMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(
+    LoginDocument,
+    baseOptions
+  )
 }
-    `;
-export type LogoutMutationFn = ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>;
-export type LogoutComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<LogoutMutation, LogoutMutationVariables>, 'mutation'>;
-
-    export const LogoutComponent = (props: LogoutComponentProps) => (
-      <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables> mutation={LogoutDocument} {...props} />
-    );
-    
-export type LogoutProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<LogoutMutation, LogoutMutationVariables>
-    } & TChildProps;
-export function withLogout<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>
+export type LoginMutationResult = ApolloReactCommon.MutationResult<
+  LoginMutation
+>
+export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  LoginMutation,
+  LoginMutationVariables
+>
+export const LogoutDocument = gql`
+  mutation logout {
+    logout {
+      success
+      username
+      error
+    }
+  }
+`
+export type LogoutMutationFn = ApolloReactCommon.MutationFunction<
   LogoutMutation,
-  LogoutMutationVariables,
-  LogoutProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, LogoutMutation, LogoutMutationVariables, LogoutProps<TChildProps, TDataName>>(LogoutDocument, {
-      alias: 'logout',
-      ...operationOptions
-    });
-};
+  LogoutMutationVariables
+>
+export type LogoutComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    LogoutMutation,
+    LogoutMutationVariables
+  >,
+  'mutation'
+>
+
+export const LogoutComponent = (props: LogoutComponentProps) => (
+  <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables>
+    mutation={LogoutDocument}
+    {...props}
+  />
+)
+
+export type LogoutProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    LogoutMutation,
+    LogoutMutationVariables
+  >
+} &
+  TChildProps
+export function withLogout<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    LogoutMutation,
+    LogoutMutationVariables,
+    LogoutProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    LogoutMutation,
+    LogoutMutationVariables,
+    LogoutProps<TChildProps, TDataName>
+  >(LogoutDocument, {
+    alias: 'logout',
+    ...operationOptions
+  })
+}
 
 /**
  * __useLogoutMutation__
@@ -1374,41 +2362,90 @@ export function withLogout<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useLogoutMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
-        return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, baseOptions);
-      }
-export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
-export type LogoutMutationResult = ApolloReactCommon.MutationResult<LogoutMutation>;
-export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<LogoutMutation, LogoutMutationVariables>;
-export const RejectSubmissionDocument = gql`
-    mutation rejectSubmission($submissionId: String!, $comment: String!) {
-  rejectSubmission(id: $submissionId, comment: $comment) {
-    id
-    comment
-    status
-  }
+export function useLogoutMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    LogoutMutation,
+    LogoutMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(
+    LogoutDocument,
+    baseOptions
+  )
 }
-    `;
-export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
-export type RejectSubmissionComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>, 'mutation'>;
-
-    export const RejectSubmissionComponent = (props: RejectSubmissionComponentProps) => (
-      <ApolloReactComponents.Mutation<RejectSubmissionMutation, RejectSubmissionMutationVariables> mutation={RejectSubmissionDocument} {...props} />
-    );
-    
-export type RejectSubmissionProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<RejectSubmissionMutation, RejectSubmissionMutationVariables>
-    } & TChildProps;
-export function withRejectSubmission<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>
+export type LogoutMutationResult = ApolloReactCommon.MutationResult<
+  LogoutMutation
+>
+export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  LogoutMutation,
+  LogoutMutationVariables
+>
+export const RejectSubmissionDocument = gql`
+  mutation rejectSubmission($submissionId: String!, $comment: String!) {
+    rejectSubmission(id: $submissionId, comment: $comment) {
+      id
+      comment
+      status
+    }
+  }
+`
+export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<
   RejectSubmissionMutation,
-  RejectSubmissionMutationVariables,
-  RejectSubmissionProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, RejectSubmissionMutation, RejectSubmissionMutationVariables, RejectSubmissionProps<TChildProps, TDataName>>(RejectSubmissionDocument, {
-      alias: 'rejectSubmission',
-      ...operationOptions
-    });
-};
+  RejectSubmissionMutationVariables
+>
+export type RejectSubmissionComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >,
+  'mutation'
+>
+
+export const RejectSubmissionComponent = (
+  props: RejectSubmissionComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+    mutation={RejectSubmissionDocument}
+    {...props}
+  />
+)
+
+export type RejectSubmissionProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+} &
+  TChildProps
+export function withRejectSubmission<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables,
+    RejectSubmissionProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables,
+    RejectSubmissionProps<TChildProps, TDataName>
+  >(RejectSubmissionDocument, {
+    alias: 'rejectSubmission',
+    ...operationOptions
+  })
+}
 
 /**
  * __useRejectSubmissionMutation__
@@ -1428,40 +2465,89 @@ export function withRejectSubmission<TProps, TChildProps = {}, TDataName extends
  *   },
  * });
  */
-export function useRejectSubmissionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>) {
-        return ApolloReactHooks.useMutation<RejectSubmissionMutation, RejectSubmissionMutationVariables>(RejectSubmissionDocument, baseOptions);
-      }
-export type RejectSubmissionMutationHookResult = ReturnType<typeof useRejectSubmissionMutation>;
-export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<RejectSubmissionMutation>;
-export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<RejectSubmissionMutation, RejectSubmissionMutationVariables>;
-export const ReqPwResetDocument = gql`
-    mutation reqPwReset($userOrEmail: String!) {
-  reqPwReset(userOrEmail: $userOrEmail) {
-    success
-    token
-  }
+export function useRejectSubmissionMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    RejectSubmissionMutation,
+    RejectSubmissionMutationVariables
+  >(RejectSubmissionDocument, baseOptions)
 }
-    `;
-export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>;
-export type ReqPwResetComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ReqPwResetMutation, ReqPwResetMutationVariables>, 'mutation'>;
-
-    export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
-      <ApolloReactComponents.Mutation<ReqPwResetMutation, ReqPwResetMutationVariables> mutation={ReqPwResetDocument} {...props} />
-    );
-    
-export type ReqPwResetProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<ReqPwResetMutation, ReqPwResetMutationVariables>
-    } & TChildProps;
-export function withReqPwReset<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type RejectSubmissionMutationHookResult = ReturnType<
+  typeof useRejectSubmissionMutation
+>
+export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<
+  RejectSubmissionMutation
+>
+export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  RejectSubmissionMutation,
+  RejectSubmissionMutationVariables
+>
+export const ReqPwResetDocument = gql`
+  mutation reqPwReset($userOrEmail: String!) {
+    reqPwReset(userOrEmail: $userOrEmail) {
+      success
+      token
+    }
+  }
+`
+export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<
   ReqPwResetMutation,
-  ReqPwResetMutationVariables,
-  ReqPwResetProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, ReqPwResetMutation, ReqPwResetMutationVariables, ReqPwResetProps<TChildProps, TDataName>>(ReqPwResetDocument, {
-      alias: 'reqPwReset',
-      ...operationOptions
-    });
-};
+  ReqPwResetMutationVariables
+>
+export type ReqPwResetComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >,
+  'mutation'
+>
+
+export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
+  <ApolloReactComponents.Mutation<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+    mutation={ReqPwResetDocument}
+    {...props}
+  />
+)
+
+export type ReqPwResetProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+} &
+  TChildProps
+export function withReqPwReset<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables,
+    ReqPwResetProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables,
+    ReqPwResetProps<TChildProps, TDataName>
+  >(ReqPwResetDocument, {
+    alias: 'reqPwReset',
+    ...operationOptions
+  })
+}
 
 /**
  * __useReqPwResetMutation__
@@ -1480,41 +2566,97 @@ export function withReqPwReset<TProps, TChildProps = {}, TDataName extends strin
  *   },
  * });
  */
-export function useReqPwResetMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ReqPwResetMutation, ReqPwResetMutationVariables>) {
-        return ApolloReactHooks.useMutation<ReqPwResetMutation, ReqPwResetMutationVariables>(ReqPwResetDocument, baseOptions);
-      }
-export type ReqPwResetMutationHookResult = ReturnType<typeof useReqPwResetMutation>;
-export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<ReqPwResetMutation>;
-export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<ReqPwResetMutation, ReqPwResetMutationVariables>;
-export const SignupDocument = gql`
-    mutation signup($firstName: String!, $lastName: String!, $email: String!, $username: String!) {
-  signup(firstName: $firstName, lastName: $lastName, email: $email, username: $username) {
-    success
-    username
-    error
-  }
+export function useReqPwResetMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    ReqPwResetMutation,
+    ReqPwResetMutationVariables
+  >(ReqPwResetDocument, baseOptions)
 }
-    `;
-export type SignupMutationFn = ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>;
-export type SignupComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<SignupMutation, SignupMutationVariables>, 'mutation'>;
-
-    export const SignupComponent = (props: SignupComponentProps) => (
-      <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables> mutation={SignupDocument} {...props} />
-    );
-    
-export type SignupProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<SignupMutation, SignupMutationVariables>
-    } & TChildProps;
-export function withSignup<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type ReqPwResetMutationHookResult = ReturnType<
+  typeof useReqPwResetMutation
+>
+export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<
+  ReqPwResetMutation
+>
+export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  ReqPwResetMutation,
+  ReqPwResetMutationVariables
+>
+export const SignupDocument = gql`
+  mutation signup(
+    $firstName: String!
+    $lastName: String!
+    $email: String!
+    $username: String!
+  ) {
+    signup(
+      firstName: $firstName
+      lastName: $lastName
+      email: $email
+      username: $username
+    ) {
+      success
+      username
+      error
+    }
+  }
+`
+export type SignupMutationFn = ApolloReactCommon.MutationFunction<
   SignupMutation,
-  SignupMutationVariables,
-  SignupProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, SignupMutation, SignupMutationVariables, SignupProps<TChildProps, TDataName>>(SignupDocument, {
-      alias: 'signup',
-      ...operationOptions
-    });
-};
+  SignupMutationVariables
+>
+export type SignupComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    SignupMutation,
+    SignupMutationVariables
+  >,
+  'mutation'
+>
+
+export const SignupComponent = (props: SignupComponentProps) => (
+  <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables>
+    mutation={SignupDocument}
+    {...props}
+  />
+)
+
+export type SignupProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    SignupMutation,
+    SignupMutationVariables
+  >
+} &
+  TChildProps
+export function withSignup<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    SignupMutation,
+    SignupMutationVariables,
+    SignupProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    SignupMutation,
+    SignupMutationVariables,
+    SignupProps<TChildProps, TDataName>
+  >(SignupDocument, {
+    alias: 'signup',
+    ...operationOptions
+  })
+}
 
 /**
  * __useSignupMutation__
@@ -1536,53 +2678,114 @@ export function withSignup<TProps, TChildProps = {}, TDataName extends string = 
  *   },
  * });
  */
-export function useSignupMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SignupMutation, SignupMutationVariables>) {
-        return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(SignupDocument, baseOptions);
-      }
-export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>;
-export type SignupMutationResult = ApolloReactCommon.MutationResult<SignupMutation>;
-export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<SignupMutation, SignupMutationVariables>;
+export function useSignupMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    SignupMutation,
+    SignupMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(
+    SignupDocument,
+    baseOptions
+  )
+}
+export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>
+export type SignupMutationResult = ApolloReactCommon.MutationResult<
+  SignupMutation
+>
+export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  SignupMutation,
+  SignupMutationVariables
+>
 export const UpdateChallengeDocument = gql`
-    mutation updateChallenge($lessonId: Int!, $order: Int, $description: String, $title: String, $id: Int!) {
-  updateChallenge(id: $id, lessonId: $lessonId, order: $order, description: $description, title: $title) {
-    id
-    docUrl
-    githubUrl
-    videoUrl
-    chatUrl
-    order
-    description
-    title
-    challenges {
+  mutation updateChallenge(
+    $lessonId: Int!
+    $order: Int
+    $description: String
+    $title: String
+    $id: Int!
+  ) {
+    updateChallenge(
+      id: $id
+      lessonId: $lessonId
+      order: $order
+      description: $description
+      title: $title
+    ) {
       id
-      description
-      lessonId
-      title
+      docUrl
+      githubUrl
+      videoUrl
+      chatUrl
       order
+      description
+      title
+      challenges {
+        id
+        description
+        lessonId
+        title
+        order
+      }
     }
   }
-}
-    `;
-export type UpdateChallengeMutationFn = ApolloReactCommon.MutationFunction<UpdateChallengeMutation, UpdateChallengeMutationVariables>;
-export type UpdateChallengeComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>, 'mutation'>;
-
-    export const UpdateChallengeComponent = (props: UpdateChallengeComponentProps) => (
-      <ApolloReactComponents.Mutation<UpdateChallengeMutation, UpdateChallengeMutationVariables> mutation={UpdateChallengeDocument} {...props} />
-    );
-    
-export type UpdateChallengeProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<UpdateChallengeMutation, UpdateChallengeMutationVariables>
-    } & TChildProps;
-export function withUpdateChallenge<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+`
+export type UpdateChallengeMutationFn = ApolloReactCommon.MutationFunction<
   UpdateChallengeMutation,
-  UpdateChallengeMutationVariables,
-  UpdateChallengeProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, UpdateChallengeMutation, UpdateChallengeMutationVariables, UpdateChallengeProps<TChildProps, TDataName>>(UpdateChallengeDocument, {
-      alias: 'updateChallenge',
-      ...operationOptions
-    });
-};
+  UpdateChallengeMutationVariables
+>
+export type UpdateChallengeComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >,
+  'mutation'
+>
+
+export const UpdateChallengeComponent = (
+  props: UpdateChallengeComponentProps
+) => (
+  <ApolloReactComponents.Mutation<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >
+    mutation={UpdateChallengeDocument}
+    {...props}
+  />
+)
+
+export type UpdateChallengeProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >
+} &
+  TChildProps
+export function withUpdateChallenge<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables,
+    UpdateChallengeProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables,
+    UpdateChallengeProps<TChildProps, TDataName>
+  >(UpdateChallengeDocument, {
+    alias: 'updateChallenge',
+    ...operationOptions
+  })
+}
 
 /**
  * __useUpdateChallengeMutation__
@@ -1605,53 +2808,120 @@ export function withUpdateChallenge<TProps, TChildProps = {}, TDataName extends 
  *   },
  * });
  */
-export function useUpdateChallengeMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>) {
-        return ApolloReactHooks.useMutation<UpdateChallengeMutation, UpdateChallengeMutationVariables>(UpdateChallengeDocument, baseOptions);
-      }
-export type UpdateChallengeMutationHookResult = ReturnType<typeof useUpdateChallengeMutation>;
-export type UpdateChallengeMutationResult = ApolloReactCommon.MutationResult<UpdateChallengeMutation>;
-export type UpdateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateChallengeMutation, UpdateChallengeMutationVariables>;
+export function useUpdateChallengeMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    UpdateChallengeMutation,
+    UpdateChallengeMutationVariables
+  >(UpdateChallengeDocument, baseOptions)
+}
+export type UpdateChallengeMutationHookResult = ReturnType<
+  typeof useUpdateChallengeMutation
+>
+export type UpdateChallengeMutationResult = ApolloReactCommon.MutationResult<
+  UpdateChallengeMutation
+>
+export type UpdateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  UpdateChallengeMutation,
+  UpdateChallengeMutationVariables
+>
 export const UpdateLessonDocument = gql`
-    mutation updateLesson($id: Int!, $docUrl: String, $githubUrl: String, $videoUrl: String, $chatUrl: String, $order: Int, $description: String, $title: String) {
-  updateLesson(docUrl: $docUrl, githubUrl: $githubUrl, videoUrl: $videoUrl, chatUrl: $chatUrl, id: $id, order: $order, description: $description, title: $title) {
-    id
-    docUrl
-    githubUrl
-    videoUrl
-    chatUrl
-    order
-    description
-    title
-    challenges {
+  mutation updateLesson(
+    $id: Int!
+    $docUrl: String
+    $githubUrl: String
+    $videoUrl: String
+    $chatUrl: String
+    $order: Int
+    $description: String
+    $title: String
+  ) {
+    updateLesson(
+      docUrl: $docUrl
+      githubUrl: $githubUrl
+      videoUrl: $videoUrl
+      chatUrl: $chatUrl
+      id: $id
+      order: $order
+      description: $description
+      title: $title
+    ) {
       id
-      description
-      lessonId
-      title
+      docUrl
+      githubUrl
+      videoUrl
+      chatUrl
       order
+      description
+      title
+      challenges {
+        id
+        description
+        lessonId
+        title
+        order
+      }
     }
   }
-}
-    `;
-export type UpdateLessonMutationFn = ApolloReactCommon.MutationFunction<UpdateLessonMutation, UpdateLessonMutationVariables>;
-export type UpdateLessonComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<UpdateLessonMutation, UpdateLessonMutationVariables>, 'mutation'>;
-
-    export const UpdateLessonComponent = (props: UpdateLessonComponentProps) => (
-      <ApolloReactComponents.Mutation<UpdateLessonMutation, UpdateLessonMutationVariables> mutation={UpdateLessonDocument} {...props} />
-    );
-    
-export type UpdateLessonProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<UpdateLessonMutation, UpdateLessonMutationVariables>
-    } & TChildProps;
-export function withUpdateLesson<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+`
+export type UpdateLessonMutationFn = ApolloReactCommon.MutationFunction<
   UpdateLessonMutation,
-  UpdateLessonMutationVariables,
-  UpdateLessonProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, UpdateLessonMutation, UpdateLessonMutationVariables, UpdateLessonProps<TChildProps, TDataName>>(UpdateLessonDocument, {
-      alias: 'updateLesson',
-      ...operationOptions
-    });
-};
+  UpdateLessonMutationVariables
+>
+export type UpdateLessonComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    UpdateLessonMutation,
+    UpdateLessonMutationVariables
+  >,
+  'mutation'
+>
+
+export const UpdateLessonComponent = (props: UpdateLessonComponentProps) => (
+  <ApolloReactComponents.Mutation<
+    UpdateLessonMutation,
+    UpdateLessonMutationVariables
+  >
+    mutation={UpdateLessonDocument}
+    {...props}
+  />
+)
+
+export type UpdateLessonProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    UpdateLessonMutation,
+    UpdateLessonMutationVariables
+  >
+} &
+  TChildProps
+export function withUpdateLesson<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UpdateLessonMutation,
+    UpdateLessonMutationVariables,
+    UpdateLessonProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    UpdateLessonMutation,
+    UpdateLessonMutationVariables,
+    UpdateLessonProps<TChildProps, TDataName>
+  >(UpdateLessonDocument, {
+    alias: 'updateLesson',
+    ...operationOptions
+  })
+}
 
 /**
  * __useUpdateLessonMutation__
@@ -1677,39 +2947,85 @@ export function withUpdateLesson<TProps, TChildProps = {}, TDataName extends str
  *   },
  * });
  */
-export function useUpdateLessonMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateLessonMutation, UpdateLessonMutationVariables>) {
-        return ApolloReactHooks.useMutation<UpdateLessonMutation, UpdateLessonMutationVariables>(UpdateLessonDocument, baseOptions);
-      }
-export type UpdateLessonMutationHookResult = ReturnType<typeof useUpdateLessonMutation>;
-export type UpdateLessonMutationResult = ApolloReactCommon.MutationResult<UpdateLessonMutation>;
-export type UpdateLessonMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateLessonMutation, UpdateLessonMutationVariables>;
-export const ChangePwDocument = gql`
-    mutation changePw($token: String!, $password: String!) {
-  changePw(token: $token, password: $password) {
-    success
-  }
+export function useUpdateLessonMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    UpdateLessonMutation,
+    UpdateLessonMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    UpdateLessonMutation,
+    UpdateLessonMutationVariables
+  >(UpdateLessonDocument, baseOptions)
 }
-    `;
-export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>;
-export type ChangePwComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<ChangePwMutation, ChangePwMutationVariables>, 'mutation'>;
-
-    export const ChangePwComponent = (props: ChangePwComponentProps) => (
-      <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables> mutation={ChangePwDocument} {...props} />
-    );
-    
-export type ChangePwProps<TChildProps = {}, TDataName extends string = 'mutate'> = {
-      [key in TDataName]: ApolloReactCommon.MutationFunction<ChangePwMutation, ChangePwMutationVariables>
-    } & TChildProps;
-export function withChangePw<TProps, TChildProps = {}, TDataName extends string = 'mutate'>(operationOptions?: ApolloReactHoc.OperationOption<
-  TProps,
+export type UpdateLessonMutationHookResult = ReturnType<
+  typeof useUpdateLessonMutation
+>
+export type UpdateLessonMutationResult = ApolloReactCommon.MutationResult<
+  UpdateLessonMutation
+>
+export type UpdateLessonMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  UpdateLessonMutation,
+  UpdateLessonMutationVariables
+>
+export const ChangePwDocument = gql`
+  mutation changePw($token: String!, $password: String!) {
+    changePw(token: $token, password: $password) {
+      success
+    }
+  }
+`
+export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<
   ChangePwMutation,
-  ChangePwMutationVariables,
-  ChangePwProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withMutation<TProps, ChangePwMutation, ChangePwMutationVariables, ChangePwProps<TChildProps, TDataName>>(ChangePwDocument, {
-      alias: 'changePw',
-      ...operationOptions
-    });
-};
+  ChangePwMutationVariables
+>
+export type ChangePwComponentProps = Omit<
+  ApolloReactComponents.MutationComponentOptions<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >,
+  'mutation'
+>
+
+export const ChangePwComponent = (props: ChangePwComponentProps) => (
+  <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables>
+    mutation={ChangePwDocument}
+    {...props}
+  />
+)
+
+export type ChangePwProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: ApolloReactCommon.MutationFunction<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >
+} &
+  TChildProps
+export function withChangePw<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    ChangePwMutation,
+    ChangePwMutationVariables,
+    ChangePwProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    ChangePwMutation,
+    ChangePwMutationVariables,
+    ChangePwProps<TChildProps, TDataName>
+  >(ChangePwDocument, {
+    alias: 'changePw',
+    ...operationOptions
+  })
+}
 
 /**
  * __useChangePwMutation__
@@ -1729,85 +3045,127 @@ export function withChangePw<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useChangePwMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<ChangePwMutation, ChangePwMutationVariables>) {
-        return ApolloReactHooks.useMutation<ChangePwMutation, ChangePwMutationVariables>(ChangePwDocument, baseOptions);
-      }
-export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>;
-export type ChangePwMutationResult = ApolloReactCommon.MutationResult<ChangePwMutation>;
-export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<ChangePwMutation, ChangePwMutationVariables>;
+export function useChangePwMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    ChangePwMutation,
+    ChangePwMutationVariables
+  >(ChangePwDocument, baseOptions)
+}
+export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>
+export type ChangePwMutationResult = ApolloReactCommon.MutationResult<
+  ChangePwMutation
+>
+export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  ChangePwMutation,
+  ChangePwMutationVariables
+>
 export const UserInfoDocument = gql`
-    query userInfo($username: String!) {
-  lessons {
-    id
-    title
-    description
-    docUrl
-    githubUrl
-    videoUrl
-    order
-    challenges {
+  query userInfo($username: String!) {
+    lessons {
       id
       title
       description
+      docUrl
+      githubUrl
+      videoUrl
       order
+      challenges {
+        id
+        title
+        description
+        order
+      }
+      chatUrl
     }
-    chatUrl
-  }
-  userInfo(username: $username) {
-    user {
-      id
-      username
-      name
-    }
-    submissions {
-      id
-      status
-      mrUrl
-      diff
-      viewCount
-      comment
-      order
-      challengeId
-      lessonId
-      reviewer {
+    userInfo(username: $username) {
+      user {
         id
         username
+        name
       }
-      createdAt
-      updatedAt
-    }
-    lessonStatus {
-      lessonId
-      isPassed
-      isTeaching
-      isEnrolled
-      starsReceived {
-        lessonId
+      submissions {
+        id
+        status
+        mrUrl
+        diff
+        viewCount
         comment
+        order
+        challengeId
+        lessonId
+        reviewer {
+          id
+          username
+        }
+        createdAt
+        updatedAt
+      }
+      lessonStatus {
+        lessonId
+        isPassed
+        isTeaching
+        isEnrolled
+        starsReceived {
+          lessonId
+          comment
+        }
       }
     }
   }
-}
-    `;
-export type UserInfoComponentProps = Omit<ApolloReactComponents.QueryComponentOptions<UserInfoQuery, UserInfoQueryVariables>, 'query'> & ({ variables: UserInfoQueryVariables; skip?: boolean; } | { skip: boolean; });
+`
+export type UserInfoComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >,
+  'query'
+> &
+  ({ variables: UserInfoQueryVariables; skip?: boolean } | { skip: boolean })
 
-    export const UserInfoComponent = (props: UserInfoComponentProps) => (
-      <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables> query={UserInfoDocument} {...props} />
-    );
-    
-export type UserInfoProps<TChildProps = {}, TDataName extends string = 'data'> = {
-      [key in TDataName]: ApolloReactHoc.DataValue<UserInfoQuery, UserInfoQueryVariables>
-    } & TChildProps;
-export function withUserInfo<TProps, TChildProps = {}, TDataName extends string = 'data'>(operationOptions?: ApolloReactHoc.OperationOption<
+export const UserInfoComponent = (props: UserInfoComponentProps) => (
+  <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables>
+    query={UserInfoDocument}
+    {...props}
+  />
+)
+
+export type UserInfoProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+} &
+  TChildProps
+export function withUserInfo<
   TProps,
-  UserInfoQuery,
-  UserInfoQueryVariables,
-  UserInfoProps<TChildProps, TDataName>>) {
-    return ApolloReactHoc.withQuery<TProps, UserInfoQuery, UserInfoQueryVariables, UserInfoProps<TChildProps, TDataName>>(UserInfoDocument, {
-      alias: 'userInfo',
-      ...operationOptions
-    });
-};
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UserInfoQuery,
+    UserInfoQueryVariables,
+    UserInfoProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    UserInfoQuery,
+    UserInfoQueryVariables,
+    UserInfoProps<TChildProps, TDataName>
+  >(UserInfoDocument, {
+    alias: 'userInfo',
+    ...operationOptions
+  })
+}
 
 /**
  * __useUserInfoQuery__
@@ -1825,12 +3183,33 @@ export function withUserInfo<TProps, TChildProps = {}, TDataName extends string 
  *   },
  * });
  */
-export function useUserInfoQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
-        return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
-      }
-export function useUserInfoLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<UserInfoQuery, UserInfoQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(UserInfoDocument, baseOptions);
-        }
-export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>;
-export type UserInfoLazyQueryHookResult = ReturnType<typeof useUserInfoLazyQuery>;
-export type UserInfoQueryResult = ApolloReactCommon.QueryResult<UserInfoQuery, UserInfoQueryVariables>;
+export function useUserInfoQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(
+    UserInfoDocument,
+    baseOptions
+  )
+}
+export function useUserInfoLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    UserInfoQuery,
+    UserInfoQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(
+    UserInfoDocument,
+    baseOptions
+  )
+}
+export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>
+export type UserInfoLazyQueryHookResult = ReturnType<
+  typeof useUserInfoLazyQuery
+>
+export type UserInfoQueryResult = ApolloReactCommon.QueryResult<
+  UserInfoQuery,
+  UserInfoQueryVariables
+>

--- a/graphql/queries/allUsers.ts
+++ b/graphql/queries/allUsers.ts
@@ -1,0 +1,16 @@
+import { gql } from 'apollo-boost'
+
+const ALL_USERS = gql`
+  query users {
+    allUsers {
+      id
+      username
+      name
+      isAdmin
+      email
+      cliToken
+    }
+  }
+`
+
+export default ALL_USERS

--- a/graphql/queries/changeAdminRights.ts
+++ b/graphql/queries/changeAdminRights.ts
@@ -1,0 +1,11 @@
+import { gql } from 'apollo-boost'
+
+const CHANGE_ADMIN_RIGHTS = gql`
+  mutation changeAdminRights($id: Int!, $status: String!) {
+    changeAdminRights(id: $id, status: $status) {
+      success
+    }
+  }
+`
+
+export default CHANGE_ADMIN_RIGHTS

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,17 +1,11 @@
 import React, { useState } from 'react'
-import { useQuery } from '@apollo/react-hooks'
-import LoadingSpinner from '../../components/LoadingSpinner'
-import Layout from '../../components/Layout'
-import { withGetApp, GetAppProps } from '../../graphql'
 import allUsers from '../../graphql/queries/allUsers'
-import _ from 'lodash'
 import { UsersTable } from '../../components/admin/users/AdminUsersTable'
-import { User } from '../../graphql/index'
-
-type AdminUsersProps = {
-  users: User[] | null
-  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
-}
+import { User, withGetApp, GetAppProps } from '../../graphql/index'
+import { AdminLayout } from '../../components/admin/AdminLayout'
+import withQueryLoader, {
+  QueryDataProps
+} from '../../containers/withQueryLoader'
 
 const titleStyle: React.CSSProperties | undefined = {
   fontSize: '6rem',
@@ -19,68 +13,35 @@ const titleStyle: React.CSSProperties | undefined = {
   fontWeight: 'bold'
 }
 
-const AdminUsers: React.FC<AdminUsersProps> = ({ users, setUsers }) => {
+type AllUsersData = {
+  allUsers: User[]
+}
+
+const AdminUsers: React.FC<QueryDataProps<AllUsersData>> = ({ queryData }) => {
+  const [users, setUsers] = useState<User[]>(queryData.allUsers)
   return (
     <div className="d-flex flex-column col-12">
       <span className="text-primary" style={titleStyle}>
         Users
       </span>
-
       <UsersTable users={users} setUsers={setUsers} />
     </div>
   )
 }
 
-const LoadUsers: React.FC = () => {
-  const { loading, error, data } = useQuery(allUsers)
-  const [users, setUsers] = useState<null | User[]>(null)
-
-  if (loading) {
-    return <LoadingSpinner />
-  }
-
-  if (error) {
-    return (
-      <Layout>
-        <h1>Error</h1>
-      </Layout>
-    )
-  }
-
-  return (
-    <Layout>
-      <AdminUsers users={users || data.allUsers} setUsers={setUsers} />
-    </Layout>
-  )
-}
+const LoadUsers: React.FC = withQueryLoader<AllUsersData>(
+  {
+    query: allUsers
+  },
+  AdminUsers
+)
 
 const Users: React.FC<GetAppProps> = ({ data }) => {
-  const { loading, error, session } = data
-  const admin = _.get(session, 'user.isAdmin', false)
-
-  if (loading) {
-    return <LoadingSpinner />
-  }
-
-  if (error) {
-    return (
-      <Layout>
-        <h1>Error</h1>
-      </Layout>
-    )
-  }
-
-  if (!session) window.location.href = '/login'
-
-  if (admin === 'false') {
-    return (
-      <Layout>
-        <h1>You must be admin to access this page</h1>
-      </Layout>
-    )
-  }
-
-  return <LoadUsers />
+  return (
+    <AdminLayout data={data}>
+      <LoadUsers />
+    </AdminLayout>
+  )
 }
 
 export default withGetApp()(Users)

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+import { useQuery } from '@apollo/react-hooks'
+import LoadingSpinner from '../../components/LoadingSpinner'
+import Layout from '../../components/Layout'
+import { withGetApp, GetAppProps } from '../../graphql'
+import allUsers from '../../graphql/queries/allUsers'
+import _ from 'lodash'
+import { UsersTable } from '../../components/admin/users/AdminUsersTable'
+import { User } from '../../graphql/index'
+
+type AdminUsersProps = {
+  users: User[] | null
+  setUsers: React.Dispatch<React.SetStateAction<User[] | null>>
+}
+
+const titleStyle: React.CSSProperties | undefined = {
+  fontSize: '6rem',
+  textAlign: 'center',
+  fontWeight: 'bold'
+}
+
+const AdminUsers: React.FC<AdminUsersProps> = ({ users, setUsers }) => {
+  return (
+    <div className="d-flex flex-column col-12">
+      <span className="text-primary" style={titleStyle}>
+        Users
+      </span>
+
+      <UsersTable users={users} setUsers={setUsers} />
+    </div>
+  )
+}
+
+const LoadUsers: React.FC = () => {
+  const { loading, error, data } = useQuery(allUsers)
+  const [users, setUsers] = useState<null | User[]>(null)
+
+  if (loading) {
+    return <LoadingSpinner />
+  }
+
+  if (error) {
+    return (
+      <Layout>
+        <h1>Error</h1>
+      </Layout>
+    )
+  }
+
+  return (
+    <Layout>
+      <AdminUsers users={users || data.allUsers} setUsers={setUsers} />
+    </Layout>
+  )
+}
+
+const Users: React.FC<GetAppProps> = ({ data }) => {
+  const { loading, error, session } = data
+  const admin = _.get(session, 'user.isAdmin', false)
+
+  if (loading) {
+    return <LoadingSpinner />
+  }
+
+  if (error) {
+    return (
+      <Layout>
+        <h1>Error</h1>
+      </Layout>
+    )
+  }
+
+  if (!session) window.location.href = '/login'
+
+  if (admin === 'false') {
+    return (
+      <Layout>
+        <h1>You must be admin to access this page</h1>
+      </Layout>
+    )
+  }
+
+  return <LoadUsers />
+}
+
+export default withGetApp()(Users)


### PR DESCRIPTION
The Admin Users page needs to be able to display a list of users and let admins `remove` or `grant` admin rights to other users. Resolvers for allUsers and changeAdminRights have been made, but queries for them have not. These queries are both needed for the Admin User page. 

There is also a problem with the `LoadingSpinner` component. It does not take up the full width and height of the browser window when it is wrapped by the `Layout` component. This needs to be addressed, since the `Admin Alerts` page will run into this problem as well if not fixed.

This PR will:
* Create a graphql query that calls the allUsers resolver to use in the front-end
* Create a graphql query that calls the changeAdminRights resolver to use in the front-end
* Create an `Admin Users` page that will display a list of users with a button to remove or grant admin rights to any user
* Fix css styling on `LoadingSpinner` component so that it takes up 100% width and height of browser screen when wrapped by the `Layout` component

# Title and beginning of Users Information Table
<img width="1174" alt="Screen Shot 2020-08-03 at 10 59 11 PM" src="https://user-images.githubusercontent.com/45890848/89258535-33b1cb00-d5dd-11ea-9888-19f7c1a588a0.png">

# Examples of `remove/grant` buttons
<img width="1173" alt="Screen Shot 2020-08-03 at 10 59 45 PM" src="https://user-images.githubusercontent.com/45890848/89258600-4cba7c00-d5dd-11ea-8c38-254c3fee89a2.png">

# Example of previous problem with loading spinner
<img width="1185" alt="Screen Shot 2020-08-05 at 10 30 59 AM" src="https://user-images.githubusercontent.com/45890848/89446801-dc5d4900-d709-11ea-9a9d-55b197ec914d.png">

