### PR TITLE
closes #449, #450 - return id in getLessonMentors, make option for size in Button component

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -7155,6 +7155,20 @@ Array [
 ]
 `;
 
+exports[`Storyshots Theme/Button Large Button 1`] = `
+<button
+  className="btn btn-lg"
+  onClick={[Function]}
+  style={
+    Object {
+      "color": "#292929",
+    }
+  }
+>
+  Large Button
+</button>
+`;
+
 exports[`Storyshots Theme/Button Margined Button 1`] = `
 <button
   className="btn m-1"
@@ -7166,6 +7180,20 @@ exports[`Storyshots Theme/Button Margined Button 1`] = `
   }
 >
   Margined Button
+</button>
+`;
+
+exports[`Storyshots Theme/Button Small Button 1`] = `
+<button
+  className="btn btn-sm"
+  onClick={[Function]}
+  style={
+    Object {
+      "color": "#292929",
+    }
+  }
+>
+  Large Button
 </button>
 `;
 

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -7193,7 +7193,7 @@ exports[`Storyshots Theme/Button Small Button 1`] = `
     }
   }
 >
-  Large Button
+  Small Button
 </button>
 `;
 

--- a/components/theme/Button.tsx
+++ b/components/theme/Button.tsx
@@ -9,6 +9,7 @@ type ButtonProps = {
   color?: ColorTypes
   m?: '1'
   ml?: '2'
+  size?: 'lg' | 'sm'
   onClick?: Function
 }
 
@@ -19,7 +20,8 @@ export const Button: React.FC<ButtonProps> = ({
   border,
   color = 'black',
   onClick = noop,
-  children
+  children,
+  size
 }) => {
   const classes = ['btn']
 
@@ -27,6 +29,7 @@ export const Button: React.FC<ButtonProps> = ({
   if (type) classes.push(`bg-${type}`)
   if (m) classes.push(`m-${m}`)
   if (ml) classes.push(`ml-${ml}`)
+  if (size) classes.push(`btn-${size}`)
 
   return (
     <button

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -502,6 +502,18 @@ export type GetAppQuery = { __typename?: 'Query' } & {
   >
 }
 
+export type LessonMentorsQueryVariables = Exact<{
+  lessonId: Scalars['String']
+}>
+
+export type LessonMentorsQuery = { __typename?: 'Query' } & {
+  getLessonMentors?: Maybe<
+    Array<
+      Maybe<{ __typename?: 'User' } & Pick<User, 'username' | 'name' | 'id'>>
+    >
+  >
+}
+
 export type SubmissionsQueryVariables = Exact<{
   lessonId: Scalars['String']
 }>
@@ -517,6 +529,7 @@ export type SubmissionsQuery = { __typename?: 'Query' } & {
           | 'diff'
           | 'comment'
           | 'challengeId'
+          | 'lessonId'
           | 'createdAt'
           | 'updatedAt'
         > & {
@@ -604,16 +617,6 @@ export type SignupMutation = { __typename?: 'Mutation' } & {
       AuthResponse,
       'success' | 'username' | 'error'
     >
-  >
-}
-
-export type LessonMentorsQueryVariables = Exact<{
-  lessonId: Scalars['String']
-}>
-
-export type LessonMentorsQuery = { __typename?: 'Query' } & {
-  getLessonMentors?: Maybe<
-    Array<Maybe<{ __typename?: 'User' } & Pick<User, 'username' | 'name'>>>
   >
 }
 
@@ -2137,6 +2140,115 @@ export type GetAppQueryResult = ApolloReactCommon.QueryResult<
   GetAppQuery,
   GetAppQueryVariables
 >
+export const LessonMentorsDocument = gql`
+  query lessonMentors($lessonId: String!) {
+    getLessonMentors(lessonId: $lessonId) {
+      username
+      name
+      id
+    }
+  }
+`
+export type LessonMentorsComponentProps = Omit<
+  ApolloReactComponents.QueryComponentOptions<
+    LessonMentorsQuery,
+    LessonMentorsQueryVariables
+  >,
+  'query'
+> &
+  (
+    | { variables: LessonMentorsQueryVariables; skip?: boolean }
+    | { skip: boolean }
+  )
+
+export const LessonMentorsComponent = (props: LessonMentorsComponentProps) => (
+  <ApolloReactComponents.Query<LessonMentorsQuery, LessonMentorsQueryVariables>
+    query={LessonMentorsDocument}
+    {...props}
+  />
+)
+
+export type LessonMentorsProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    LessonMentorsQuery,
+    LessonMentorsQueryVariables
+  >
+} &
+  TChildProps
+export function withLessonMentors<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    LessonMentorsQuery,
+    LessonMentorsQueryVariables,
+    LessonMentorsProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    LessonMentorsQuery,
+    LessonMentorsQueryVariables,
+    LessonMentorsProps<TChildProps, TDataName>
+  >(LessonMentorsDocument, {
+    alias: 'lessonMentors',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useLessonMentorsQuery__
+ *
+ * To run a query within a React component, call `useLessonMentorsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLessonMentorsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLessonMentorsQuery({
+ *   variables: {
+ *      lessonId: // value for 'lessonId'
+ *   },
+ * });
+ */
+export function useLessonMentorsQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<
+    LessonMentorsQuery,
+    LessonMentorsQueryVariables
+  >
+) {
+  return ApolloReactHooks.useQuery<
+    LessonMentorsQuery,
+    LessonMentorsQueryVariables
+  >(LessonMentorsDocument, baseOptions)
+}
+export function useLessonMentorsLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    LessonMentorsQuery,
+    LessonMentorsQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<
+    LessonMentorsQuery,
+    LessonMentorsQueryVariables
+  >(LessonMentorsDocument, baseOptions)
+}
+export type LessonMentorsQueryHookResult = ReturnType<
+  typeof useLessonMentorsQuery
+>
+export type LessonMentorsLazyQueryHookResult = ReturnType<
+  typeof useLessonMentorsLazyQuery
+>
+export type LessonMentorsQueryResult = ApolloReactCommon.QueryResult<
+  LessonMentorsQuery,
+  LessonMentorsQueryVariables
+>
 export const SubmissionsDocument = gql`
   query submissions($lessonId: String!) {
     submissions(lessonId: $lessonId) {
@@ -2148,6 +2260,7 @@ export const SubmissionsDocument = gql`
         title
       }
       challengeId
+      lessonId
       user {
         id
         username
@@ -2862,114 +2975,6 @@ export type SignupMutationResult = ApolloReactCommon.MutationResult<
 export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<
   SignupMutation,
   SignupMutationVariables
->
-export const LessonMentorsDocument = gql`
-  query lessonMentors($lessonId: String!) {
-    getLessonMentors(lessonId: $lessonId) {
-      username
-      name
-    }
-  }
-`
-export type LessonMentorsComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >,
-  'query'
-> &
-  (
-    | { variables: LessonMentorsQueryVariables; skip?: boolean }
-    | { skip: boolean }
-  )
-
-export const LessonMentorsComponent = (props: LessonMentorsComponentProps) => (
-  <ApolloReactComponents.Query<LessonMentorsQuery, LessonMentorsQueryVariables>
-    query={LessonMentorsDocument}
-    {...props}
-  />
-)
-
-export type LessonMentorsProps<
-  TChildProps = {},
-  TDataName extends string = 'data'
-> = {
-  [key in TDataName]: ApolloReactHoc.DataValue<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >
-} &
-  TChildProps
-export function withLessonMentors<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'data'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables,
-    LessonMentorsProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withQuery<
-    TProps,
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables,
-    LessonMentorsProps<TChildProps, TDataName>
-  >(LessonMentorsDocument, {
-    alias: 'lessonMentors',
-    ...operationOptions
-  })
-}
-
-/**
- * __useLessonMentorsQuery__
- *
- * To run a query within a React component, call `useLessonMentorsQuery` and pass it any options that fit your needs.
- * When your component renders, `useLessonMentorsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useLessonMentorsQuery({
- *   variables: {
- *      lessonId: // value for 'lessonId'
- *   },
- * });
- */
-export function useLessonMentorsQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >
-) {
-  return ApolloReactHooks.useQuery<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >(LessonMentorsDocument, baseOptions)
-}
-export function useLessonMentorsLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >
-) {
-  return ApolloReactHooks.useLazyQuery<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >(LessonMentorsDocument, baseOptions)
-}
-export type LessonMentorsQueryHookResult = ReturnType<
-  typeof useLessonMentorsQuery
->
-export type LessonMentorsLazyQueryHookResult = ReturnType<
-  typeof useLessonMentorsLazyQuery
->
-export type LessonMentorsQueryResult = ApolloReactCommon.QueryResult<
-  LessonMentorsQuery,
-  LessonMentorsQueryVariables
 >
 export const UpdateChallengeDocument = gql`
   mutation updateChallenge(

--- a/graphql/queries/getLessonMentors.ts
+++ b/graphql/queries/getLessonMentors.ts
@@ -5,6 +5,7 @@ const LESSON_MENTORS = gql`
     getLessonMentors(lessonId: $lessonId) {
       username
       name
+      id
     }
   }
 `

--- a/graphql/queryResolvers/getLessonMentors.test.js
+++ b/graphql/queryResolvers/getLessonMentors.test.js
@@ -8,15 +8,23 @@ describe('getLessonMentors resolver', () => {
     validateLessonId.mockReturnValue(true)
   })
 
-  test('should return an array of usernames', async () => {
-    UserLesson.findAll = jest
-      .fn()
-      .mockReturnValue([
-        { User: { username: 'user1', email: 'abc@mail' } },
-        { User: { username: 'user2', email: 'xyz@mail' } }
-      ])
+  test('should return an array of User objects', async () => {
+    UserLesson.findAll = jest.fn().mockReturnValue([
+      { User: { username: 'user1', email: 'abc@mail', name: 'lol', id: 2 } },
+      {
+        User: {
+          username: 'user2',
+          email: 'xyz@mail',
+          name: 'potato',
+          id: 240
+        }
+      }
+    ])
     const res = await getLessonMentors(null, { lessonId: '3' })
-    expect(res).toEqual([{ username: 'user1' }, { username: 'user2' }])
+    expect(res).toEqual([
+      { username: 'user1', name: 'lol', id: 2 },
+      { username: 'user2', name: 'potato', id: 240 }
+    ])
     expect(UserLesson.findAll).toHaveBeenCalledWith({
       where: { lessonId: '3' },
       include: [{ model: User }]

--- a/graphql/queryResolvers/getLessonMentors.ts
+++ b/graphql/queryResolvers/getLessonMentors.ts
@@ -17,8 +17,8 @@ export const getLessonMentors = async (
       include: [{ model: User }]
     })
 
-    return results.map(({ User: { username, name } }: { User: User }) => {
-      return { username, name }
+    return results.map(({ User: { username, name, id } }: { User: User }) => {
+      return { username, name, id }
     })
   } catch (err) {
     throw new Error(err)

--- a/stories/theme/Button.stories.tsx
+++ b/stories/theme/Button.stories.tsx
@@ -33,3 +33,11 @@ export const TypedButton: React.FC = () => (
 export const BorderButton: React.FC = () => (
   <Button border>Border Button</Button>
 )
+
+export const SmallButton: React.FC = () => (
+  <Button size={'sm'}>Large Button</Button>
+)
+
+export const LargeButton: React.FC = () => (
+  <Button size={'lg'}>Large Button</Button>
+)

--- a/stories/theme/Button.stories.tsx
+++ b/stories/theme/Button.stories.tsx
@@ -35,7 +35,7 @@ export const BorderButton: React.FC = () => (
 )
 
 export const SmallButton: React.FC = () => (
-  <Button size="sm">Large Button</Button>
+  <Button size="sm">Small Button</Button>
 )
 
 export const LargeButton: React.FC = () => (

--- a/stories/theme/Button.stories.tsx
+++ b/stories/theme/Button.stories.tsx
@@ -35,9 +35,9 @@ export const BorderButton: React.FC = () => (
 )
 
 export const SmallButton: React.FC = () => (
-  <Button size={'sm'}>Large Button</Button>
+  <Button size="sm">Large Button</Button>
 )
 
 export const LargeButton: React.FC = () => (
-  <Button size={'lg'}>Large Button</Button>
+  <Button size="lg">Large Button</Button>
 )


### PR DESCRIPTION
## Issues

#449 
The design spec for a button on the `giveStarCard` has a bigger button than the one our codebase provides. 

Here is the design spec with the big button:
https://app.zeplin.io/project/5e19606fd539a701e62f9d70/screen/5e44ed5557b4ff8a25025e1f

#450 
The getLessonMentors resolver needs to return a user's Id, or else the upcoming `giveStarCard` has no id to use as a `mentorId` when making a mutation request to give a star to another user.

## This PR will:
* Update `Button` component to include size option as a prop, update snapshots and stories accordingly
* Update getLessonMentors resolver and query to return a user's Id, update test and `graphql/index.js` file accordingly