### PR TITLE
closes #420 - fix issue where url and urlCaption has value of null when alerts are created

### DIFF
--- a/graphql/queries/addAlert.ts
+++ b/graphql/queries/addAlert.ts
@@ -1,8 +1,13 @@
 import { gql } from 'apollo-boost'
 
 const ADD_ALERT = gql`
-  mutation addAlert($text: String!, $type: String!) {
-    addAlert(text: $text, type: $type) {
+  mutation addAlert(
+    $text: String!
+    $type: String!
+    $url: String
+    $urlCaption: String
+  ) {
+    addAlert(text: $text, type: $type, url: $url, urlCaption: $urlCaption) {
       id
       text
       type


### PR DESCRIPTION
In the form to add a new alert on the `admin alerts` page, the `url` and `urlCaption` gets set equal to `null` after a person clicks the `create alert` button, even when someone types in values for them.

This PR fixes that problem by updating the `addAlert` mutation request to include parameters for `url` and `urlCaption`