### PR TITLE
fix bug when `newPath` is undefined

### DIFF
--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -36,6 +36,7 @@ const DiffView: React.FC<DiffViewProps> = ({ diff = '' }) => {
 
   const renderFile = ({ hunks, newPath }: File) => {
     const newValue: String[] = []
+    if (!hunks.length || !newPath) return
     let extension = newPath.split('.').pop() || prismLanguages[0]
     if (!prismLanguages.includes(extension)) {
       extension = 'javascript'


### PR DESCRIPTION
Today when I was going to review some JS4 submissions I was faced with an error message saying "An unexpected error has occurred.".

On the console there was the following error:

```
_app.js:1 TypeError: Cannot read property 'split' of undefined
    at [lesson].js:formatted:74
```

And looking at line 74 of the mentioned file:

```js
let n = t.split(".").pop() || $[0];
```

I recognized that as a line of code I recently had written for PR #457. That line extracts the file extension for the submission.

Upon further investigation, I discovered that for deleted files commit, the file name is `undefined`, causing the error.

So in this PR, I fixed that by simply checking for the diff hunks length, which is 0 when a file is deleted, or for an undefined file name (`newPath`).