### PR TITLE
closes #389 - Create api/lessons page that returns object of lessons data

### DIFF
--- a/pages/api/lessons.test.js
+++ b/pages/api/lessons.test.js
@@ -1,0 +1,22 @@
+import lessonsAPI from './lessons'
+import noop from '../../helpers/noop'
+import * as getLessons from '../../graphql/queryResolvers/lessons'
+
+getLessons.lessons = jest.fn().mockReturnValue([1, 2, 3])
+
+describe('lessonsAPI', () => {
+  const res = {
+    json: jest.fn(noop),
+    status: jest.fn(noop)
+  }
+
+  test('should respond with 200 status code', async () => {
+    await lessonsAPI(null, res)
+    expect(res.status).toBeCalledWith(200)
+  })
+
+  test('should respond with json data from getLessons.lessons', async () => {
+    await lessonsAPI(null, res)
+    expect(res.json).toBeCalledWith([1, 2, 3])
+  })
+})

--- a/pages/api/lessons.test.js
+++ b/pages/api/lessons.test.js
@@ -1,10 +1,7 @@
 import lessonsAPI from './lessons'
 import noop from '../../helpers/noop'
-import * as getLessons from '../../graphql/queryResolvers/lessons'
-
-getLessons.lessons = jest
-  .fn()
-  .mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
+import { lessons } from '../../graphql/queryResolvers/lessons'
+lessons = jest.fn().mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
 
 describe('lessonsAPI', () => {
   const res = {
@@ -12,13 +9,15 @@ describe('lessonsAPI', () => {
     status: jest.fn(noop)
   }
 
-  test('should respond with 200 status code', async () => {
-    await lessonsAPI(null, res)
+  const req = null
+
+  test('should respond with 200 status code when there is no error', async () => {
+    await lessonsAPI(req, res)
     expect(res.status).toBeCalledWith(200)
   })
 
-  test('should respond with json data from getLessons.lessons', async () => {
-    await lessonsAPI(null, res)
+  test('should respond with json data from lessons() when there is no error', async () => {
+    await lessonsAPI(req, res)
     expect(res.json).toBeCalledWith(['man', 'bear', 'pig', 'manbearpig'])
   })
 })

--- a/pages/api/lessons.test.js
+++ b/pages/api/lessons.test.js
@@ -1,7 +1,6 @@
 import lessonsAPI from './lessons'
 import noop from '../../helpers/noop'
-import { lessons } from '../../graphql/queryResolvers/lessons'
-lessons = jest.fn().mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
+import * as getLessons from '../../graphql/queryResolvers/lessons'
 
 describe('lessonsAPI', () => {
   const res = {
@@ -9,15 +8,35 @@ describe('lessonsAPI', () => {
     status: jest.fn(noop)
   }
 
-  const req = null
-
   test('should respond with 200 status code when there is no error', async () => {
-    await lessonsAPI(req, res)
+    getLessons.lessons = jest
+      .fn()
+      .mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
+    await lessonsAPI(null, res)
     expect(res.status).toBeCalledWith(200)
   })
 
   test('should respond with json data from lessons() when there is no error', async () => {
-    await lessonsAPI(req, res)
+    getLessons.lessons = jest
+      .fn()
+      .mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
+    await lessonsAPI(null, res)
     expect(res.json).toBeCalledWith(['man', 'bear', 'pig', 'manbearpig'])
+  })
+
+  test('should respond with 500 status code when there is an error', async () => {
+    getLessons.lessons = jest.fn().mockImplementation(() => {
+      throw new Error('Error')
+    })
+    await lessonsAPI(null, res)
+    expect(res.status).toBeCalledWith(500)
+  })
+
+  test('should respond with error message when there is an error', async () => {
+    getLessons.lessons = jest.fn().mockImplementation(() => {
+      throw new Error('Error')
+    })
+    await lessonsAPI(null, res)
+    expect(res.json).toBeCalledWith('Error occured :(')
   })
 })

--- a/pages/api/lessons.test.js
+++ b/pages/api/lessons.test.js
@@ -8,18 +8,16 @@ describe('lessonsAPI', () => {
     status: jest.fn(noop)
   }
 
+  getLessons.lessons = jest
+    .fn()
+    .mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
+
   test('should respond with 200 status code when there is no error', async () => {
-    getLessons.lessons = jest
-      .fn()
-      .mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
     await lessonsAPI(null, res)
     expect(res.status).toBeCalledWith(200)
   })
 
   test('should respond with json data from lessons() when there is no error', async () => {
-    getLessons.lessons = jest
-      .fn()
-      .mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
     await lessonsAPI(null, res)
     expect(res.json).toBeCalledWith(['man', 'bear', 'pig', 'manbearpig'])
   })
@@ -34,7 +32,7 @@ describe('lessonsAPI', () => {
 
   test('should respond with error message when there is an error', async () => {
     getLessons.lessons = jest.fn().mockImplementation(() => {
-      throw new Error('Error')
+      throw new Error('Error occured :(')
     })
     await lessonsAPI(null, res)
     expect(res.json).toBeCalledWith('Error occured :(')

--- a/pages/api/lessons.test.js
+++ b/pages/api/lessons.test.js
@@ -2,7 +2,9 @@ import lessonsAPI from './lessons'
 import noop from '../../helpers/noop'
 import * as getLessons from '../../graphql/queryResolvers/lessons'
 
-getLessons.lessons = jest.fn().mockReturnValue([1, 2, 3])
+getLessons.lessons = jest
+  .fn()
+  .mockReturnValue(['man', 'bear', 'pig', 'manbearpig'])
 
 describe('lessonsAPI', () => {
   const res = {
@@ -17,6 +19,6 @@ describe('lessonsAPI', () => {
 
   test('should respond with json data from getLessons.lessons', async () => {
     await lessonsAPI(null, res)
-    expect(res.json).toBeCalledWith([1, 2, 3])
+    expect(res.json).toBeCalledWith(['man', 'bear', 'pig', 'manbearpig'])
   })
 })

--- a/pages/api/lessons.ts
+++ b/pages/api/lessons.ts
@@ -1,10 +1,9 @@
-import * as getLessons from '../../graphql/queryResolvers/lessons'
+import { lessons } from '../../graphql/queryResolvers/lessons'
 import { LoggedRequest } from '../../@types/helpers'
 import { NextApiResponse } from 'next'
 
-const lessons = async (_: LoggedRequest, res: NextApiResponse) => {
-  const allLessons = await getLessons.lessons()
+export default async (_: LoggedRequest, res: NextApiResponse) => {
+  const allLessons = await lessons()
   res.status(200)
   res.json(allLessons)
 }
-export default lessons

--- a/pages/api/lessons.ts
+++ b/pages/api/lessons.ts
@@ -4,6 +4,7 @@ import { NextApiResponse } from 'next'
 
 const lessons = async (_: LoggedRequest, res: NextApiResponse) => {
   const allLessons = await getLessons.lessons()
+  res.status(200)
   res.json(allLessons)
 }
 export default lessons

--- a/pages/api/lessons.ts
+++ b/pages/api/lessons.ts
@@ -3,7 +3,12 @@ import { LoggedRequest } from '../../@types/helpers'
 import { NextApiResponse } from 'next'
 
 export default async (_: LoggedRequest, res: NextApiResponse) => {
-  const allLessons = await lessons()
-  res.status(200)
-  res.json(allLessons)
+  try {
+    const allLessons = await lessons()
+    res.status(200)
+    res.json(allLessons)
+  } catch (err) {
+    res.status(500)
+    res.json('Error occured :(')
+  }
 }

--- a/pages/api/lessons.ts
+++ b/pages/api/lessons.ts
@@ -1,0 +1,9 @@
+import * as getLessons from '../../graphql/queryResolvers/lessons'
+import { LoggedRequest } from '../../@types/helpers'
+import { NextApiResponse } from 'next'
+
+const lessons = async (_: LoggedRequest, res: NextApiResponse) => {
+  const allLessons = await getLessons.lessons()
+  res.json(allLessons)
+}
+export default lessons


### PR DESCRIPTION
This page needs to be created, as the API is used in examples in the c0d3 curriculum

This PR will:
* Create an `api/lessons` page that returns an object containing the same data the lessons API for version 1 of code returned.
* Create tests for the api page