### PR TITLE
closes #479 - Update GiveStarCard to return null when the show prop has a value of false

### DIFF
--- a/components/GiveStarCard.test.js
+++ b/components/GiveStarCard.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent, wait, act, waitFor } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { GiveStarCard } from './GiveStarCard'
 import { MockedProvider } from '@apollo/react-testing'
 import SET_STAR from '../graphql/queries/setStar'
@@ -46,6 +46,14 @@ describe('GiveStarCard Component', () => {
       lessonId: '4',
       starGiven: 'flimmy flam jam'
     }
+  })
+
+  test('should display nothing when show prop is empty', async () => {
+    // expect(GiveStarCard({ ...mockProps })).toEqual(null)
+    mockProps.show = false
+    render(<GiveStarCard {...mockProps} />)
+    expect(GiveStarCard(mockProps)).toBeNull()
+    expect(document.body).toMatchSnapshot()
   })
 
   test('should display `already given star to` display when starGiven prop does not equal empty string', async () => {

--- a/components/GiveStarCard.test.js
+++ b/components/GiveStarCard.test.js
@@ -48,7 +48,7 @@ describe('GiveStarCard Component', () => {
     }
   })
 
-  test('should display nothing when show prop is empty', async () => {
+  test('should display nothing when show prop is false', async () => {
     mockProps.show = false
     render(<GiveStarCard {...mockProps} />)
     expect(GiveStarCard(mockProps)).toBeNull()

--- a/components/GiveStarCard.test.js
+++ b/components/GiveStarCard.test.js
@@ -49,7 +49,6 @@ describe('GiveStarCard Component', () => {
   })
 
   test('should display nothing when show prop is empty', async () => {
-    // expect(GiveStarCard({ ...mockProps })).toEqual(null)
     mockProps.show = false
     render(<GiveStarCard {...mockProps} />)
     expect(GiveStarCard(mockProps)).toBeNull()

--- a/components/GiveStarCard.tsx
+++ b/components/GiveStarCard.tsx
@@ -198,6 +198,10 @@ export const GiveStarCard: React.FC<GiveStarCardProps> = ({
   starGiven,
   setStarGiven
 }) => {
+  if (!show) {
+    return null
+  }
+
   if (starGiven) {
     return (
       <ModalCard show={show} close={close}>

--- a/components/__snapshots__/GiveStarCard.test.js.snap
+++ b/components/__snapshots__/GiveStarCard.test.js.snap
@@ -998,7 +998,7 @@ exports[`GiveStarCard Component should display error message when giving a star 
 </body>
 `;
 
-exports[`GiveStarCard Component should display nothing when show prop is empty 1`] = `
+exports[`GiveStarCard Component should display nothing when show prop is false 1`] = `
 <body>
   <div />
 </body>

--- a/components/__snapshots__/GiveStarCard.test.js.snap
+++ b/components/__snapshots__/GiveStarCard.test.js.snap
@@ -998,6 +998,12 @@ exports[`GiveStarCard Component should display error message when giving a star 
 </body>
 `;
 
+exports[`GiveStarCard Component should display nothing when show prop is empty 1`] = `
+<body>
+  <div />
+</body>
+`;
+
 exports[`GiveStarCard Component should successfully search for and give mentor a Star 1`] = `
 <body
   class="modal-open"


### PR DESCRIPTION
closes #479 

While I was working on integrating the `GiveStarCard` into the website, I noticed that a graphql request gets sent to get the `lessonMentors` inside the `GiveStarCard` before the `GiveStarCard` modal pops up. This is problematic because on the lesson challenges page, if a student has not completed all challenges for a lesson yet, then the request to get the `lessonMentors` will still get sent even though the student can't give someone a star yet.

This request should `only` be sent when someone clicks the button to display the `GiveStarCard` -- not before it shows up. 

## Solution
Return null when the `show` prop of `GiveStarCard` equals false. 

## This PR will
* Make the `GiveStarCard` return null when the `show` prop value of `GiveStarCard` equals false
* Update corresponding snapshots
* Update corresponding test