### PR TITLE
Add contributors on README

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -79,6 +79,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "coltonehrman",
+      "name": "Colton Ehrman",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/12456288?v=4",
+      "profile": "https://coltonehrman.github.io/react-portfolio/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -106,6 +106,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "stevenlay",
+      "name": "Steven Lay",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/20160586?v=4",
+      "profile": "https://github.com/stevenlay",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,29 @@
+{
+  "projectName": "c0d3-app",
+  "projectOwner": "garageScript",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "songz",
+      "name": "Song Zheng",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/686933?v=4",
+      "profile": "https://www.c0d3.com/",
+      "contributions": [
+        "bug",
+        "doc",
+        "ideas",
+        "infra",
+        "mentoring",
+        "projectManagement"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -43,6 +43,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Wolfy64",
+      "name": "David De Wulf",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/25457563?v=4",
+      "profile": "https://dewulfdavid.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -70,6 +70,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "SahilKalra98",
+      "name": "SahilKalra98",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/23374591?v=4",
+      "profile": "https://github.com/SahilKalra98",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -52,6 +52,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "michaelbayday",
+      "name": "Michael Dinh",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/35093298?v=4",
+      "profile": "https://github.com/michaelbayday",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -61,6 +61,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "rkalra247",
+      "name": "rkalra247",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/27792256?v=4",
+      "profile": "https://github.com/rkalra247",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -88,6 +88,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "danielthalhuber",
+      "name": "Daniel Thalhuber",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/32470229?v=4",
+      "profile": "https://github.com/danielthalhuber",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -97,6 +97,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Cijin",
+      "name": "Cijin Cherian",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1990966?v=4",
+      "profile": "https://github.com/Cijin",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -115,6 +115,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ggwadera",
+      "name": "Guilherme Gwadera",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/16023489?v=4",
+      "profile": "https://www.linkedin.com/in/guilherme-gwadera/",
+      "contributions": [
+        "doc",
+        "review"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -23,6 +23,17 @@
         "mentoring",
         "projectManagement"
       ]
+    },
+    {
+      "login": "hwong0305",
+      "name": "Herman Wong",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/7990856?v=4",
+      "profile": "https://www.devwong.com/",
+      "contributions": [
+        "bug",
+        "code",
+        "review"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -34,6 +34,15 @@
         "code",
         "review"
       ]
+    },
+    {
+      "login": "aortizoj15",
+      "name": "Alexis Ortiz Ojeda",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/36532821?v=4",
+      "profile": "https://github.com/aortizoj15",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -49,6 +49,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href="https://www.c0d3.com/"><img src="https://avatars2.githubusercontent.com/u/686933?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Song Zheng</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/issues?q=author%3Asongz" title="Bug reports">🐛</a> <a href="https://github.com/garageScript/c0d3-app/commits?author=songz" title="Documentation">📖</a> <a href="#ideas-songz" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-songz" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#mentoring-songz" title="Mentoring">🧑‍🏫</a> <a href="#projectManagement-songz" title="Project Management">📆</a></td>
+    <td align="center"><a href="https://www.devwong.com/"><img src="https://avatars1.githubusercontent.com/u/7990856?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Herman Wong</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/issues?q=author%3Ahwong0305" title="Bug reports">🐛</a> <a href="https://github.com/garageScript/c0d3-app/commits?author=hwong0305" title="Code">💻</a> <a href="https://github.com/garageScript/c0d3-app/pulls?q=is%3Apr+reviewed-by%3Ahwong0305" title="Reviewed Pull Requests">👀</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -59,6 +59,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://coltonehrman.github.io/react-portfolio/"><img src="https://avatars1.githubusercontent.com/u/12456288?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Colton Ehrman</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=coltonehrman" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/danielthalhuber"><img src="https://avatars1.githubusercontent.com/u/32470229?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Daniel Thalhuber</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=danielthalhuber" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/Cijin"><img src="https://avatars0.githubusercontent.com/u/1990966?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Cijin Cherian</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=Cijin" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -53,6 +53,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/aortizoj15"><img src="https://avatars3.githubusercontent.com/u/36532821?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexis Ortiz Ojeda</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=aortizoj15" title="Code">💻</a></td>
     <td align="center"><a href="https://dewulfdavid.com/"><img src="https://avatars3.githubusercontent.com/u/25457563?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David De Wulf</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=Wolfy64" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/michaelbayday"><img src="https://avatars2.githubusercontent.com/u/35093298?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michael Dinh</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=michaelbayday" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/rkalra247"><img src="https://avatars1.githubusercontent.com/u/27792256?v=4?s=100" width="100px;" alt=""/><br /><sub><b>rkalra247</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=rkalra247" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -52,6 +52,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://www.devwong.com/"><img src="https://avatars1.githubusercontent.com/u/7990856?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Herman Wong</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/issues?q=author%3Ahwong0305" title="Bug reports">🐛</a> <a href="https://github.com/garageScript/c0d3-app/commits?author=hwong0305" title="Code">💻</a> <a href="https://github.com/garageScript/c0d3-app/pulls?q=is%3Apr+reviewed-by%3Ahwong0305" title="Reviewed Pull Requests">👀</a></td>
     <td align="center"><a href="https://github.com/aortizoj15"><img src="https://avatars3.githubusercontent.com/u/36532821?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexis Ortiz Ojeda</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=aortizoj15" title="Code">💻</a></td>
     <td align="center"><a href="https://dewulfdavid.com/"><img src="https://avatars3.githubusercontent.com/u/25457563?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David De Wulf</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=Wolfy64" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/michaelbayday"><img src="https://avatars2.githubusercontent.com/u/35093298?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michael Dinh</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=michaelbayday" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # c0d3.com
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
 [![codecov](https://codecov.io/gh/garageScript/c0d3-app/branch/master/graph/badge.svg)](https://codecov.io/gh/garageScript/c0d3-app)
@@ -35,3 +38,23 @@ Watch the video below to find out how to develop with TypeScript in React
 
 1. Before submitting your code run `yarn autofix`.
 2. When creating a new Component, include a StoryBook demo of the Component with the PR.
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://www.c0d3.com/"><img src="https://avatars2.githubusercontent.com/u/686933?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Song Zheng</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/issues?q=author%3Asongz" title="Bug reports">🐛</a> <a href="https://github.com/garageScript/c0d3-app/commits?author=songz" title="Documentation">📖</a> <a href="#ideas-songz" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-songz" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#mentoring-songz" title="Mentoring">🧑‍🏫</a> <a href="#projectManagement-songz" title="Project Management">📆</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -55,6 +55,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/michaelbayday"><img src="https://avatars2.githubusercontent.com/u/35093298?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michael Dinh</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=michaelbayday" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/rkalra247"><img src="https://avatars1.githubusercontent.com/u/27792256?v=4?s=100" width="100px;" alt=""/><br /><sub><b>rkalra247</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=rkalra247" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/SahilKalra98"><img src="https://avatars1.githubusercontent.com/u/23374591?v=4?s=100" width="100px;" alt=""/><br /><sub><b>SahilKalra98</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=SahilKalra98" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://coltonehrman.github.io/react-portfolio/"><img src="https://avatars1.githubusercontent.com/u/12456288?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Colton Ehrman</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=coltonehrman" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -50,6 +50,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://www.c0d3.com/"><img src="https://avatars2.githubusercontent.com/u/686933?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Song Zheng</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/issues?q=author%3Asongz" title="Bug reports">🐛</a> <a href="https://github.com/garageScript/c0d3-app/commits?author=songz" title="Documentation">📖</a> <a href="#ideas-songz" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-songz" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#mentoring-songz" title="Mentoring">🧑‍🏫</a> <a href="#projectManagement-songz" title="Project Management">📆</a></td>
     <td align="center"><a href="https://www.devwong.com/"><img src="https://avatars1.githubusercontent.com/u/7990856?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Herman Wong</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/issues?q=author%3Ahwong0305" title="Bug reports">🐛</a> <a href="https://github.com/garageScript/c0d3-app/commits?author=hwong0305" title="Code">💻</a> <a href="https://github.com/garageScript/c0d3-app/pulls?q=is%3Apr+reviewed-by%3Ahwong0305" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://github.com/aortizoj15"><img src="https://avatars3.githubusercontent.com/u/36532821?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexis Ortiz Ojeda</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=aortizoj15" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -58,6 +58,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://coltonehrman.github.io/react-portfolio/"><img src="https://avatars1.githubusercontent.com/u/12456288?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Colton Ehrman</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=coltonehrman" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/danielthalhuber"><img src="https://avatars1.githubusercontent.com/u/32470229?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Daniel Thalhuber</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=danielthalhuber" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-12-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -61,6 +61,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/danielthalhuber"><img src="https://avatars1.githubusercontent.com/u/32470229?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Daniel Thalhuber</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=danielthalhuber" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/Cijin"><img src="https://avatars0.githubusercontent.com/u/1990966?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Cijin Cherian</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=Cijin" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/stevenlay"><img src="https://avatars1.githubusercontent.com/u/20160586?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Steven Lay</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=stevenlay" title="Code">💻</a></td>
+    <td align="center"><a href="https://www.linkedin.com/in/guilherme-gwadera/"><img src="https://avatars2.githubusercontent.com/u/16023489?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Guilherme Gwadera</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=ggwadera" title="Documentation">📖</a> <a href="https://github.com/garageScript/c0d3-app/pulls?q=is%3Apr+reviewed-by%3Aggwadera" title="Reviewed Pull Requests">👀</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -60,6 +60,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://coltonehrman.github.io/react-portfolio/"><img src="https://avatars1.githubusercontent.com/u/12456288?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Colton Ehrman</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=coltonehrman" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/danielthalhuber"><img src="https://avatars1.githubusercontent.com/u/32470229?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Daniel Thalhuber</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=danielthalhuber" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/Cijin"><img src="https://avatars0.githubusercontent.com/u/1990966?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Cijin Cherian</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=Cijin" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/stevenlay"><img src="https://avatars1.githubusercontent.com/u/20160586?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Steven Lay</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=stevenlay" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -51,6 +51,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://www.c0d3.com/"><img src="https://avatars2.githubusercontent.com/u/686933?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Song Zheng</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/issues?q=author%3Asongz" title="Bug reports">🐛</a> <a href="https://github.com/garageScript/c0d3-app/commits?author=songz" title="Documentation">📖</a> <a href="#ideas-songz" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-songz" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#mentoring-songz" title="Mentoring">🧑‍🏫</a> <a href="#projectManagement-songz" title="Project Management">📆</a></td>
     <td align="center"><a href="https://www.devwong.com/"><img src="https://avatars1.githubusercontent.com/u/7990856?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Herman Wong</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/issues?q=author%3Ahwong0305" title="Bug reports">🐛</a> <a href="https://github.com/garageScript/c0d3-app/commits?author=hwong0305" title="Code">💻</a> <a href="https://github.com/garageScript/c0d3-app/pulls?q=is%3Apr+reviewed-by%3Ahwong0305" title="Reviewed Pull Requests">👀</a></td>
     <td align="center"><a href="https://github.com/aortizoj15"><img src="https://avatars3.githubusercontent.com/u/36532821?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexis Ortiz Ojeda</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=aortizoj15" title="Code">💻</a></td>
+    <td align="center"><a href="https://dewulfdavid.com/"><img src="https://avatars3.githubusercontent.com/u/25457563?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David De Wulf</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=Wolfy64" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c0d3.com
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ![CI](https://github.com/garageScript/c0d3.com/workflows/CI/badge.svg)
@@ -54,6 +54,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://dewulfdavid.com/"><img src="https://avatars3.githubusercontent.com/u/25457563?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David De Wulf</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=Wolfy64" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/michaelbayday"><img src="https://avatars2.githubusercontent.com/u/35093298?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michael Dinh</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=michaelbayday" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/rkalra247"><img src="https://avatars1.githubusercontent.com/u/27792256?v=4?s=100" width="100px;" alt=""/><br /><sub><b>rkalra247</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=rkalra247" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/SahilKalra98"><img src="https://avatars1.githubusercontent.com/u/23374591?v=4?s=100" width="100px;" alt=""/><br /><sub><b>SahilKalra98</b></sub></a><br /><a href="https://github.com/garageScript/c0d3-app/commits?author=SahilKalra98" title="Code">💻</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
This PR adds a Contributors section at the end of the project readme file.

The contributors section follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification.

You can see a preview on my fork [here](https://github.com/ggwadera/c0d3-app/tree/all-contributors#contributors-).

### Why?

From the all-contributors [overview](https://allcontributors.org/docs/en/overview):

> This is a specification for recognizing contributors to an open source project in a way that rewards each and every contribution, not just code. The basic idea is this:

> Use the project README (or another prominent public documentation page in the project) to recognize the contributions of members of the project community.

> People are giving themselves and their free time to contribute to open source projects in so many ways, so we believe everyone should be praised for their contributions (code or not).

### How?

You can use the [@all-contributors bot 🤖](https://allcontributors.org/docs/en/bot/overview) to automate acknowledging contributors, by commenting on an issue or a pull request. Check out how to use the bot [right here](https://allcontributors.org/docs/en/bot/usage).