### PR TITLE
closes #458 - update starGiven field to return string instead of Star type

### DIFF
--- a/@types/lesson.d.ts
+++ b/@types/lesson.d.ts
@@ -4,7 +4,7 @@ export type LessonStatus = {
   isTeaching: string | null
   lessonId: string
   starsReceived?: Star[]
-  starGiven?: String
+  starGiven?: string
 }
 
 export type User = {

--- a/@types/lesson.d.ts
+++ b/@types/lesson.d.ts
@@ -4,7 +4,7 @@ export type LessonStatus = {
   isTeaching: string | null
   lessonId: string
   starsReceived?: Star[]
-  starGiven?: Star
+  starGiven?: String
 }
 
 export type User = {

--- a/__tests__/pages/[lesson].test.js
+++ b/__tests__/pages/[lesson].test.js
@@ -53,13 +53,15 @@ describe('Lesson Page', () => {
           lessonId: '5',
           isPassed: true,
           isTeaching: true,
-          isEnrolled: false
+          isEnrolled: false,
+          starGiven: null
         },
         {
           lessonId: '2',
           isPassed: false,
           isTeaching: false,
-          isEnrolled: true
+          isEnrolled: true,
+          starGiven: null
         }
       ]
     }
@@ -135,13 +137,15 @@ describe('Lesson Page', () => {
           lessonId: '5',
           isPassed: true,
           isTeaching: true,
-          isEnrolled: false
+          isEnrolled: false,
+          starGiven: null
         },
         {
           lessonId: '2',
           isPassed: false,
           isTeaching: false,
-          isEnrolled: true
+          isEnrolled: true,
+          starGiven: null
         }
       ]
     }

--- a/__tests__/pages/curriculum.test.js
+++ b/__tests__/pages/curriculum.test.js
@@ -101,19 +101,22 @@ describe('Curriculum Page', () => {
           lessonId: '5',
           isPassed: true,
           isTeaching: true,
-          isEnrolled: false
+          isEnrolled: false,
+          starGiven: null
         },
         {
           lessonId: '2',
           isPassed: true,
           isTeaching: true,
-          isEnrolled: false
+          isEnrolled: false,
+          starGiven: null
         },
         {
           lessonId: '1',
           isPassed: true,
           isTeaching: true,
-          isEnrolled: false
+          isEnrolled: false,
+          starGiven: null
         }
       ]
     }

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -285,7 +285,7 @@ export type UserLesson = {
   isTeaching?: Maybe<Scalars['String']>
   isEnrolled?: Maybe<Scalars['String']>
   starsReceived?: Maybe<Array<Maybe<Star>>>
-  starGiven?: Maybe<Star>
+  starGiven?: Maybe<Scalars['String']>
 }
 
 export type AcceptSubmissionMutationVariables = Exact<{
@@ -489,7 +489,7 @@ export type GetAppQuery = { __typename?: 'Query' } & {
       lessonStatus: Array<
         { __typename?: 'UserLesson' } & Pick<
           UserLesson,
-          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled'
+          'lessonId' | 'isPassed' | 'isTeaching' | 'isEnrolled' | 'starGiven'
         >
       >
     }
@@ -1293,7 +1293,7 @@ export type UserLessonResolvers<
     ParentType,
     ContextType
   >
-  starGiven?: Resolver<Maybe<ResolversTypes['Star']>, ParentType, ContextType>
+  starGiven?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType>
 }
 
@@ -2041,6 +2041,7 @@ export const GetAppDocument = gql`
         isPassed
         isTeaching
         isEnrolled
+        starGiven
       }
     }
     alerts {

--- a/graphql/queries/getApp.ts
+++ b/graphql/queries/getApp.ts
@@ -47,6 +47,7 @@ const GET_APP = gql`
         isPassed
         isTeaching
         isEnrolled
+        starGiven
       }
     }
     alerts {

--- a/graphql/queryResolvers/session.test.js
+++ b/graphql/queryResolvers/session.test.js
@@ -2,7 +2,7 @@ jest.mock('../../helpers/dbload')
 import { session } from './session'
 import db from '../../helpers/dbload'
 
-const { Submission, UserLesson, Star } = db
+const { Submission, UserLesson, Star, User } = db
 
 describe('Session resolver', () => {
   test('should return null if req.user does not exist', async () => {
@@ -13,19 +13,24 @@ describe('Session resolver', () => {
   test('should return user including submissions and lessonStatus', async () => {
     const result = {
       user: { username: 'test', id: 815 },
-      submissions: [{ id: '1' }],
-      lessonStatus: [{ id: '1', lessonId: 4 }],
-      starGiven: [{ dataValues: { lessonId: 4, comment: 'lol' } }]
+      submissions: { id: '1' },
+      lessonStatus: { id: '1', lessonId: 4, starGiven: 'jobless' }
     }
-    const req = { user: result.user }
-    Submission.findAll = jest.fn().mockReturnValue(result.submissions)
-    UserLesson.findAll = jest.fn().mockReturnValue(result.lessonStatus)
-    Star.findAll = jest.fn().mockReturnValue(result.starGiven)
-
+    const req = { user: { ...result.user } }
+    Submission.findAll = jest.fn().mockReturnValue([{ ...result.submissions }])
+    UserLesson.findAll = jest.fn().mockReturnValue([{ ...result.lessonStatus }])
+    Star.findAll = jest
+      .fn()
+      .mockReturnValue([
+        { dataValues: { mentorId: 3, studentId: 815, lessonId: 4 } }
+      ])
+    User.findAll = jest
+      .fn()
+      .mockReturnValue([{ dataValues: { id: 3, username: 'jobless' } }])
     const returnValue = await session({}, {}, { req })
 
     expect(returnValue.user).toEqual(result.user)
-    expect(returnValue.submissions).toEqual(result.submissions)
-    expect(returnValue.lessonStatus).toEqual(result.lessonStatus)
+    expect(returnValue.submissions).toEqual([result.submissions])
+    expect(returnValue.lessonStatus).toEqual([result.lessonStatus])
   })
 })

--- a/graphql/queryResolvers/session.ts
+++ b/graphql/queryResolvers/session.ts
@@ -1,11 +1,18 @@
 import db from '../../helpers/dbload'
 import { Context } from '../../@types/helpers'
+import { User as UserType } from '../../helpers/models/User'
 import { Star as StarType, LessonStatus } from '../../@types/lesson'
 import _ from 'lodash'
 const { User, Submission, UserLesson, Star } = db
 
 type Submission = {
   lessonId: string
+}
+interface mentorUsernamesMapType {
+  [userId: number]: string
+}
+interface mentorIdsMapType {
+  [lessonId: string]: number
 }
 
 export const session = async (_parent: void, _args: void, context: Context) => {
@@ -24,16 +31,32 @@ export const session = async (_parent: void, _args: void, context: Context) => {
     Star.findAll({ where: { studentId: userId } })
   ])
 
-  const starMap = stars.reduce(
-    (map: any, { dataValues }: { dataValues: StarType }) => {
-      map[dataValues.lessonId] = dataValues
+  const mentorIdsMap: mentorIdsMapType = stars.reduce(
+    (map: mentorIdsMapType, { dataValues }: { dataValues: StarType }) => {
+      const { lessonId, mentorId } = dataValues
+      map[lessonId] = mentorId
+      return map
+    },
+    {}
+  )
+
+  const mentors = await User.findAll({
+    where: { id: Object.values(mentorIdsMap) as number[] }
+  })
+
+  const mentorUsernamesMap: mentorUsernamesMapType = mentors.reduce(
+    (map: mentorUsernamesMapType, { dataValues }: { dataValues: UserType }) => {
+      const { id, username } = dataValues
+      map[id] = username
       return map
     },
     {}
   )
 
   lessonStatus.forEach((lesson: LessonStatus) => {
-    lesson.starGiven = starMap[lesson.lessonId]
+    const mentorId = mentorIdsMap[lesson.lessonId]
+    const username = mentorUsernamesMap[mentorId]
+    lesson.starGiven = username
   })
 
   return {

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -134,7 +134,7 @@ export default gql`
     isTeaching: String
     isEnrolled: String
     starsReceived: [Star]
-    starGiven: Star
+    starGiven: String
   }
 
   type Lesson {


### PR DESCRIPTION
In our graphql typedefs, the starGiven field of the lessonStatus type is defined as a Star, but the field needs a username string instead. This field is intended to be used for the `GiveStarCard` component as a prop value to pass in -- therefore a username is needed

## This PR will update these files to reflect the change in the `starGiven` field:
* session resolver to return a username `string` instead of a `Star` object for the `starGiven` field
* tests for session resolver
* other tests that were failing after updating the session resolver
* typescript `LessonStatus` type 
* graphql/index file since typedefs file changed
* getApp query
