### PR TITLE
closes #452 - Creation of ModalCard component

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -3744,6 +3744,48 @@ exports[`Storyshots Components/MdInput With Submission Buttons 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/ModalCard Large 1`] = `
+<button
+  className="btn"
+  onClick={[Function]}
+  style={
+    Object {
+      "color": "#292929",
+    }
+  }
+>
+  Launch demo modal
+</button>
+`;
+
+exports[`Storyshots Components/ModalCard Medium 1`] = `
+<button
+  className="btn"
+  onClick={[Function]}
+  style={
+    Object {
+      "color": "#292929",
+    }
+  }
+>
+  Launch demo modal
+</button>
+`;
+
+exports[`Storyshots Components/ModalCard Small 1`] = `
+<button
+  className="btn"
+  onClick={[Function]}
+  style={
+    Object {
+      "color": "#292929",
+    }
+  }
+>
+  Launch demo modal
+</button>
+`;
+
 exports[`Storyshots Components/NavLink Active Link 1`] = `
 Array [
   <a

--- a/__tests__/storyshots.test.js
+++ b/__tests__/storyshots.test.js
@@ -1,9 +1,9 @@
 import initStoryshots from '@storybook/addon-storyshots'
 
 /*	
-		This mock is necessary because there is currently a problem
-		with taking storyshots of Modals. See here for more info:
-		https://github.com/storybookjs/storybook/issues/2822
+	This mock is necessary because there is currently a problem
+	with taking storyshots of Modals. See here for more info:
+	https://github.com/storybookjs/storybook/issues/2822
 */
 jest.mock('react-bootstrap/Modal', () => {
   return props => (props.isOpen ? props.children : null)

--- a/__tests__/storyshots.test.js
+++ b/__tests__/storyshots.test.js
@@ -1,3 +1,10 @@
 import initStoryshots from '@storybook/addon-storyshots'
 
+/*	This mock is necessary because there is currently a problem
+		with taking storyshots of Modals. See here for more info:
+		https://github.com/storybookjs/storybook/issues/2822
+*/
+jest.mock('react-bootstrap/Modal', () => {
+  return props => (props.isOpen ? props.children : null)
+})
 initStoryshots()

--- a/__tests__/storyshots.test.js
+++ b/__tests__/storyshots.test.js
@@ -1,6 +1,7 @@
 import initStoryshots from '@storybook/addon-storyshots'
 
-/*	This mock is necessary because there is currently a problem
+/*	
+		This mock is necessary because there is currently a problem
 		with taking storyshots of Modals. See here for more info:
 		https://github.com/storybookjs/storybook/issues/2822
 */

--- a/components/ModalCard.test.js
+++ b/components/ModalCard.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { ModalCard } from './ModalCard'
+
+describe('ModalCard Component', () => {
+  test('should call callback function when exit button is clicked', () => {
+    let res = ''
+    const expectedResult = 'potatus maximus'
+    const { container, getByRole } = render(
+      <ModalCard show={true} close={() => (res = expectedResult)} />
+    )
+    const exitBtn = getByRole('img')
+    fireEvent.click(exitBtn)
+    expect(res).toEqual(expectedResult)
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/components/ModalCard.tsx
+++ b/components/ModalCard.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import Modal from 'react-bootstrap/Modal'
+import '../scss/modalCard.scss'
+
+export enum ModalSize {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large'
+}
+
+interface ModalCardProps {
+  show: boolean
+  close: Function
+  size?: ModalSize
+}
+
+export const ModalCard: React.FC<ModalCardProps> = ({
+  show,
+  close,
+  size = 'medium',
+  children
+}) => {
+  return (
+    <Modal show={show} onHide={close} dialogClassName={size}>
+      <img
+        className=".img-fluid btn position-absolute exitBtn"
+        src={'/curriculumAssets/icons/exit.svg'}
+        onClick={() => close()}
+      />
+      {children}
+    </Modal>
+  )
+}

--- a/components/__snapshots__/ModalCard.test.js.snap
+++ b/components/__snapshots__/ModalCard.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalCard Component should call callback function when exit button is clicked 1`] = `
+<div
+  aria-hidden="true"
+/>
+`;

--- a/public/curriculumAssets/icons/exit.svg
+++ b/public/curriculumAssets/icons/exit.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="42px" height="42px" viewBox="0 0 42 42" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 62 (101010) - https://sketch.com -->
+    <title>581230D0-3F14-4881-AB2F-7F664A8BC016</title>
+    <desc>Created with sketchtool.</desc>
+    <defs>
+        <circle id="path-1" cx="17" cy="17" r="17"></circle>
+        <filter x="-20.6%" y="-14.7%" width="141.2%" height="141.2%" filterUnits="objectBoundingBox" id="filter-2">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"></feComposite>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.5 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix>
+        </filter>
+    </defs>
+    <g id="Designs" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="25.-Bravo---Success" transform="translate(-994.000000, -81.000000)">
+            <g id="icon-close" transform="translate(998.000000, 83.000000)">
+                <g id="Oval">
+                    <use fill="black" fill-opacity="1" filter="url(#filter-2)" xlink:href="#path-1"></use>
+                    <circle stroke="#FFFFFF" stroke-width="2" stroke-linejoin="square" fill="#181818" fill-rule="evenodd" cx="17" cy="17" r="16"></circle>
+                </g>
+                <path d="M23.675007,22.1437883 C23.8811705,22.3468749 23.9979653,22.6230857 24,22.9114491 C24.0010098,23.2008524 23.8872646,23.478064 23.6821047,23.6821514 C23.4779717,23.8872682 23.200709,24.0010071 22.9112892,24 C22.6228573,23.9979631 22.346619,23.8811879 22.1435156,23.6750547 L17.4930918,19.025314 L12.842668,23.6750547 C12.4181579,24.0924058 11.7377146,24.0893644 11.3172603,23.6689615 C10.896806,23.248569 10.8937642,22.5682256 11.3111662,22.1437779 L15.96159,17.4940372 L11.3111662,12.8442965 C10.8937538,12.4198488 10.8967956,11.7395054 11.3172603,11.3191129 C11.7377146,10.8987204 12.4181579,10.895679 12.842668,11.3130223 L17.4930918,15.962763 L22.1435156,11.3130223 L22.1435156,11.3120059 C22.5670117,10.893641 23.2494829,10.8966824 23.6709511,11.3170827 C24.0914054,11.738489 24.0944473,12.42086 23.6750148,12.8442939 L19.0245909,17.4940346 L23.675007,22.1437883 Z" id="Fill-1" fill="#FFFFFF"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/scss/modalCard.scss
+++ b/scss/modalCard.scss
@@ -1,0 +1,28 @@
+// .small {
+// 	max-width: 392px;
+// }
+
+// .medium {
+// 	max-width: 588px;
+// }
+
+// .large {
+// 	max-width: 784px;
+// }
+
+.small {
+	max-width: 28%;
+}
+
+.medium {
+	max-width: 42%;
+}
+
+.large {
+	max-width: 56%;
+}
+
+.exitBtn {
+	right: -34px; 
+	top: -27px;
+}

--- a/scss/modalCard.scss
+++ b/scss/modalCard.scss
@@ -1,15 +1,3 @@
-// .small {
-// 	max-width: 392px;
-// }
-
-// .medium {
-// 	max-width: 588px;
-// }
-
-// .large {
-// 	max-width: 784px;
-// }
-
 .small {
 	max-width: 28%;
 }

--- a/stories/components/ModalCard.stories.tsx
+++ b/stories/components/ModalCard.stories.tsx
@@ -1,0 +1,27 @@
+import _ from 'lodash'
+import React, { useState } from 'react'
+import { ModalCard, ModalSize } from '../../components/ModalCard'
+import { Button } from '../../components/theme/Button'
+
+export default {
+  component: ModalCard,
+  title: 'Components/ModalCard'
+}
+
+const MockSize: React.FC<{ size: ModalSize }> = ({ size }) => {
+  const [show, setShow] = useState(true)
+  return (
+    <>
+      <Button onClick={() => setShow(true)}>Launch demo modal</Button>
+      <ModalCard size={size} show={show} close={() => setShow(false)}>
+        <h1 className="text-center">{_.capitalize(size)}</h1>
+      </ModalCard>
+    </>
+  )
+}
+
+export const Small = () => <MockSize size={ModalSize.SMALL} />
+
+export const Medium = () => <MockSize size={ModalSize.MEDIUM} />
+
+export const Large = () => <MockSize size={ModalSize.LARGE} />


### PR DESCRIPTION
closes #452 

The upcoming `GiveStarCard` component needs to be displayed as a modal. We do not have any existing Modal type components in our codebase.

## This PR will
* Create `ModalCard` component along with testing file
* Add an `svg` image to use as exit button in `ModalCard`
* Add `ModalCard` to storybook, update snapshots

<img width="458" alt="Screen Shot 2020-12-22 at 4 54 52 PM" src="https://user-images.githubusercontent.com/45890848/102948067-dd550400-4479-11eb-84c0-553bad80eefa.png">
<img width="648" alt="Screen Shot 2020-12-22 at 4 55 02 PM" src="https://user-images.githubusercontent.com/45890848/102948072-e0e88b00-4479-11eb-8372-92529fbac860.png">
<img width="842" alt="Screen Shot 2020-12-22 at 4 55 14 PM" src="https://user-images.githubusercontent.com/45890848/102948074-e2b24e80-4479-11eb-8af6-223d28260b4e.png">
