### PR TITLE
Fix broken link on home page

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -6086,7 +6086,7 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
     </p>
     <a
       className="btn btn-primary py-3 px-5 mt-4"
-      href="https://c0d3.com/book"
+      href="https://www.c0d3.com/book"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5783,7 +5783,7 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
       >
         <a
           className="btn btn-primary py-3 px-5"
-          href="https://c0d3.com/book"
+          href="https://www.c0d3.com/book"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -196,7 +196,7 @@ const LandingPage: React.FC = () => {
           Start your journey to being a full stack software engineer
         </p>
         <NavLink
-          path="https://c0d3.com/book"
+          path="https://www.c0d3.com/book"
           className="btn btn-primary py-3 px-5 mt-4"
           external
         >

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -30,7 +30,7 @@ const LandingPage: React.FC = () => {
         <div className="row mt-5">
           <div className="col-md-6 offset-md-3 mb-5">
             <NavLink
-              path="https://c0d3.com/book"
+              path="https://www.c0d3.com/book"
               className="btn btn-primary py-3 px-5"
               external
             >


### PR DESCRIPTION
This is a quick fix to make it so the "Get Started" link on the home page is not broken anymore.
https://c0d3.com/book redirects to the home page so when you click the "Get Started" button, it just reloads the home page, so it's pretty much a broken link because it doesn't do what we would expect.
We should make it so the link to https://c0d3.com/book works.
For now, we're fixing this by making the link https://www.c0d3.com/book