### PR TITLE
closes #387 - change functions in lessonHelpers so they can be usable for admin alerts page

### DIFF
--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -9,8 +9,8 @@ import {
   checkForErrors,
   checkForAllErrors,
   makeGraphqlVariable
-} from '../../../helpers/admin/lessonHelpers'
-import { titleStyle } from './AdminLessonInfo'
+} from '../../../helpers/admin/processingHelpers'
+import { titleStyle, errorChecks } from './AdminLessonInfo'
 
 const challengeAttributes = {
   title: '',
@@ -50,7 +50,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
   // alter gets called when someone clicks button to create a lesson
   const alter = async () => {
     const newProperties = [...challengeProperties]
-    const errors = checkForAllErrors(newProperties)
+    const errors = checkForAllErrors(newProperties, ...errorChecks)
     if (errors) {
       setChallengeProperties(newProperties)
       return
@@ -70,7 +70,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
   const handleChange = (value: string, propertyIndex: number) => {
     const newChallengeProperties = [...challengeProperties]
     newChallengeProperties[propertyIndex].value = value
-    checkForErrors(newChallengeProperties[propertyIndex])
+    checkForErrors(newChallengeProperties[propertyIndex], ...errorChecks)
     setChallengeProperties(newChallengeProperties)
   }
 
@@ -101,7 +101,7 @@ const LessonChallenge: React.FC<LessonChallengeProps> = ({
   const handleChange = (value: string, propertyIndex: number) => {
     const newChallengeProperties = [...challengeProperties]
     newChallengeProperties[propertyIndex].value = value
-    checkForErrors(newChallengeProperties[propertyIndex])
+    checkForErrors(newChallengeProperties[propertyIndex], ...errorChecks)
     setChallengeProperties(newChallengeProperties)
   }
 
@@ -109,7 +109,7 @@ const LessonChallenge: React.FC<LessonChallengeProps> = ({
     title: 'Update Challenge',
     onClick: () => {
       const newProperties = [...challengeProperties]
-      const errors = checkForAllErrors(newProperties)
+      const errors = checkForAllErrors(newProperties, ...errorChecks)
       if (errors) {
         setChallengeProperties(newProperties)
         return

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -9,7 +9,7 @@ import {
   makeGraphqlVariable,
   checkForErrors,
   checkForAllErrors
-} from '../../../helpers/admin/lessonHelpers'
+} from '../../../helpers/admin/processingHelpers'
 import { Lesson } from '../../../graphql/index'
 import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
 
@@ -17,6 +17,9 @@ export const titleStyle: React.CSSProperties | undefined = {
   fontSize: '4rem',
   fontWeight: 'bold'
 }
+
+// [required, numbersOnly]
+export const errorChecks = [['title', 'description', 'order'], ['order']]
 
 type LessonInfoProps = {
   lessons: Lesson[] | undefined
@@ -47,7 +50,7 @@ const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
   // alter gets called when someone clicks button to update a lesson
   const alter = async () => {
     const newProperties = [...lessonProperties]
-    const errors = checkForAllErrors(newProperties)
+    const errors = checkForAllErrors(newProperties, ...errorChecks)
     if (errors) {
       setLessonProperties(newProperties)
       return
@@ -62,7 +65,7 @@ const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
   const handleChange = (value: string, propertyIndex: number) => {
     const newLessonProperties = [...lessonProperties]
     newLessonProperties[propertyIndex].value = value
-    checkForErrors(newLessonProperties[propertyIndex])
+    checkForErrors(newLessonProperties[propertyIndex], ...errorChecks)
     setLessonProperties(newLessonProperties)
   }
 
@@ -108,7 +111,7 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
   // alter gets called when someone clicks button to create a lesson
   const alter = async () => {
     const newProperties = [...lessonProperties]
-    const errors = checkForAllErrors(newProperties)
+    const errors = checkForAllErrors(newProperties, ...errorChecks)
     if (errors) {
       setLessonProperties(newProperties)
       return
@@ -124,7 +127,7 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
   const handleChange = (value: string, propertyIndex: number) => {
     const newLessonProperties = [...lessonProperties]
     newLessonProperties[propertyIndex].value = value
-    checkForErrors(newLessonProperties[propertyIndex])
+    checkForErrors(newLessonProperties[propertyIndex], ...errorChecks)
     setLessonProperties(newLessonProperties)
   }
 

--- a/helpers/admin/processingHelpers.ts
+++ b/helpers/admin/processingHelpers.ts
@@ -24,11 +24,9 @@ export const makeGraphqlVariable = (options: any, addProp?: any) => {
     return acc
   }, {})
 
-  res.order = parseInt(res.order)
+  if (res.hasOwnProperty('order')) res.order = parseInt(res.order)
 
-  if (res.hasOwnProperty('id')) {
-    res.id = parseInt(res.id ? res.id + '' : '')
-  }
+  if (res.hasOwnProperty('id')) res.id = parseInt(res.id ? res.id + '' : '')
 
   if (addProp) {
     const keys = Object.keys(addProp)
@@ -41,16 +39,27 @@ export const makeGraphqlVariable = (options: any, addProp?: any) => {
 }
 
 //checks for error for one element in the `inputvalues` array
-export const checkForErrors = (option: any) => {
+export const checkForErrors = (
+  option: any,
+  required?: string[],
+  numbersOnly?: string[]
+) => {
   const { title, value } = option
-  const required = ['title', 'description', 'order']
 
-  if (required.includes(title) && !value) {
+  if (required && required.includes(title) && !value) {
     option.error = 'Required'
     return true
   }
 
-  if (title === 'order' && isNaN(parseInt(value))) {
+  /**
+   * parseInt(value).toString() !== value needed incase someone begins typing
+   * with a number, but then types a non-number. Ex: '32F'
+   */
+  if (
+    numbersOnly &&
+    numbersOnly.includes(title) &&
+    parseInt(value).toString() !== value
+  ) {
     option.error = 'Numbers only'
     return true
   }
@@ -61,10 +70,14 @@ export const checkForErrors = (option: any) => {
 }
 
 //checks for error for each element in the `inputvalues` array
-export const checkForAllErrors = (options: any) => {
+export const checkForAllErrors = (
+  options: any,
+  required?: string[],
+  numbersOnly?: string[]
+) => {
   let error = false
   options.forEach((option: any) => {
-    if (checkForErrors(option)) error = true
+    if (checkForErrors(option, required, numbersOnly)) error = true
   })
   return error
 }


### PR DESCRIPTION
The lessonHelpers has several functions that need to be changed in order for it to be usable for the upcoming admin alerts page.
These functions are:
1) Function `makeGraphqlVariable` needs to check if the order property exists or typeError will occur
2) Functions `checkForErrors` and `checkForAllErrors` need to take in required and numbersOnly properties. This is because the admin alerts page have different requirements on what property fields must be required what property fields can only contain numbers only.

This PR will:
* Change `makeGraphqlVariable`, `checkForErrors`, and `checkForAllErrors` functions so that it is usable for upcoming admin alerts page
* Change name of file from `lessonHelpers` to `processingHelpers` because the file is not only used for the admin lessons page
* Change code for admin lessons page to reflect update to the functions in the `processingHelpers` file