### PR TITLE
closes #405 - Enabling Card component to make its title the purple primary color

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -413,6 +413,31 @@ exports[`Storyshots Components/Card With Fail 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Card With Primary 1`] = `
+<div
+  className="row mt-5"
+>
+  <div
+    className="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
+  >
+    <div
+      className="card-body text-center pt-5 pb-5"
+    >
+      <h1
+        className="card-title h2 font-weight-bold mb-5 text-primary"
+      >
+        Title of the card
+      </h1>
+      <p
+        className="card-text"
+      >
+        Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Card With Success 1`] = `
 <div
   className="row mt-5"

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -430,9 +430,7 @@ exports[`Storyshots Components/Card With Primary 1`] = `
       </h1>
       <p
         className="card-text"
-      >
-        Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...
-      </p>
+      />
     </div>
   </div>
 </div>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -3,6 +3,7 @@ import { ReactComponent as Checked } from '../assets/images/checked.svg'
 import { ReactComponent as Fail } from '../public/curriculumAssets/icons/exclamation.svg'
 
 type Props = {
+  primary?: boolean
   children?: React.ReactNode
   type?: 'success' | 'fail'
   text?: string
@@ -21,18 +22,28 @@ const icons: { [type: string]: React.FC } = {
   fail: Fail
 }
 
-const Card: React.FC<Props> = props => {
-  const classes = `${props.classes ||
-    'col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0'}`
-  const Icon = props.type ? icons[props.type] : null
+const Card: React.FC<Props> = ({
+  primary,
+  children,
+  type,
+  text,
+  classes,
+  title
+}) => {
+  const classesList =
+    classes || 'col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0'
+  const Icon = type ? icons[type] : null
+  const titleClasses =
+    'card-title h2 font-weight-bold mb-5' + (primary ? ' text-primary' : '')
+
   return (
     <div className="row mt-5">
-      <div className={`card shadow-sm ${classes}`}>
+      <div className={`card shadow-sm ${classesList}`}>
         <div className="card-body text-center pt-5 pb-5">
           {Icon && <Icon {...iconProps} />}
-          <h1 className="card-title h2 font-weight-bold mb-5">{props.title}</h1>
-          <p className="card-text">{props.text}</p>
-          {props.children}
+          <h1 className={titleClasses}>{title}</h1>
+          <p className="card-text">{text}</p>
+          {children}
         </div>
       </div>
     </div>

--- a/stories/components/Card.stories.tsx
+++ b/stories/components/Card.stories.tsx
@@ -8,6 +8,14 @@ export default {
 
 export const Basic: React.FC = () => <Card title="Title of the card" />
 
+export const WithPrimary: React.FC = () => (
+  <Card
+    primary={true}
+    title="Title of the card"
+    text="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit..."
+  />
+)
+
 export const WithText: React.FC = () => (
   <Card
     title="Title of the card"

--- a/stories/components/Card.stories.tsx
+++ b/stories/components/Card.stories.tsx
@@ -9,11 +9,7 @@ export default {
 export const Basic: React.FC = () => <Card title="Title of the card" />
 
 export const WithPrimary: React.FC = () => (
-  <Card
-    primary={true}
-    title="Title of the card"
-    text="Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit..."
-  />
+  <Card primary={true} title="Title of the card" />
 )
 
 export const WithText: React.FC = () => (


### PR DESCRIPTION
## Issues:
1) The purple `primary` color from bootstrap classes is everywhere on C0d3.com. The landing page, review submission pages, admin users and lesson pages, etc. all have places that use the `primary` color. Currently, the [Card Component](https://github.com/garageScript/c0d3-app/blob/master/components/Card.tsx) does not have the option of turning its title the `primary` purple color. This should be fixed so that the upcoming `admin alerts` page can use the `card component` to maintain codebase consistency. 
2) Card component props are not deconstructed -- they should be, since the overwhelming majority(`this is the first i've seen them not deconstructed`) of the codebase deconstruct props. Doing this will increase codebase consistency

## This PR will:
* Deconstruct props in Card component
* Enable the title in Card component to turn the purple primary color through a prop named `primary`
* Update storybook to include example of using `primary` prop to turn a title purple
* Update snapshots
<img width="794" alt="Screen Shot 2020-09-25 at 12 12 37 PM" src="https://user-images.githubusercontent.com/45890848/94310080-eba08c00-ff2d-11ea-8292-73f854183037.png">
