### PR TITLE
Fix contributor page loading screen styling

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -209,6 +209,7 @@ exports[`Storyshots Components/AppNav Logged In 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -244,6 +245,7 @@ exports[`Storyshots Components/AppNav Logged Out 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -2958,6 +2960,7 @@ Array [
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
+        "zIndex": 1,
       }
     }
   >
@@ -3039,6 +3042,7 @@ Array [
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
+        "zIndex": 1,
       }
     }
   >
@@ -3509,6 +3513,7 @@ exports[`Storyshots Components/LoadingSpinner Basic 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -5331,6 +5336,7 @@ Array [
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
+        "zIndex": 1,
       }
     }
   >
@@ -5522,6 +5528,7 @@ exports[`Storyshots Pages/Curriculum Basic 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -5557,6 +5564,7 @@ exports[`Storyshots Pages/Curriculum Completed Lessons 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -5592,6 +5600,7 @@ exports[`Storyshots Pages/Curriculum With Alerts 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -5628,6 +5637,7 @@ Array [
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
+        "zIndex": 1,
       }
     }
   >
@@ -6105,6 +6115,7 @@ exports[`Storyshots Pages/Lesson Basic 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -6140,6 +6151,7 @@ exports[`Storyshots Pages/Lesson Completed Challenges 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -6175,6 +6187,7 @@ exports[`Storyshots Pages/Lesson With Alerts 1`] = `
       "minHeight": "100vh",
       "position": "fixed",
       "top": 0,
+      "zIndex": 1,
     }
   }
 >
@@ -6211,6 +6224,7 @@ Array [
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
+        "zIndex": 1,
       }
     }
   >
@@ -6484,6 +6498,7 @@ Array [
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
+        "zIndex": 1,
       }
     }
   >
@@ -6595,6 +6610,7 @@ Array [
         "minHeight": "100vh",
         "position": "fixed",
         "top": 0,
+        "zIndex": 1,
       }
     }
   >

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -3,7 +3,13 @@ import React from 'react'
 const LoadingSpinner = () => {
   return (
     <div
-      style={{ minHeight: '100vh', position: 'fixed', top: 0, left: 0 }}
+      style={{
+        minHeight: '100vh',
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        zIndex: 1
+      }}
       className="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
     >
       <h1


### PR DESCRIPTION
Before, when you loaded the contributor page, you'd see a loading
screen where there was a component above the loading page which
looked awkward. This commit fixes that styling bug.

I was able to figure out how to fix the styling by opening
up Chrome devtools, going to the Elements tab, placing a break
point on subtree modifications on the body element, then I refreshed
the page and was able to add styles. It turns out that adding a simple
z-index: 1 was all it took to fix this.

How to reproduce this bug:
* Go to /contributors
* You should see the bug on the loading screen, if it's too fast, go to the Chrome devtools Network tab and simulate 3G connection speed or go to Elements tab and set a break point on subtree modification of the body element then refresh the page.

Before:
![Screenshot from 2020-11-07 13-15-33](https://user-images.githubusercontent.com/7637655/98452117-4d454000-2101-11eb-994c-0052aad7adb4.png)

After:
![Screenshot from 2020-11-07 13-16-48](https://user-images.githubusercontent.com/7637655/98452120-52a28a80-2101-11eb-8e50-545277ab81f0.png)
