### PR TITLE
Add cors header to lessons api response

### DIFF
--- a/__tests__/pages/api/lessons.test.js
+++ b/__tests__/pages/api/lessons.test.js
@@ -3,6 +3,7 @@ import * as getLessons from '../../../graphql/queryResolvers/lessons'
 
 describe('lessonsAPI', () => {
   const res = {
+    setHeader: jest.fn(),
     json: jest.fn(),
     status: jest.fn()
   }

--- a/pages/api/lessons.ts
+++ b/pages/api/lessons.ts
@@ -5,6 +5,7 @@ import { NextApiResponse } from 'next'
 export default async (_: LoggedRequest, res: NextApiResponse) => {
   try {
     const allLessons = await lessons()
+    res.setHeader('Access-Control-Allow-Origin', '*')
     res.json(allLessons)
   } catch (err) {
     res.status(500).json('Error occured 😮')


### PR DESCRIPTION
This PR changes the lessons API so it adds the `Access-Control-Allow-Origin` header in the response to avoid browsers refusing it, like in the screenshot below.

<img width="1010" alt="Screen Shot 2020-11-20 at 8 34 45 PM" src="https://user-images.githubusercontent.com/16023489/99831576-0d894a00-2b3e-11eb-893f-26481b01ba14.png">
