### PR TITLE
Improve submission syntax highlighting, Add profile link in review comment

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5053,7 +5053,15 @@ exports[`Storyshots Components/ReviewStatus Need More Work Status 1`] = `
 <div
   className="text-center p-2 my-2 border border-danger text-danger"
 >
-  Your solution was reviewed and rejected by dan
+  Your solution was reviewed and rejected by 
+  <a
+    className="text-reset"
+    href="/profile/dan"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+  >
+    dan
+  </a>
 </div>
 `;
 
@@ -5061,7 +5069,7 @@ exports[`Storyshots Components/ReviewStatus Open Status 1`] = `
 <div
   className="text-center p-2 my-2 border border-warning text-warning"
 >
-  Your MR is currently waiting to be reviewed
+  Your submission is currently waiting to be reviewed
 </div>
 `;
 
@@ -5069,7 +5077,15 @@ exports[`Storyshots Components/ReviewStatus Passed Status 1`] = `
 <div
   className="text-center p-2 my-2 border border-success text-success"
 >
-  Your solution was reviewed and accepted by dan
+  Your solution was reviewed and accepted by 
+  <a
+    className="text-reset"
+    href="/profile/dan"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+  >
+    dan
+  </a>
 </div>
 `;
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -16,11 +16,18 @@ const inlineReactSvg = [
   }
 ]
 
+const prismJs = [
+  'prismjs',
+  {
+    languages: ['javascript', 'css', 'html', 'jsx', 'json']
+  }
+]
+
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],
     '@babel/preset-react',
     '@babel/preset-typescript'
   ],
-  plugins: [inlineReactSvg, '@babel/syntax-dynamic-import']
+  plugins: [inlineReactSvg, prismJs, '@babel/syntax-dynamic-import']
 }

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -60,20 +60,34 @@ export const ReviewStatus: React.FC<ReviewStatusProps> = ({
   status,
   reviewerUserName
 }) => {
-  //TODO change reviewerUserName to NavLink to Profile Page when page is completed
   let reviewStatusComment
   let statusClassName
+  const profileLink = (
+    <NavLink
+      className="text-reset"
+      path="/profile/[username]"
+      as={`/profile/${reviewerUserName}`}
+    >
+      {reviewerUserName}
+    </NavLink>
+  )
   switch (status) {
     case 'passed':
-      reviewStatusComment = `Your solution was reviewed and accepted by ${reviewerUserName}`
+      reviewStatusComment = (
+        <>Your solution was reviewed and accepted by {profileLink}</>
+      )
       statusClassName = 'border border-success text-success'
       break
     case 'needMoreWork':
-      reviewStatusComment = `Your solution was reviewed and rejected by ${reviewerUserName}`
+      reviewStatusComment = (
+        <>Your solution was reviewed and rejected by {profileLink}</>
+      )
       statusClassName = 'border border-danger text-danger'
       break
     case 'open':
-      reviewStatusComment = 'Your MR is currently waiting to be reviewed'
+      reviewStatusComment = (
+        <>Your submission is currently waiting to be reviewed</>
+      )
       statusClassName = 'border border-warning text-warning'
       break
     default:

--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -29,11 +29,17 @@ type DiffViewProps = {
   diff?: string
 }
 
+const prismLanguages = ['js', 'javascript', 'html', 'css', 'json', 'jsx']
+
 const DiffView: React.FC<DiffViewProps> = ({ diff = '' }) => {
   const files = gitDiffParser.parse(diff)
 
   const renderFile = ({ hunks, newPath }: File) => {
     const newValue: String[] = []
+    let extension = newPath.split('.').pop() || prismLanguages[0]
+    if (!prismLanguages.includes(extension)) {
+      extension = 'javascript'
+    }
 
     hunks.forEach(hunk => {
       hunk.changes.forEach(change => {
@@ -46,8 +52,8 @@ const DiffView: React.FC<DiffViewProps> = ({ diff = '' }) => {
 
       const language = Prism.highlight(
         str,
-        Prism.languages.javascript,
-        'javascript'
+        Prism.languages[extension],
+        extension
       )
       return <span dangerouslySetInnerHTML={{ __html: language }} />
     }

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -831,7 +831,7 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
           <div
             class="text-center p-2 my-2 border border-warning text-warning"
           >
-            Your MR is currently waiting to be reviewed
+            Your submission is currently waiting to be reviewed
           </div>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-inline-react-svg": "^1.1.1",
+    "babel-plugin-prismjs": "^2.0.1",
     "babel-preset-react-app": "^9.1.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4837,6 +4837,11 @@ babel-plugin-named-asset-import@^0.3.1:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz#c9750a1b38d85112c9e166bf3ef7c5dbc605f4be"
 
+babel-plugin-prismjs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-prismjs/-/babel-plugin-prismjs-2.0.1.tgz#b56095f423926662259de8f5ee50a7afbcf0fd92"
+  integrity sha512-GqQGa3xX3Z2ft97oDbGvEFoxD8nKqb3ZVszrOc5H7icnEUA56BIjVYm86hfZZA82uuHLwTIfCXbEKzKG1BzKzg==
+
 babel-plugin-react-docgen@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-4.1.0.tgz#1dfa447dac9ca32d625a123df5733a9e47287c26"


### PR DESCRIPTION
Currently the syntax highlighting for the submissions review page is hardcoded to highlight only Javascript.

Also, there was a TODO in the code to put a link to the reviewer profile in the challenge card component.

This PR:

* makes the syntax highlighting more dynamic by using the file extension like `.js`, `.html`, `.css`, etc. For this to work, the PrismJS babel plugin had to be added into the project dev dependencies as well.
	* I selected a few languages that are more likely to be used for the challenges, so we don't have to worry about supporting every language that PrismJS supports.
	* These languages are: `javascript`, `css`, `html`, `jsx`, `json`.
	* They are defined in the Babel config file, for the PrismJS babel plugin.
* add a link to the reviewer profile in the `ChallengeMaterial` component.
	* uses the internal `NavLink` component
	* snapshots were also updated
