### PR TITLE
[Feature] Send chat notification on submission review

### DIFF
--- a/@types/mattermost.d.ts
+++ b/@types/mattermost.d.ts
@@ -4,6 +4,12 @@ export interface ChannelInfo {
   json: () => Promise<{ id: string }>
 }
 
+export interface UserInfo {
+  id: string
+  username: string
+  email: string
+}
+
 export type GetChannelInfo = (roomName: string) => Promise<{ id: string }>
 
 export type PublicChannelMessage = (
@@ -12,3 +18,10 @@ export type PublicChannelMessage = (
 ) => void
 
 export type SendMessage = (channelId: string, message: string) => void
+
+export type SendDirectMessage = (userId: string, message: string) => void
+
+export type DirectChannelInfo = (
+  senderId: string,
+  receiverId: string
+) => Promise<{ id: string }>

--- a/helpers/controllers/submissionController.test.js
+++ b/helpers/controllers/submissionController.test.js
@@ -90,7 +90,7 @@ describe('Submissions Mutations', () => {
       })
 
       // mock mattermost getUserByEmail
-      getUserByEmail.mockReturnValue(username)
+      getUserByEmail.mockReturnValue({ username })
 
       await Mutation.createSubmission(null, args)
       expect(publicChannelMessage).toHaveBeenCalledWith(
@@ -125,7 +125,7 @@ describe('Submissions Mutations', () => {
       Lesson.findOne = jest.fn().mockReturnValue(null)
 
       // mock mattermost getUserByEmail
-      getUserByEmail.mockReturnValue(username)
+      getUserByEmail.mockReturnValue({ username })
 
       await Mutation.createSubmission(null, args)
       expect(publicChannelMessage).not.toHaveBeenCalled()

--- a/helpers/controllers/submissionController.ts
+++ b/helpers/controllers/submissionController.ts
@@ -58,7 +58,7 @@ export const createSubmission = async (
     // if no Lesson was found nextLesson is null
     if (nextLesson) {
       const nextLessonChannelName = nextLesson.chatUrl.split('/').pop()
-      const username = await getUserByEmail(email)
+      const { username } = await getUserByEmail(email)
       const message = `@${username} has submitted a solution **_${challenge.title}_**. Click [here](<https://www.c0d3.com/review/${currentLesson.id}>) to review the code.`
       publicChannelMessage(nextLessonChannelName, message)
     }

--- a/helpers/controllers/submissionController.ts
+++ b/helpers/controllers/submissionController.ts
@@ -18,6 +18,12 @@ type ArgsGetSubmissions = {
   lessonId: string
 }
 
+export enum SubmissionStatus {
+  OPEN = 'open',
+  PASSED = 'passed',
+  REJECTED = 'needMoreWork'
+}
+
 export const createSubmission = async (
   _parent: void,
   args: ArgsCreateSubmission
@@ -33,7 +39,11 @@ export const createSubmission = async (
       where: { lessonId, challengeId, userId }
     })
 
-    await submission.update({ diff, status: 'open', viewCount: 0 })
+    await submission.update({
+      diff,
+      status: SubmissionStatus.OPEN,
+      viewCount: 0
+    })
 
     const [currentLesson, challenge] = await Promise.all([
       Lesson.findByPk(lessonId),
@@ -68,7 +78,11 @@ export const acceptSubmission = async (
     const reviewerId = _.get(ctx, 'req.user.id', false)
     if (!args) throw new Error('Invalid args')
     if (!reviewerId) throw new Error('Invalid user')
-    return updateSubmission({ ...args, reviewerId, status: 'passed' })
+    return updateSubmission({
+      ...args,
+      reviewerId,
+      status: SubmissionStatus.PASSED
+    })
   } catch (error) {
     throw new Error(error)
   }
@@ -83,7 +97,11 @@ export const rejectSubmission = async (
     const reviewerId = _.get(ctx, 'req.user.id', false)
     if (!args) throw new Error('Invalid args')
     if (!reviewerId) throw new Error('Invalid user')
-    return updateSubmission({ ...args, reviewerId, status: 'needMoreWork' })
+    return updateSubmission({
+      ...args,
+      reviewerId,
+      status: SubmissionStatus.REJECTED
+    })
   } catch (error) {
     throw new Error(error)
   }

--- a/helpers/mattermost.ts
+++ b/helpers/mattermost.ts
@@ -1,9 +1,13 @@
 import fetch from 'node-fetch'
+import _ from 'lodash'
 import {
+  UserInfo,
   ChannelInfo,
   GetChannelInfo,
   SendMessage,
-  PublicChannelMessage
+  PublicChannelMessage,
+  SendDirectMessage,
+  DirectChannelInfo
 } from '../@types/mattermost'
 
 const accessToken = process.env.MATTERMOST_ACCESS_TOKEN || '123' // For Testing
@@ -99,6 +103,17 @@ export const sendMessage: SendMessage = async (channelId, message) => {
   })
 }
 
+export const sendDirectMessage: SendDirectMessage = async (userId, message) => {
+  // the mattermost api endpoint '/users/me' returns the info
+  // about the authenticated user, which in this case is the bot
+  const { id: botId } = await getChatUserById('me')
+  const { id: channelId } = await findOrCreateDirectMessageChannel(
+    botId,
+    userId
+  )
+  return sendMessage(channelId, message)
+}
+
 export const publicChannelMessage: PublicChannelMessage = async (
   channelName,
   message
@@ -111,14 +126,39 @@ export const publicChannelMessage: PublicChannelMessage = async (
   }
 }
 
-export const getUserByEmail = async (email: string): Promise<string> => {
+export const getUserByEmail = async (email: string): Promise<UserInfo> => {
   try {
     const user = await fetch(`${chatServiceUrl}/users/email/${email}`, {
       headers
     })
-    const { username } = await user.json()
-    return username
+    return await user.json()
   } catch (error) {
     throw new Error(error)
   }
 }
+
+export const getChatUserById = _.memoize(
+  async (id: string): Promise<UserInfo> => {
+    try {
+      const response = await fetch(`${chatServiceUrl}/users/${id}`, { headers })
+      return await response.json()
+    } catch (error) {
+      throw new Error(error)
+    }
+  }
+)
+
+export const findOrCreateDirectMessageChannel: DirectChannelInfo = _.memoize(
+  async (senderId, receiverId) => {
+    try {
+      const response = await fetch(`${chatServiceUrl}/channels/direct`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify([senderId, receiverId])
+      })
+      return await response.json()
+    } catch (error) {
+      throw new Error(error)
+    }
+  }
+)

--- a/helpers/mattermost.ts
+++ b/helpers/mattermost.ts
@@ -141,7 +141,7 @@ export const getChatUserById = _.memoize(
   async (id: string): Promise<UserInfo> => {
     try {
       const response = await fetch(`${chatServiceUrl}/users/${id}`, { headers })
-      return await response.json()
+      return response.json()
     } catch (error) {
       throw new Error(error)
     }
@@ -156,7 +156,7 @@ export const findOrCreateDirectMessageChannel: DirectChannelInfo = _.memoize(
         headers,
         body: JSON.stringify([senderId, receiverId])
       })
-      return await response.json()
+      return response.json()
     } catch (error) {
       throw new Error(error)
     }

--- a/helpers/updateSubmission.ts
+++ b/helpers/updateSubmission.ts
@@ -1,11 +1,23 @@
 import db from './dbload'
-import { getUserByEmail, publicChannelMessage } from './mattermost'
+import { SubmissionData } from '../@types/submission'
+import {
+  getUserByEmail,
+  publicChannelMessage,
+  sendDirectMessage
+} from './mattermost'
+import { SubmissionStatus } from './controllers/submissionController'
 
 const { Submission, Challenge, User, UserLesson, Lesson } = db
 
 export type ArgsUpdateSubmission = {
   id: number
   comment: string
+}
+
+export type ArgsChatNotification = {
+  submission: SubmissionData
+  userChatId: string
+  reviewerId: number
 }
 
 export const updateSubmission = async (
@@ -16,10 +28,14 @@ export const updateSubmission = async (
     const { id, comment, status, reviewerId } = args
     // query submission that is being updated
     const submission = await Submission.findByPk(id)
-    // count challenges inside lesson that submission belongs to
-    const lessonChallengeCount = await Challenge.count({
-      where: { lessonId: submission.lessonId }
-    })
+
+    // count challenges inside lesson that submission belongs to and query user email
+    const [lessonChallengeCount, { email }] = await Promise.all([
+      Challenge.count({
+        where: { lessonId: submission.lessonId }
+      }),
+      User.findByPk(submission.userId)
+    ])
 
     // update and save submission data
     submission.set('reviewerId', reviewerId)
@@ -27,12 +43,24 @@ export const updateSubmission = async (
     submission.set('comment', comment)
     await submission.save()
 
-    // query other user submissions that belong to same lesson
-    const lessonSubmissions = await Submission.findAll({
-      where: {
-        lessonId: submission.lessonId,
-        userId: submission.userId
-      }
+    const [
+      { id: userChatId, username: chatUsername },
+      lessonSubmissions
+    ] = await Promise.all([
+      getUserByEmail(email), // query user chat id and username
+      // query other user submissions that belong to same lesson
+      Submission.findAll({
+        where: {
+          lessonId: submission.lessonId,
+          userId: submission.userId
+        }
+      })
+    ])
+
+    sendChatNotification({
+      submission,
+      userChatId,
+      reviewerId
     })
 
     // count how many submissions user passed in total
@@ -58,18 +86,12 @@ export const updateSubmission = async (
     // immediately return and do not proceed
     if (userLesson.isPassed) return submission
 
-    const [{ email }, currentLesson] = await Promise.all([
-      User.findByPk(submission.userId), // query user data
-      Lesson.findByPk(userLesson.lessonId) // query lesson data
-    ])
+    const currentLesson = Lesson.findByPk(userLesson.lessonId)
 
-    const [chatUsername, nextLesson] = await Promise.all([
-      getUserByEmail(email), // get user chat username from email
-      Lesson.findOne({
-        // query next lesson
-        where: { order: currentLesson.order + 1 }
-      })
-    ])
+    // query next lesson
+    const nextLesson = Lesson.findOne({
+      where: { order: currentLesson.order + 1 }
+    })
 
     // if current lesson has a chatUrl
     if (currentLesson.chatUrl) {
@@ -102,4 +124,24 @@ export const updateSubmission = async (
   } catch (error) {
     throw new Error(error)
   }
+}
+
+export const sendChatNotification = async (
+  args: ArgsChatNotification
+): Promise<void> => {
+  const {
+    submission: { status, comment, challengeId },
+    userChatId,
+    reviewerId
+  } = args
+  const { email: reviewerEmail } = await User.findByPk(reviewerId)
+  const { username: reviewerChatUsername } = await getUserByEmail(reviewerEmail)
+  const { title } = await Challenge.findByPk(challengeId)
+  let message = `Your submission for the challenge **_${title}_** has been **${
+    status === SubmissionStatus.PASSED ? 'ACCEPTED' : 'REJECTED'
+  }** by @${reviewerChatUsername}.`
+  if (comment) {
+    message += `\n\nThe reviewer left the following comment:\n\n___\n\n${comment}`
+  }
+  await sendDirectMessage(userChatId, message)
 }

--- a/helpers/updateSubmission.ts
+++ b/helpers/updateSubmission.ts
@@ -9,7 +9,7 @@ export type ArgsUpdateSubmission = {
 }
 
 export const updateSubmission = async (
-  args: ArgsUpdateSubmission & { reviewerId: number; status: string }
+  args: ArgsUpdateSubmission & { reviewerId: number; status: SubmissionStatus }
 ) => {
   try {
     if (!args) throw new Error('Invalid args')
@@ -37,7 +37,8 @@ export const updateSubmission = async (
 
     // count how many submissions user passed in total
     const passedLessonSubmissions = lessonSubmissions.reduce(
-      (sum: number, s: any) => sum + (s.status === 'passed' ? 1 : 0),
+      (sum: number, s: any) =>
+        sum + (s.status === SubmissionStatus.PASSED ? 1 : 0),
       0
     )
 


### PR DESCRIPTION
Closes #444 

This PR will:

- add a new `SubmissionStatus` enum to help avoid using strings for submission status;
- add new Mattermost helper functions so the bot can send direct messages;
- add a new `sendChatNotification` function in `updateSubmission`, to send a notification to the user when their submission has been accepted or rejected, including the review comment;
- add and fix tests relevant to the mentioned functions.

![image](https://user-images.githubusercontent.com/16023489/102422055-acda1980-3fe4-11eb-8c8f-d943e836fa05.png)