### PR TITLE
closes #428 - lessonExists helper function 

### DIFF
--- a/helpers/controllers/challengesController.test.js
+++ b/helpers/controllers/challengesController.test.js
@@ -19,7 +19,7 @@ const mockChallengeData = {
   title: 'potato'
 }
 
-Lesson.findAll = jest.fn().mockReturnValue(lessonData)
+Lesson.findAll.mockReturnValue(lessonData)
 
 describe('Challenges controller tests', () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('Challenges controller tests', () => {
     }
   }
 
-  Challenge.build = jest.fn().mockReturnValue({ save: () => {} })
+  Challenge.build.mockReturnValue({ save: () => {} })
 
   test('Should create new challenge', async () => {
     await expect(

--- a/helpers/controllers/challengesController.test.js
+++ b/helpers/controllers/challengesController.test.js
@@ -1,10 +1,14 @@
 jest.mock('../dbload')
 jest.mock('../mattermost')
 jest.mock('../lessonExists')
+jest.mock('../../graphql/queryResolvers/lessons')
 import db from '../dbload'
 import { createChallenge, updateChallenge } from './challengesController'
 import { lessonExists } from '../lessonExists'
 import lessonData from '../../__dummy__/lessonData'
+import { lessons } from '../../graphql/queryResolvers/lessons'
+
+lessons.mockReturnValue(lessonData)
 const { Challenge, Lesson } = db
 
 const mockChallengeData = {
@@ -29,63 +33,47 @@ describe('Challenges controller tests', () => {
 
   Challenge.build = jest.fn().mockReturnValue({ save: () => {} })
 
-  test('Should create new challenge', () => {
-    expect(createChallenge(null, mockChallengeData, ctx)).resolves.toEqual(
-      lessonData
-    )
+  test('Should create new challenge', async () => {
+    await expect(
+      createChallenge(null, mockChallengeData, ctx)
+    ).resolves.toEqual(lessonData)
   })
 
-  test('Should update challenge', () => {
-    expect(updateChallenge(null, mockChallengeData, ctx)).resolves.toEqual(
-      lessonData
-    )
+  test('Should update challenge', async () => {
+    await expect(
+      updateChallenge(null, mockChallengeData, ctx)
+    ).resolves.toEqual(lessonData)
   })
 
   test('Should throw "lessonId does not exist" error if lessonId does not exist \
    in database when creating challenge', async () => {
     lessonExists.mockReturnValue(false)
-    let res
-    try {
-      await createChallenge(null, mockChallengeData, ctx)
-    } catch (err) {
-      res = String(err)
-    }
-    expect(res).toContain('lessonId does not exist in database')
+    await expect(
+      createChallenge(null, mockChallengeData, ctx)
+    ).rejects.toThrowError('lessonId does not exist in database')
   })
 
   test('Should throw "lessonId does not exist" error if lessonId does not exist \
   in database when updating challenge', async () => {
     lessonExists.mockReturnValue(false)
-    let res
-    try {
-      await updateChallenge(null, mockChallengeData, ctx)
-    } catch (err) {
-      res = String(err)
-    }
-    expect(res).toContain('lessonId does not exist in database')
+    await expect(
+      updateChallenge(null, mockChallengeData, ctx)
+    ).rejects.toThrowError('lessonId does not exist in database')
   })
 
   test('Should throw Error "User is not admin" error if user is not an admin \
   when updating challenge', async () => {
     ctx.req.user.isAdmin = 'false'
-    let res
-    try {
-      await updateChallenge(null, mockChallengeData, ctx)
-    } catch (err) {
-      res = String(err)
-    }
-    expect(res).toContain('User is not an admin')
+    await expect(
+      updateChallenge(null, mockChallengeData, ctx)
+    ).rejects.toThrowError('User is not an admin')
   })
 
   test('Should throw "User is not an admin" error if user is not an admin when \
   creating challenge', async () => {
     ctx.req.user.isAdmin = 'false'
-    let res
-    try {
-      await createChallenge(null, mockChallengeData, ctx)
-    } catch (err) {
-      res = String(err)
-    }
-    expect(res).toContain('User is not an admin')
+    await expect(
+      createChallenge(null, mockChallengeData, ctx)
+    ).rejects.toThrowError('User is not an admin')
   })
 })

--- a/helpers/controllers/challengesController.test.js
+++ b/helpers/controllers/challengesController.test.js
@@ -61,7 +61,7 @@ describe('Challenges controller tests', () => {
     ).rejects.toThrowError('lessonId does not exist in database')
   })
 
-  test('Should throw Error "User is not admin" error if user is not an admin \
+  test('Should throw "User is not admin" error if user is not an admin \
   when updating challenge', async () => {
     ctx.req.user.isAdmin = 'false'
     await expect(

--- a/helpers/controllers/challengesController.ts
+++ b/helpers/controllers/challengesController.ts
@@ -3,7 +3,7 @@ import { Context } from '../../@types/helpers'
 import _ from 'lodash'
 import { isAdmin } from '../isAdmin'
 import { lessons } from '../../graphql/queryResolvers/lessons'
-
+import { lessonExists } from '../lessonExists'
 const { Challenge } = db
 
 type challengeData = {
@@ -23,6 +23,10 @@ export const createChallenge = async (
   try {
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
+    }
+
+    if (!(await lessonExists(arg.lessonId))) {
+      throw new Error('lessonId does not exist in database')
     }
 
     const newChallenge = Challenge.build(arg)
@@ -45,6 +49,11 @@ export const updateChallenge = async (
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
+
+    if (!(await lessonExists(arg.lessonId))) {
+      throw new Error('lessonId does not exist in database')
+    }
+
     const { id } = arg
 
     await Challenge.update(arg, { where: { id } })

--- a/helpers/controllers/lessonsController.test.js
+++ b/helpers/controllers/lessonsController.test.js
@@ -52,9 +52,9 @@ describe('Lessons controller tests', () => {
   test('Should throw "lessonId does not exist" error if lessonId does not exist \
   in database when updating lesson', async () => {
     lessonExists.mockReturnValue(false)
-    await expect(
-      updateLesson(null, mockChallengeData, ctx)
-    ).rejects.toThrowError('lessonId does not exist in database')
+    await expect(updateLesson(null, mockLessonData, ctx)).rejects.toThrowError(
+      'lessonId does not exist in database'
+    )
   })
 
   test('Should throw Error when user is not an admin when updating lesson', async () => {

--- a/helpers/controllers/lessonsController.test.js
+++ b/helpers/controllers/lessonsController.test.js
@@ -23,9 +23,9 @@ const mockLessonData = {
   chatUrl: ''
 }
 
-Lesson.findAll = jest.fn().mockReturnValue(lessonData)
-Lesson.update = jest.fn().mockReturnValue(() => {})
-Lesson.build = jest.fn().mockReturnValue({ save: () => {} })
+Lesson.findAll.mockReturnValue(lessonData)
+Lesson.update.mockReturnValue(() => {})
+Lesson.build.mockReturnValue({ save: () => {} })
 
 describe('Lessons controller tests', () => {
   beforeEach(() => {

--- a/helpers/controllers/lessonsController.test.js
+++ b/helpers/controllers/lessonsController.test.js
@@ -57,14 +57,14 @@ describe('Lessons controller tests', () => {
     )
   })
 
-  test('Should throw Error when user is not an admin when updating lesson', async () => {
+  test('Should throw "User is not an admin" error when user is not an admin when updating lesson', async () => {
     ctx.req.user.isAdmin = 'false'
     await expect(createLesson(null, mockLessonData, ctx)).rejects.toThrowError(
       'User is not an admin'
     )
   })
 
-  test('Should throw Error when user is not an admin when creating lesson', async () => {
+  test('Should throw "User is not an admin" error when user is not an admin when creating lesson', async () => {
     ctx.req.user.isAdmin = 'false'
     await expect(updateLesson(null, mockLessonData, ctx)).rejects.toThrowError(
       'User is not an admin'

--- a/helpers/controllers/lessonsController.test.js
+++ b/helpers/controllers/lessonsController.test.js
@@ -1,11 +1,14 @@
 jest.mock('../dbload')
 jest.mock('../mattermost')
 jest.mock('../lessonExists')
+jest.mock('../../graphql/queryResolvers/lessons')
 import db from '../dbload'
 import { createLesson, updateLesson } from './lessonsController'
 import lessonData from '../../__dummy__/lessonData'
 import { lessonExists } from '../lessonExists'
+import { lessons } from '../../graphql/queryResolvers/lessons'
 
+lessons.mockReturnValue(lessonData)
 const { Lesson } = db
 
 const mockLessonData = {
@@ -35,44 +38,36 @@ describe('Lessons controller tests', () => {
   }
 
   test('Should create new lesson', async () => {
-    expect(createLesson(null, mockLessonData, ctx)).resolves.toEqual(lessonData)
+    await expect(createLesson(null, mockLessonData, ctx)).resolves.toEqual(
+      lessonData
+    )
   })
 
   test('Should update lesson', async () => {
-    expect(updateLesson(null, mockLessonData, ctx)).resolves.toEqual(lessonData)
+    await expect(updateLesson(null, mockLessonData, ctx)).resolves.toEqual(
+      lessonData
+    )
   })
 
   test('Should throw "lessonId does not exist" error if lessonId does not exist \
   in database when updating lesson', async () => {
     lessonExists.mockReturnValue(false)
-    let res
-    try {
-      await updateLesson(null, mockLessonData, ctx)
-    } catch (err) {
-      res = String(err)
-    }
-    expect(res).toContain('lessonId does not exist in database')
+    await expect(
+      updateLesson(null, mockChallengeData, ctx)
+    ).rejects.toThrowError('lessonId does not exist in database')
   })
 
   test('Should throw Error when user is not an admin when updating lesson', async () => {
     ctx.req.user.isAdmin = 'false'
-    let res = 'lol'
-    try {
-      await updateLesson(null, mockLessonData, ctx)
-    } catch (err) {
-      res = String(err)
-    }
-    expect(res).toContain('User is not an admin')
+    await expect(createLesson(null, mockLessonData, ctx)).rejects.toThrowError(
+      'User is not an admin'
+    )
   })
 
   test('Should throw Error when user is not an admin when creating lesson', async () => {
     ctx.req.user.isAdmin = 'false'
-    let res = 'lol'
-    try {
-      await createLesson(null, mockLessonData, ctx)
-    } catch (err) {
-      res = String(err)
-    }
-    expect(res).toContain('User is not an admin')
+    await expect(updateLesson(null, mockLessonData, ctx)).rejects.toThrowError(
+      'User is not an admin'
+    )
   })
 })

--- a/helpers/controllers/lessonsController.ts
+++ b/helpers/controllers/lessonsController.ts
@@ -3,6 +3,7 @@ import { Context } from '../../@types/helpers'
 import _ from 'lodash'
 import { isAdmin } from '../isAdmin'
 import { lessons } from '../../graphql/queryResolvers/lessons'
+import { lessonExists } from '../lessonExists'
 const { Lesson } = db
 
 type lessonData = {
@@ -48,6 +49,10 @@ export const updateLesson = async (
     }
 
     const { id } = arg
+
+    if (!(await lessonExists(id))) {
+      throw new Error('lessonId does not exist in database')
+    }
 
     await Lesson.update(arg, { where: { id } })
 

--- a/helpers/lessonExists.test.js
+++ b/helpers/lessonExists.test.js
@@ -1,0 +1,16 @@
+import { lessonExists } from './lessonExists'
+import db from './dbload'
+const { Lesson } = db
+
+describe('lessonExists helper function', () => {
+  test('should return true when id exists in the database', async () => {
+    Lesson.findOne = jest.fn().mockReturnValue(true)
+    const res = await lessonExists(5)
+    expect(res).toEqual(true)
+  })
+  test('should return false when id does not exist in the database', async () => {
+    Lesson.findOne = jest.fn().mockReturnValue(null)
+    const res = await lessonExists(5)
+    expect(res).toEqual(false)
+  })
+})

--- a/helpers/lessonExists.ts
+++ b/helpers/lessonExists.ts
@@ -1,0 +1,7 @@
+import db from './dbload'
+const { Lesson } = db
+
+export const lessonExists = async (id: number): Promise<Boolean> => {
+  const lesson = await Lesson.findOne({ where: { id } })
+  return lesson !== null
+}


### PR DESCRIPTION
## The issue
#428 

Currently, graphql resolvers to update/create challenges do not check if a lessonId exists in the database before attempting to update/create a challenge for a lesson. The resolver to update a lesson similarly does not check if a lessonId exists before attempting to update a lesson. The upcoming `setStar` resolver also needs this helper function to check if a lessonId exists in the database.

There is absolutely no point in trying to update the database using an invalid lessonId. Error messages should be thrown to provide better documentation.

## This PR will
1) Create a `lessonExists` helper function to check if a lesson exists in the database, and make tests for the function
2) Update the `updateChallenge`, `createChallenge`, and `updateLesson` graphql resolvers to throw error message when lessonId does not exist, update tests for those resolvers accordingly
3) Fix tests for lessonsController and challengesController helper files. Before, `await` was **NOT** being used before the `expect` call, which means that some tests were useless. You could have done `expect(func()).rejects.toThrowError('something super duper random')` and the test would pass, even if the actual error message thrown didn't contain `something super duper random`. This is the file I looked at in order to learn: https://github.com/garageScript/c0d3-app/blob/master/helpers/controllers/authController.test.js