### PR TITLE
updates #473 - fix Thanks and ModalCard components for better display on mobile

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5385,7 +5385,7 @@ exports[`Storyshots Components/Thanks Basic 1`] = `
           src="/curriculumAssets/icons/success.svg"
         />
         <h2
-          className="mt-4 mb-4 pt-3 pb-3 font-weight-bold"
+          className="mt-4 mb-4 pt-3 pb-3 font-weight-bold text-center"
         >
           Thanks for letting us know!
         </h2>

--- a/components/Thanks.tsx
+++ b/components/Thanks.tsx
@@ -5,7 +5,7 @@ import { Button } from './theme/Button'
 export const Thanks: React.FC<{ close: Function }> = ({ close }) => (
   <div className="d-flex justify-content-center align-items-center flex-column modal-height-med">
     <img className="h-25 w-25" src="/curriculumAssets/icons/success.svg" />
-    <h2 className="mt-4 mb-4 pt-3 pb-3 font-weight-bold">
+    <h2 className="mt-4 mb-4 pt-3 pb-3 font-weight-bold text-center">
       Thanks for letting us know!
     </h2>
     <Button type="primary" color="white" size="lg" onClick={close}>

--- a/components/__snapshots__/Thanks.test.js.snap
+++ b/components/__snapshots__/Thanks.test.js.snap
@@ -10,7 +10,7 @@ exports[`Thanks Component should call callback function when done button is clic
       src="/curriculumAssets/icons/success.svg"
     />
     <h2
-      class="mt-4 mb-4 pt-3 pb-3 font-weight-bold"
+      class="mt-4 mb-4 pt-3 pb-3 font-weight-bold text-center"
     >
       Thanks for letting us know!
     </h2>

--- a/scss/modalCard.scss
+++ b/scss/modalCard.scss
@@ -1,20 +1,27 @@
+@media only screen and (max-width: 812px) {
+  .small, .medium, .large {
+    max-width: 100% !important;
+    padding: 20px 15px;
+  }
+}
+
 .small {
-	max-width: 25%;
+  max-width: 25%;
 }
 
 .medium {
-	max-width: 35%;
+  max-width: 35%;
 }
 
 .large {
-	max-width: 45%;
+  max-width: 45%;
 }
 
 .exitBtn {
-	right: -34px; 
-	top: -27px;
+  right: -34px; 
+  top: -27px;
 }
 
 .modal-height-med {
-	height: 53vh;
+  height: 53vh;
 }


### PR DESCRIPTION
updates #473 

The `Thanks` and `ModalCard` components have noticeable flaws on mobile, and look really bad. This PR will make those components look better on mobile by:

* Adding media query for `ModalCard` widths -- on mobile, width of modals will be 100% because the width of a mobile phone is already small.
* Adding `text-center` bootstrap class to `h4` element of the `Thanks` component 

Try the components out in the storybook!
### ModalCard
https://story-code.khoa.app/iframe.html?id=components-modalcard--medium&viewMode=story
### Thanks
https://story-code.khoa.app/iframe.html?id=components-thanks--modal&viewMode=story

**The following pictures are iphone X mobile view displays**
# Before
<img width="408" alt="Screen Shot 2021-01-22 at 7 21 06 PM" src="https://user-images.githubusercontent.com/45890848/105567478-fe15b100-5ce6-11eb-904e-ccdf3e0f1507.png">
<img width="404" alt="Screen Shot 2021-01-22 at 5 49 48 PM" src="https://user-images.githubusercontent.com/45890848/105567392-61531380-5ce6-11eb-8eb0-8f79841f4532.png">

# After
<img width="408" alt="Screen Shot 2021-01-22 at 4 34 05 PM" src="https://user-images.githubusercontent.com/45890848/105567396-687a2180-5ce6-11eb-8e6f-4a71d270194d.png">
<img width="404" alt="Screen Shot 2021-01-22 at 5 49 13 PM" src="https://user-images.githubusercontent.com/45890848/105567397-6a43e500-5ce6-11eb-836d-01e81b6e0eed.png">
