### PR TITLE
closes #476 - Notify chatroom when someone receives a star

### DIFF
--- a/helpers/controllers/starsController.test.js
+++ b/helpers/controllers/starsController.test.js
@@ -1,16 +1,22 @@
 jest.mock('../../helpers/dbload')
 jest.mock('../../helpers/validateLessonId')
+jest.mock('../mattermost')
 import { setStar } from './starsController'
 import { validateLessonId } from '../validateLessonId'
+import { getUserByEmail } from '../mattermost'
 import db from '../dbload'
 
-const { Star } = db
 const ctx = {
   req: {
     error: jest.fn(),
     user: { id: 1337 }
   }
 }
+const { Star, Lesson, User } = db
+Lesson.findByPk = jest.fn().mockReturnValue({ chatUrl: 'jim/flam' })
+User.findByPk = jest.fn().mockReturnValue({ email: 'potatoLove@potatus.com' })
+getUserByEmail.mockReturnValue({ username: 'flam' })
+
 describe('setStar resolver', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/helpers/controllers/starsController.ts
+++ b/helpers/controllers/starsController.ts
@@ -4,8 +4,9 @@ import { Star as StarType } from '../../@types/lesson'
 import _ from 'lodash'
 import { validateLessonId } from '../validateLessonId'
 import { validateStudentId } from '../validation/validateStudentId'
+import { getUserByEmail, publicChannelMessage } from '../mattermost'
 
-const { Star } = db
+const { Star, Lesson, User } = db
 
 export const setStar = async (
   _parent: void,
@@ -15,20 +16,30 @@ export const setStar = async (
   const { req } = ctx
   try {
     const studentId = validateStudentId(req)
-    const { lessonId } = arg
+    const { lessonId, mentorId } = arg
     await validateLessonId(lessonId)
 
     const lookupData = { where: { studentId, lessonId } }
     const starsList = await Star.findAll(lookupData)
-    /*  If there is an element in starsList, then that means the student has already given
-        a star to someone for this lessonId. Students can only give one star per lesson, so
-        delete the previous star(s) already in the database before creating a new one
+    /*
+      If there is an element in starsList, then that means the student has already given
+      a star to someone for this lessonId. Students can only give one star per lesson, so
+      delete the previous star(s) already in the database before creating a new one
     */
     if (starsList.length) {
       await Star.destroy(lookupData)
     }
 
     await Star.create({ ...arg, studentId })
+
+    const [{ chatUrl }, { email }] = await Promise.all([
+      Lesson.findByPk(lessonId, { raw: true }),
+      User.findByPk(mentorId, { raw: true })
+    ])
+
+    const channelName = chatUrl.split('/').pop()
+    const { username } = await getUserByEmail(email)
+    publicChannelMessage(channelName, `@${username} received a star!`)
     return { success: true }
   } catch (err) {
     req.error(`Failed to add Star into Database: ${err}`)


### PR DESCRIPTION
closes #476 

Version 1 of c0d3 had it such that whenever someone received a star for a lesson module, a notification would appear in that lesson module's chatroom(for example js0 chatroom)

Currently, our setStar resolver(which handles making a request to the database to give a user a star) does not notify the chatroom

## This PR will
* Update the `setStar` graphql resolver to notify chatroom when star has been received by someone
* Update corresponding testing file