### PR TITLE
Enable `add alert` feature into admin alerts page

### DIFF
--- a/components/admin/alerts/AdminNewAlert.tsx
+++ b/components/admin/alerts/AdminNewAlert.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useEffect } from 'react'
+import { useMutation } from '@apollo/react-hooks'
+import Alert from '../../../components/Alert'
+import { FormCard } from '../../../components/FormCard'
+import ADD_ALERT from '../../../graphql/queries/addAlert'
+import { Alert as AlertType } from '../../../graphql'
+import noop from '../../../helpers/noop'
+import { alertValidation } from '../../../helpers/formValidation'
+import { formChange } from '../../../helpers/formChange'
+import {
+  errorCheckAllFields,
+  getPropertyArr,
+  makeGraphqlVariable
+} from '../../../helpers/admin/adminHelpers'
+
+type NewAlertProps = {
+  setAlerts: React.Dispatch<React.SetStateAction<AlertType[]>>
+}
+
+const newAlertAttributes = {
+  text: '',
+  type: [
+    { title: 'info', as: 'button' },
+    { title: 'urgent', as: 'button' }
+  ],
+  url: '',
+  urlCaption: ''
+}
+
+export const NewAlert: React.FC<NewAlertProps> = ({ setAlerts }) => {
+  const handleChange = async (value: string, propertyIndex: number) => {
+    await formChange(
+      value,
+      propertyIndex,
+      alertProperties,
+      setAlertProperties,
+      alertValidation
+    )
+  }
+
+  const blankValuesForm = getPropertyArr(
+    { ...newAlertAttributes },
+    undefined,
+    handleChange
+  )
+
+  const [createAlert, { loading, data }] = useMutation(ADD_ALERT)
+  const [alertProperties, setAlertProperties] = useState(blankValuesForm)
+
+  // when data is fully loaded after sending mutation request, update front-end alerts info
+  useEffect(() => {
+    if (!loading && data) {
+      setAlerts(data.addAlert)
+      setAlertProperties(blankValuesForm)
+    }
+  }, [data])
+
+  // alter gets called when someone clicks button to create a lesson
+  const alter = async () => {
+    const newProperties = [...alertProperties]
+    const valid = await errorCheckAllFields(newProperties, alertValidation)
+    if (!valid) {
+      setAlertProperties(newProperties)
+      return
+    }
+    try {
+      await createAlert(makeGraphqlVariable(newProperties))
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+
+  return (
+    <div className="row mb-4">
+      <div className="col-8 offset-2">
+        <div className="mb-3">
+          <Alert
+            alert={{
+              id: '-1',
+              ...makeGraphqlVariable(alertProperties).variables
+            }}
+            onDismiss={noop}
+          />
+        </div>
+        <div className="text-left">
+          <FormCard
+            values={alertProperties}
+            onSubmit={{ title: 'Create New Alert', onClick: alter }}
+            onChange={handleChange}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -7,10 +7,10 @@ import { Lesson, Challenge, Maybe } from '../../../graphql/index'
 import {
   getPropertyArr,
   makeGraphqlVariable,
-  errorCheckAllFields,
-  errorCheckSingleField
+  errorCheckAllFields
 } from '../../../helpers/admin/adminHelpers'
 import { lessonSchema } from '../../../helpers/formValidation'
+import { formChange } from '../../../helpers/formChange'
 
 const challengeAttributes = {
   title: '',
@@ -68,14 +68,13 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
   }
 
   const handleChange = async (value: string, propertyIndex: number) => {
-    const newChallengeProperties = [...challengeProperties]
-    newChallengeProperties[propertyIndex].value = value
-    await errorCheckSingleField(
-      newChallengeProperties,
+    await formChange(
+      value,
       propertyIndex,
+      challengeProperties,
+      setChallengeProperties,
       lessonSchema
     )
-    setChallengeProperties(newChallengeProperties)
   }
 
   return (
@@ -104,14 +103,13 @@ const LessonChallenge: React.FC<LessonChallengeProps> = ({
   )
 
   const handleChange = async (value: string, propertyIndex: number) => {
-    const newChallengeProperties = [...challengeProperties]
-    newChallengeProperties[propertyIndex].value = value
-    await errorCheckSingleField(
-      newChallengeProperties,
+    await formChange(
+      value,
       propertyIndex,
+      challengeProperties,
+      setChallengeProperties,
       lessonSchema
     )
-    setChallengeProperties(newChallengeProperties)
   }
 
   const handleSubmit = {

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -99,7 +99,7 @@ const LessonChallenge: React.FC<LessonChallengeProps> = ({
   alter
 }) => {
   const [challengeProperties, setChallengeProperties] = useState(
-    getPropertyArr(challenge, ['lessonId'])
+    getPropertyArr(challenge, ['lessonId', '__typename'])
   )
 
   const handleChange = async (value: string, propertyIndex: number) => {

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -33,7 +33,7 @@ type NewLessonProps = {
 const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
   const [alterLesson, { loading, data }] = useMutation(updateLesson)
   const [lessonProperties, setLessonProperties] = useState(
-    getPropertyArr(lesson, ['challenges'])
+    getPropertyArr(lesson, ['challenges', '__typename'])
   )
   // when data is fully loaded after sending mutation request, update front-end lessons info
   useEffect(() => {

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -7,12 +7,12 @@ import _ from 'lodash'
 import {
   getPropertyArr,
   makeGraphqlVariable,
-  errorCheckAllFields,
-  errorCheckSingleField
+  errorCheckAllFields
 } from '../../../helpers/admin/adminHelpers'
 import { Lesson } from '../../../graphql/index'
 import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
 import { lessonSchema } from '../../../helpers/formValidation'
+import { formChange } from '../../../helpers/formChange'
 
 type LessonInfoProps = {
   lessons: Lesson[] | undefined
@@ -56,14 +56,13 @@ const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
   }
 
   const handleChange = async (value: string, propertyIndex: number) => {
-    const newLessonProperties = [...lessonProperties]
-    newLessonProperties[propertyIndex].value = value
-    await errorCheckSingleField(
-      newLessonProperties,
+    await formChange(
+      value,
       propertyIndex,
+      lessonProperties,
+      setLessonProperties,
       lessonSchema
     )
-    setLessonProperties(newLessonProperties)
   }
 
   return (
@@ -124,14 +123,13 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
   }
 
   const handleChange = async (value: string, propertyIndex: number) => {
-    let newLessonProperties: any = [...lessonProperties]
-    newLessonProperties[propertyIndex].value = value
-    await errorCheckSingleField(
-      newLessonProperties,
+    await formChange(
+      value,
       propertyIndex,
+      lessonProperties,
+      setLessonProperties,
       lessonSchema
     )
-    setLessonProperties(newLessonProperties)
   }
 
   return (

--- a/helpers/admin/adminHelpers.test.js
+++ b/helpers/admin/adminHelpers.test.js
@@ -1,0 +1,153 @@
+import * as adminHelpers from './adminHelpers'
+import {
+  getPropertyArr,
+  errorCheckSingleField,
+  errorCheckAllFields
+} from './adminHelpers'
+jest.mock('yup')
+import { reach } from 'yup'
+reach.mockReturnValue({
+  validate: jest.fn()
+})
+const dropdownMenuItems = [
+  { title: 'Lessons', as: 'button' },
+  { title: 'Users', as: 'button' },
+  { title: 'Alerts', as: 'button' }
+]
+
+describe('adminHelper function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should return correct results in getPropertyArr function', async () => {
+    const testFunc = jest.fn()
+    const res = getPropertyArr(
+      {
+        description: 'lol',
+        bam: 'bam',
+        deem: [],
+        potate: 0,
+        cactus: undefined
+      },
+      ['bam'],
+      testFunc
+    )
+    expect(res).toEqual([
+      { title: 'description', type: 'MD_INPUT', value: 'lol' },
+      {
+        title: 'deem',
+        type: 'DROP_DOWN',
+        value: []
+      },
+      { title: 'potate', type: 'TEXT_AREA', value: '0' },
+      { title: 'cactus', type: 'TEXT_AREA', value: '' }
+    ])
+
+    const res2 = getPropertyArr(
+      { deem: dropdownMenuItems },
+      undefined,
+      testFunc
+    )
+    res2[0].value[0].onClick()
+    expect(testFunc).toBeCalledWith('Lessons', 0)
+  })
+
+  test('should return correct results in makegraphql variable function', async () => {
+    const res = adminHelpers.makeGraphqlVariable(
+      [
+        { title: 'id', value: '4' },
+        {
+          title: 'deem',
+          type: 'DROP_DOWN',
+          value: [{ title: 'dragon' }]
+        },
+        { title: 'order', value: '5' }
+      ],
+      { pop: 'open' }
+    )
+    expect(res).toEqual({
+      variables: { deem: 'dragon', id: 4, order: 5, pop: 'open' }
+    })
+
+    const res2 = adminHelpers.makeGraphqlVariable([
+      { title: 'order', value: '' },
+      { title: 'id', value: '' }
+    ])
+    expect(res2).toEqual({
+      variables: { order: undefined, id: NaN }
+    })
+  })
+
+  test('should delete error property(if present) when theres no error \
+	and display error Message when error is found', async () => {
+    const mockProperties = [{ title: 'hi', value: '4', error: 'lolz' }]
+    const mockSchemaValidation = jest.fn()
+    adminHelpers.makeGraphqlVariable = jest.fn().mockReturnValue({
+      variables: {
+        deem: 'dragon',
+        id: 4,
+        order: 5,
+        pop: 'open'
+      }
+    })
+
+    const res = await errorCheckSingleField(
+      mockProperties,
+      0,
+      mockSchemaValidation
+    )
+    expect(res).toEqual(true)
+    expect(mockProperties).toEqual([{ title: 'hi', value: '4' }])
+
+    reach.mockReturnValue({
+      validate: jest.fn().mockImplementation(() => {
+        throw new Error('hello my friend u have an error')
+      })
+    })
+    const res2 = await errorCheckSingleField(
+      mockProperties,
+      0,
+      mockSchemaValidation
+    )
+    expect(res2).toEqual(false)
+    expect(mockProperties).toEqual([
+      { title: 'hi', value: '4', error: 'hello my friend u have an error' }
+    ])
+  })
+
+  test('should return correct results in errorCheckAllFields function', async () => {
+    const mockProperties = [{ title: 'hi', value: '4' }]
+    const mockSchemaValidation = {
+      validate: jest.fn()
+    }
+    adminHelpers.makeGraphqlVariable = jest.fn().mockReturnValue({
+      variables: {
+        deem: 'dragon',
+        id: 4,
+        order: 5,
+        pop: 'open'
+      }
+    })
+
+    const res = await errorCheckAllFields(mockProperties, mockSchemaValidation)
+    expect(res).toEqual(true)
+    expect(mockProperties).toEqual([{ title: 'hi', value: '4' }])
+
+    class CustomError extends Error {
+      constructor(custom, ...params) {
+        // Pass remaining arguments (including vendor specific ones) to parent constructor
+        super(...params)
+        this.errors = custom.errors
+        this.inner = custom.inner
+      }
+    }
+
+    mockSchemaValidation.validate.mockImplementation(() => {
+      throw new CustomError({ inner: [{ path: 'hi' }], errors: ['hi'] })
+    })
+    const res2 = await errorCheckAllFields(mockProperties, mockSchemaValidation)
+    expect(res2).toEqual(false)
+    expect(mockProperties).toEqual([{ title: 'hi', value: '4', error: 'hi' }])
+  })
+})

--- a/helpers/formChange.test.js
+++ b/helpers/formChange.test.js
@@ -1,0 +1,26 @@
+jest.mock('./admin/adminHelpers')
+import { errorCheckSingleField } from './admin/adminHelpers'
+import { formChange } from './formChange'
+const setState = jest.fn()
+describe('formChange helper function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  test('should call errorCheckSingleField if item is not an array', async () => {
+    await formChange('hi', 0, [{ value: 'lol' }], setState, 'ji')
+    expect(errorCheckSingleField).toHaveBeenCalledTimes(1)
+  })
+
+  test('should not call errorCheckSingleField if item is an array', async () => {
+    await formChange(
+      'hi',
+      0,
+      [{ value: [{ title: 'lol' }, { title: 'hi' }] }],
+      setState
+    )
+    expect(errorCheckSingleField).toHaveBeenCalledTimes(0)
+    expect(setState).toBeCalledWith([
+      { value: [{ title: 'hi' }, { title: 'lol' }] }
+    ])
+  })
+})

--- a/helpers/formChange.ts
+++ b/helpers/formChange.ts
@@ -1,0 +1,36 @@
+import { errorCheckSingleField } from './admin/adminHelpers'
+
+export const formChange = async (
+  value: string,
+  propertyIndex: number,
+  state: any,
+  setState: any,
+  validationSchema?: any
+) => {
+  const newOptions: any = [...state]
+
+  if (!(newOptions[propertyIndex].value instanceof Array)) {
+    newOptions[propertyIndex].value = value
+    validationSchema &&
+      (await errorCheckSingleField(newOptions, propertyIndex, validationSchema))
+    return setState(newOptions)
+  }
+  // if code is run here, it means field is a dropdown menu
+  let save
+
+  // remove dropdown item from array
+  const newDropdownItems: any = newOptions[propertyIndex].value.filter(
+    (e: any) => {
+      if (e.title === value) {
+        save = e
+        return false
+      }
+      return true
+    }
+  )
+
+  // put as first item in array to make it appear first
+  newDropdownItems.unshift(save)
+  newOptions[propertyIndex].value = newDropdownItems
+  setState(newOptions)
+}

--- a/helpers/formChange.ts
+++ b/helpers/formChange.ts
@@ -3,8 +3,8 @@ import { errorCheckSingleField } from './admin/adminHelpers'
 export const formChange = async (
   value: string,
   propertyIndex: number,
-  state: any,
-  setState: any,
+  state: any[],
+  setState: React.Dispatch<React.SetStateAction<any[]>>,
   validationSchema?: any
 ) => {
   const newOptions: any = [...state]
@@ -17,12 +17,11 @@ export const formChange = async (
   }
   // if code is run here, it means field is a dropdown menu
   let save
-
   // remove dropdown item from array
   const newDropdownItems: any = newOptions[propertyIndex].value.filter(
-    (e: any) => {
-      if (e.title === value) {
-        save = e
+    (item: any) => {
+      if (item.title === value) {
+        save = item
         return false
       }
       return true

--- a/helpers/formValidation.tsx
+++ b/helpers/formValidation.tsx
@@ -5,6 +5,17 @@ const TEXT_MAX = 64
 const PASSWORD_MIN = 6
 const REGEX_ALPHANUMERICS_AND_SPACE = /^[a-zA-Z0-9_\s]*$/
 
+const alertValidation = Yup.object({
+  text: Yup.string()
+    .required('Required')
+    .strict(true),
+  type: Yup.string()
+    .required('Required')
+    .strict(true),
+  url: Yup.string(),
+  urlCaption: Yup.string()
+})
+
 const lessonSchema = Yup.object({
   title: Yup.string()
     .required('Required')
@@ -86,6 +97,7 @@ const resetPasswordValidation = Yup.object({
 })
 
 export {
+  alertValidation,
   lessonSchema,
   signupValidation,
   loginValidation,

--- a/pages/admin/alerts.tsx
+++ b/pages/admin/alerts.tsx
@@ -7,6 +7,7 @@ import REMOVE_ALERT from '../../graphql/queries/removeAlert'
 import { withGetApp, GetAppProps, Alert as AlertType } from '../../graphql'
 import noop from '../../helpers/noop'
 import Card from '../../components/Card'
+import { NewAlert } from '../../components/admin/alerts/AdminNewAlert'
 
 type AlertRowProps = {
   alerts: AlertType[]
@@ -54,9 +55,7 @@ const Alerts: React.FC<GetAppProps> = ({ data }) => {
   // useEffect needed to update `alerts` state after data has finished loading alerts
   // if this is not done, no alerts will be displayed because alerts will just equal []
   useEffect(() => {
-    if (!data.error && !data.loading) {
-      setAlerts(data.alerts as AlertType[])
-    }
+    !data.error && !data.loading && setAlerts(data.alerts as AlertType[])
   }, [data])
 
   const currentAlerts = alerts.map((alert: AlertType, key: number) => (
@@ -71,6 +70,14 @@ const Alerts: React.FC<GetAppProps> = ({ data }) => {
         classes="col-12"
         text="Add new messages you want c0d3.com students to see or remove old and outdated alerts!"
       />
+      <Card
+        primary={true}
+        title="Create New Alert"
+        classes="col-12"
+        text="Make a new alert. Look at the preview to see if the alert looks and functions how you want it to!"
+      >
+        <NewAlert setAlerts={setAlerts} />
+      </Card>
       <Card
         primary={true}
         title="Current Alerts"

--- a/stories/components/FormCard.stories.tsx
+++ b/stories/components/FormCard.stories.tsx
@@ -6,6 +6,7 @@ import {
   DROP_DOWN
 } from '../../components/FormCard'
 import { Item } from '../../components/DropdownMenu'
+import { formChange } from '../../helpers/formChange'
 
 export default {
   component: FormCard,
@@ -49,28 +50,7 @@ const MockBasic: React.FC = () => {
   ]
   const [options, setOptions] = useState(mockedDropdown)
   const onChange = (value: string, index: number) => {
-    const newOptions: any = [...options]
-
-    if (!(options[index].value instanceof Array)) {
-      newOptions[index].value = value
-      return setOptions(newOptions)
-    }
-    // if code is run here, it means field is a dropdown menu
-    let save
-
-    // remove dropdown item from array
-    const newDropdownItems: any = newOptions[index].value.filter((e: any) => {
-      if (e.title === value) {
-        save = e
-        return false
-      }
-      return true
-    })
-
-    // put as first item in array to make it appear first
-    newDropdownItems.unshift(save)
-    newOptions[index].value = newDropdownItems
-    setOptions(newOptions)
+    formChange(value, index, options, setOptions)
   }
 
   return <FormCard onChange={onChange} values={options} onSubmit={mockBtn} />
@@ -79,9 +59,7 @@ const MockBasic: React.FC = () => {
 const MockWithTitle: React.FC = () => {
   const [options, setOptions] = useState(mockValues)
   const onChange = (value: string, index: number) => {
-    const newOptions = [...options]
-    newOptions[index].value = value
-    setOptions(newOptions)
+    formChange(value, index, options, setOptions)
   }
 
   return (
@@ -97,10 +75,7 @@ const MockWithTitle: React.FC = () => {
 const MockWithValidation: React.FC = () => {
   const [options, setOptions] = useState(mockValues)
   const onChange = (value: string, index: number) => {
-    const newOptions = [...options]
-    newOptions[index].value = value
-    newOptions[index].error = value ? '' : 'Field cannot be empty'
-    setOptions(newOptions)
+    formChange(value, index, options, setOptions)
   }
 
   return (
@@ -116,9 +91,7 @@ const MockWithValidation: React.FC = () => {
 const MockWithBorder: React.FC = () => {
   const [options, setOptions] = useState(mockValues)
   const onChange = (value: string, index: number) => {
-    const newOptions = [...options]
-    newOptions[index].value = value
-    setOptions(newOptions)
+    formChange(value, index, options, setOptions)
   }
 
   return (


### PR DESCRIPTION
closes #415
closes #414 

The admin alerts page needs to be able to create new alerts. Currently, it can only display and remove alerts.

## This PR will:
* Create a form for people to fill out to make a new alert. The form includes a preview that changes as someone types in the form
* Create a `formChange` component to use with the formCard component.
    * Update relevant files to use `formChange` component
* Create tests for `adminHelpers` file 

<img width="1178" alt="Screen Shot 2020-10-05 at 6 35 31 PM" src="https://user-images.githubusercontent.com/45890848/95149254-52962000-073a-11eb-812e-79266e6a73de.png">

<img width="1193" alt="Screen Shot 2020-10-05 at 6 35 52 PM" src="https://user-images.githubusercontent.com/45890848/95149263-56c23d80-073a-11eb-9c1a-dc851c8b668b.png">
