### PR TITLE
closes #383 - searchTerm not capitalized correctly when highlighted

### DIFF
--- a/components/admin/users/AdminUsersSplitSearch.tsx
+++ b/components/admin/users/AdminUsersSplitSearch.tsx
@@ -1,38 +1,5 @@
 import React from 'react'
-
-/*
-	convert string to array, separated by and including searchTerm
-	Ex:
-		Inputs: searchTerm='bon', str = 'bonJourbon'
-		Output: [bon, Jour, bon]
-*/
-const splitWithSearchTerm = (str: string, searchTerm: string) => {
-  const lowerCaseSearchTerm = searchTerm.toLowerCase()
-  const splitArr = str.toLowerCase().split(lowerCaseSearchTerm)
-  // tracker is used for `str.substr` to extract characters from the original string at the correct places
-  let tracker = 0
-
-  const res = splitArr.reduce(
-    (acc: string[], word: string, splitArrIndex: number) => {
-      // converts words back into their original capitalization
-      const originalWord = str.substr(tracker, word.length)
-      acc.push(originalWord)
-      tracker += word.length
-
-      // used to prevent over-adding of searchTerm back into array
-      if (splitArrIndex === splitArr.length - 1) return acc
-
-      // convert searchTerm to match original capitalization of string
-      const correctSearchCapitalization = str.substr(tracker, searchTerm.length)
-      acc.push(correctSearchCapitalization)
-      tracker += searchTerm.length
-      return acc
-    },
-    []
-  )
-
-  return res
-}
+import { splitWithSearchTerm } from '../../../helpers/splitWithSearchTerm'
 
 export const AdminUsersSplitSearch = (str: string, searchTerm: string) => {
   // make all lowercase now to ensure both lower and uppercase characters can be searched for

--- a/components/admin/users/AdminUsersSplitSearch.tsx
+++ b/components/admin/users/AdminUsersSplitSearch.tsx
@@ -21,7 +21,10 @@ const splitWithSearchTerm = (str: string, searchTerm: string) => {
 
       // used to prevent over-adding of searchTerm back into array
       if (splitArrIndex === splitArr.length - 1) return acc
-      acc.push(searchTerm)
+
+      // convert searchTerm to match original capitalization of string
+      const correctSearchCapitalization = str.substr(tracker, searchTerm.length)
+      acc.push(correctSearchCapitalization)
       tracker += searchTerm.length
       return acc
     },

--- a/components/admin/users/AdminUsersTable.tsx
+++ b/components/admin/users/AdminUsersTable.tsx
@@ -124,7 +124,14 @@ const UsersList: React.FC<UsersListProps> = ({
   const list: User[] = users.filter((user: any, usersIndex: number) => {
     let bool = true
 
-    if (searchTerm) bool = (user[option] || '').includes(searchTerm)
+    /* 
+			Need to make searchTerm and value of user[option] lowercase, 
+      to ensure both lower and uppercase characters can be searched for
+		*/
+    const lowerCaseSearchTerm = searchTerm.toLowerCase()
+    const lowerCaseOptionValue = user[option].toLowerCase()
+
+    if (searchTerm) bool = lowerCaseOptionValue.includes(lowerCaseSearchTerm)
     if (bool && admin === 'Non-Admins') bool = user.isAdmin === 'false'
     if (bool && admin === 'Admins') bool = user.isAdmin === 'true'
 

--- a/components/admin/users/AdminUsersTable.tsx
+++ b/components/admin/users/AdminUsersTable.tsx
@@ -125,8 +125,8 @@ const UsersList: React.FC<UsersListProps> = ({
     let bool = true
 
     /* 
-    Need to make searchTerm and value of user[option] lowercase, 
-    to ensure both lower and uppercase characters can be searched for
+      Need to make searchTerm and value of user[option] lowercase, 
+      to ensure both lower and uppercase characters can be searched for
     */
     const lowerCaseSearchTerm = searchTerm.toLowerCase()
     const lowerCaseOptionValue = user[option].toLowerCase()

--- a/components/admin/users/AdminUsersTable.tsx
+++ b/components/admin/users/AdminUsersTable.tsx
@@ -125,9 +125,9 @@ const UsersList: React.FC<UsersListProps> = ({
     let bool = true
 
     /* 
-			Need to make searchTerm and value of user[option] lowercase, 
-      to ensure both lower and uppercase characters can be searched for
-		*/
+    Need to make searchTerm and value of user[option] lowercase, 
+    to ensure both lower and uppercase characters can be searched for
+    */
     const lowerCaseSearchTerm = searchTerm.toLowerCase()
     const lowerCaseOptionValue = user[option].toLowerCase()
 

--- a/helpers/splitWithSearchTerm.test.js
+++ b/helpers/splitWithSearchTerm.test.js
@@ -3,14 +3,15 @@ import { splitWithSearchTerm } from './splitWithSearchTerm'
 describe('splitWithSearchTerm helper function', () => {
   test('Should produce array matching original capitalization of string', () => {
     const str = 'hiNgaDiNGADuurgen'
+    const result = ['hiNga', 'DiNGA', 'Duurgen']
     const searchTerm1 = 'dinga'
     const searchTerm2 = 'dINga'
     const searchTerm3 = 'DINGA'
     const splitArr1 = splitWithSearchTerm(str, searchTerm1)
     const splitArr2 = splitWithSearchTerm(str, searchTerm2)
     const splitArr3 = splitWithSearchTerm(str, searchTerm3)
-    expect(splitArr1).toEqual(['hiNga', 'DiNGA', 'Duurgen'])
-    expect(splitArr2).toEqual(['hiNga', 'DiNGA', 'Duurgen'])
-    expect(splitArr3).toEqual(['hiNga', 'DiNGA', 'Duurgen'])
+    expect(splitArr1).toEqual(result)
+    expect(splitArr2).toEqual(result)
+    expect(splitArr3).toEqual(result)
   })
 })

--- a/helpers/splitWithSearchTerm.test.js
+++ b/helpers/splitWithSearchTerm.test.js
@@ -1,0 +1,16 @@
+import { splitWithSearchTerm } from './splitWithSearchTerm'
+
+describe('splitWithSearchTerm helper function', () => {
+  test('Should produce array matching original capitalization of string', () => {
+    const str = 'hiNgaDiNGADuurgen'
+    const searchTerm1 = 'dinga'
+    const searchTerm2 = 'dINga'
+    const searchTerm3 = 'DINGA'
+    const splitArr1 = splitWithSearchTerm(str, searchTerm1)
+    const splitArr2 = splitWithSearchTerm(str, searchTerm2)
+    const splitArr3 = splitWithSearchTerm(str, searchTerm3)
+    expect(splitArr1).toEqual(['hiNga', 'DiNGA', 'Duurgen'])
+    expect(splitArr2).toEqual(['hiNga', 'DiNGA', 'Duurgen'])
+    expect(splitArr3).toEqual(['hiNga', 'DiNGA', 'Duurgen'])
+  })
+})

--- a/helpers/splitWithSearchTerm.tsx
+++ b/helpers/splitWithSearchTerm.tsx
@@ -7,9 +7,10 @@
 
 export const splitWithSearchTerm = (str: string, searchTerm: string) => {
   /*
-	Using regex with split will return an array with the separator included.
-	The `i` flag is the case insensitive flag, used to ensure that the returned array
-	will include the searchTerm, regardless of the original capialization of the searchTerm
+	Using regex containing capturing parentheses `()` with split will return an array
+	with the separator included. The `i` flag is the case insensitive flag, used to
+	ensure that the returned array will include the searchTerm, regardless of the
+	original capialization of str or searchTerm.
   */
   const regex = new RegExp(`(${searchTerm})`, 'i')
   return str.split(regex).filter(s => s !== '')

--- a/helpers/splitWithSearchTerm.tsx
+++ b/helpers/splitWithSearchTerm.tsx
@@ -4,30 +4,14 @@
 		Inputs: searchTerm='bon', str = 'bonJourbon'
 		Output: [bon, Jour, bon]
 */
+
 export const splitWithSearchTerm = (str: string, searchTerm: string) => {
-  const lowerCaseSearchTerm = searchTerm.toLowerCase()
-  const splitArr = str.toLowerCase().split(lowerCaseSearchTerm)
-  // tracker is used for `str.substr` to extract characters from the original string at the correct places
-  let tracker = 0
-
-  const res = splitArr.reduce(
-    (acc: string[], word: string, splitArrIndex: number) => {
-      // converts words back into their original capitalization
-      const originalWord = str.substr(tracker, word.length)
-      acc.push(originalWord)
-      tracker += word.length
-
-      // used to prevent over-adding of searchTerm back into array
-      if (splitArrIndex === splitArr.length - 1) return acc
-
-      // convert searchTerm to match original capitalization of string
-      const correctSearchCapitalization = str.substr(tracker, searchTerm.length)
-      acc.push(correctSearchCapitalization)
-      tracker += searchTerm.length
-      return acc
-    },
-    []
-  )
-
-  return res
+  /*
+	Using regex with split will return an array with the separator included.
+	The `i` flag is the case insensitive flag, used to ensure that the returned array
+	will include the searchTerm, regardless of the original capialization of the searchTerm
+  */
+  const regex = new RegExp(`(${searchTerm})`, 'i')
+  return str.split(regex).filter(s => s !== '')
+  // filter to remove the empty strings that appear if searchTerm is at the start or end
 }

--- a/helpers/splitWithSearchTerm.tsx
+++ b/helpers/splitWithSearchTerm.tsx
@@ -1,0 +1,33 @@
+/*
+	convert string to array, separated by and including searchTerm
+	Ex:
+		Inputs: searchTerm='bon', str = 'bonJourbon'
+		Output: [bon, Jour, bon]
+*/
+export const splitWithSearchTerm = (str: string, searchTerm: string) => {
+  const lowerCaseSearchTerm = searchTerm.toLowerCase()
+  const splitArr = str.toLowerCase().split(lowerCaseSearchTerm)
+  // tracker is used for `str.substr` to extract characters from the original string at the correct places
+  let tracker = 0
+
+  const res = splitArr.reduce(
+    (acc: string[], word: string, splitArrIndex: number) => {
+      // converts words back into their original capitalization
+      const originalWord = str.substr(tracker, word.length)
+      acc.push(originalWord)
+      tracker += word.length
+
+      // used to prevent over-adding of searchTerm back into array
+      if (splitArrIndex === splitArr.length - 1) return acc
+
+      // convert searchTerm to match original capitalization of string
+      const correctSearchCapitalization = str.substr(tracker, searchTerm.length)
+      acc.push(correctSearchCapitalization)
+      tracker += searchTerm.length
+      return acc
+    },
+    []
+  )
+
+  return res
+}


### PR DESCRIPTION
When highlighted, the searchTerm is not being correctly capitalized to how it appeared in the original string. 
## Example of problem:
<img width="1156" alt="Screen Shot 2020-08-15 at 10 30 30 AM" src="https://user-images.githubusercontent.com/45890848/90318121-189b6100-dee3-11ea-944a-f7d77d0f4d86.png">

The last two highlighted `E`'s should be lowercase, not uppercase.

This PR will:
* capitalize the searchTerm to how it appears in the original string when highlighting it in the search results.
* put `splitWithSearchTerm` into a separate file so it can be re-usable 
* create tests for `splitWithSearchTerm` to ensure capitalization is correct in its return value

## Example of fix:
<img width="1127" alt="Screen Shot 2020-08-15 at 10 44 31 AM" src="https://user-images.githubusercontent.com/45890848/90318434-4bdeef80-dee5-11ea-96b1-69d582d0aad3.png">
