### PR TITLE
add profile/username test

### DIFF
--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -801,27 +801,800 @@ exports[`user profile test Should render anonymous users 1`] = `
 
 exports[`user profile test Should render loading spinner if data is not ready 1`] = `
 <div>
-  <div
-    class="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
-    style="min-height: 100vh; position: fixed; top: 0px; left: 0px; z-index: 1;"
+  <nav
+    class="navbar navbar-expand-lg navbar-light justify-content-between bg-white"
   >
-    <h1
-      class="text-white font-weight-bold display-3"
-      style="font-family: 'PT Mono', sans-serif;"
-    >
-      C0D3
-    </h1>
     <div
-      class="spinner-border text-white"
-      role="status"
+      class="container"
     >
-      <h1
-        class="sr-only"
+      <a
+        class="navbar-brand text-primary font-weight-bold"
+        href="/"
       >
-        Loading...
-      </h1>
+        C0D3
+      </a>
+      <div
+        id="navbarNav"
+      >
+        <div
+          class="navbar-nav collapse navbar-collapse"
+        >
+          <div
+            class="navbar-nav collapse navbar-collapse"
+          >
+            <a
+              class="nav-item nav-link active"
+              href="/curriculum"
+            >
+              <span
+                class="sr-only"
+              >
+                (current)
+              </span>
+              Curriculum
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://github.com/garageScript/c0d3-app"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Repo
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://www.notion.so/Table-of-Contents-a83980f81560429faca3821a9af8a5e2"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Journey
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://chat.c0d3.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Help
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="/contributors"
+            >
+              Contributors
+            </a>
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-none"
+                type="button"
+              >
+                Admin
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="d-flex"
+      >
+        <a
+          class="btn btn-secondary border overflow-hidden p-2 text-truncate"
+          href="/profile/fakeusername"
+        >
+           fakeusername
+        </a>
+        <button
+          class="btn border ml-2"
+          style="color: rgb(41, 41, 41);"
+        >
+          Logout
+        </button>
+      </div>
+    </div>
+  </nav>
+  <div
+    class="container"
+  >
+    <div
+      class="row mt-4"
+    >
+      <div
+        class="col-4"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="ml-auto mr-auto mt-4 profile_image_container"
+          >
+            <div
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image"
+            >
+              fu
+            </div>
+          </div>
+          <h2
+            class="text-center mt-4"
+          >
+            fake user
+          </h2>
+          <h4
+            class="text-center text-muted mb-4"
+          >
+            @fake user
+          </h4>
+        </div>
+      </div>
+      <div
+        class="col-8"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="card-body"
+          >
+            <h3
+              class="profilelessons_title"
+            >
+              Lessons
+            </h3>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="card shadow-sm profile-submissions mt-3"
+        >
+          <div
+            class="card-body"
+          >
+            <h3>
+              Challenges
+            </h3>
+            <div
+              class="display_lessons"
+            >
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Foundations of JavaScript
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Variables & Functions
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Arrays
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Objects
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Front End Engineering
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 7  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    End To End
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 9  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    React, GraphQL, SocketIO
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 8  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    JavaScript Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Trees
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    General Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 5  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
+  <footer
+    class="mt-5 font-weight-light text-center pb-5 text-muted"
+  >
+    © Copyright 2020 GarageScript
+    <br />
+    All Rights Reserved
+  </footer>
 </div>
 `;
 

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -1,0 +1,3551 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`user profile test Should render anonymous users 1`] = `
+<div>
+  <nav
+    class="navbar navbar-expand-lg navbar-light justify-content-between bg-white"
+  >
+    <div
+      class="container"
+    >
+      <a
+        class="navbar-brand text-primary font-weight-bold"
+        href="/"
+      >
+        C0D3
+      </a>
+      <div
+        id="navbarNav"
+      >
+        <div
+          class="navbar-nav collapse navbar-collapse"
+        >
+          <div
+            class="navbar-nav collapse navbar-collapse"
+          >
+            <a
+              class="nav-item nav-link active"
+              href="/curriculum"
+            >
+              <span
+                class="sr-only"
+              >
+                (current)
+              </span>
+              Curriculum
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://github.com/garageScript/c0d3-app"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Repo
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://www.notion.so/Table-of-Contents-a83980f81560429faca3821a9af8a5e2"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Journey
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://chat.c0d3.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Help
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="/contributors"
+            >
+              Contributors
+            </a>
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-none"
+                type="button"
+              >
+                Admin
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="d-flex"
+      >
+        <a
+          class="btn btn-secondary border overflow-hidden p-2 text-truncate"
+          href="/profile/fakeusername"
+        >
+           fakeusername
+        </a>
+        <button
+          class="btn border ml-2"
+          style="color: rgb(41, 41, 41);"
+        >
+          Logout
+        </button>
+      </div>
+    </div>
+  </nav>
+  <div
+    class="container"
+  >
+    <div
+      class="row mt-4"
+    >
+      <div
+        class="col-4"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="ml-auto mr-auto mt-4 profile_image_container"
+          >
+            <div
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image"
+            >
+              A 
+            </div>
+          </div>
+          <h2
+            class="text-center mt-4"
+          >
+            A  
+          </h2>
+          <h4
+            class="text-center text-muted mb-4"
+          >
+            @fake user
+          </h4>
+        </div>
+      </div>
+      <div
+        class="col-8"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="card-body"
+          >
+            <h3
+              class="profilelessons_title"
+            >
+              Lessons
+            </h3>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="card shadow-sm profile-submissions mt-3"
+        >
+          <div
+            class="card-body"
+          >
+            <h3>
+              Challenges
+            </h3>
+            <div
+              class="display_lessons"
+            >
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Foundations of JavaScript
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Variables & Functions
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Arrays
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Objects
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Front End Engineering
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 7  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    End To End
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 9  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    React, GraphQL, SocketIO
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 8  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    JavaScript Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Trees
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    General Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 5  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer
+    class="mt-5 font-weight-light text-center pb-5 text-muted"
+  >
+    © Copyright 2020 GarageScript
+    <br />
+    All Rights Reserved
+  </footer>
+</div>
+`;
+
+exports[`user profile test Should render loading spinner if data is not ready 1`] = `
+<div>
+  <div
+    class="container-fluid bg-primary d-flex flex-column justify-content-center align-items-center"
+    style="min-height: 100vh; position: fixed; top: 0px; left: 0px; z-index: 1;"
+  >
+    <h1
+      class="text-white font-weight-bold display-3"
+      style="font-family: 'PT Mono', sans-serif;"
+    >
+      C0D3
+    </h1>
+    <div
+      class="spinner-border text-white"
+      role="status"
+    >
+      <h1
+        class="sr-only"
+      >
+        Loading...
+      </h1>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`user profile test Should render nulled lessons 1`] = `
+<div>
+  <nav
+    class="navbar navbar-expand-lg navbar-light justify-content-between bg-white"
+  >
+    <div
+      class="container"
+    >
+      <a
+        class="navbar-brand text-primary font-weight-bold"
+        href="/"
+      >
+        C0D3
+      </a>
+      <div
+        id="navbarNav"
+      >
+        <div
+          class="navbar-nav collapse navbar-collapse"
+        >
+          <div
+            class="navbar-nav collapse navbar-collapse"
+          >
+            <a
+              class="nav-item nav-link active"
+              href="/curriculum"
+            >
+              <span
+                class="sr-only"
+              >
+                (current)
+              </span>
+              Curriculum
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://github.com/garageScript/c0d3-app"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Repo
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://www.notion.so/Table-of-Contents-a83980f81560429faca3821a9af8a5e2"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Journey
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://chat.c0d3.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Help
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="/contributors"
+            >
+              Contributors
+            </a>
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-none"
+                type="button"
+              >
+                Admin
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="d-flex"
+      >
+        <a
+          class="btn btn-secondary border overflow-hidden p-2 text-truncate"
+          href="/profile/fakeusername"
+        >
+           fakeusername
+        </a>
+        <button
+          class="btn border ml-2"
+          style="color: rgb(41, 41, 41);"
+        >
+          Logout
+        </button>
+      </div>
+    </div>
+  </nav>
+  <div
+    class="container"
+  >
+    <div
+      class="row mt-4"
+    >
+      <div
+        class="col-4"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="ml-auto mr-auto mt-4 profile_image_container"
+          >
+            <div
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image"
+            >
+              fu
+            </div>
+          </div>
+          <h2
+            class="text-center mt-4"
+          >
+            fake user
+          </h2>
+          <h4
+            class="text-center text-muted mb-4"
+          >
+            @fake user
+          </h4>
+        </div>
+      </div>
+      <div
+        class="col-8"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="card-body"
+          >
+            <h3
+              class="profilelessons_title"
+            >
+              Lessons
+            </h3>
+            <div
+              class="lessonimage_container"
+            >
+              <p
+                class="lessonimage_progressbadge badge badge-pill badge-primary"
+              >
+                NaN%
+              </p>
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_container"
+            >
+              <p
+                class="lessonimage_progressbadge badge badge-pill badge-primary"
+              >
+                NaN%
+              </p>
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_container"
+            >
+              <p
+                class="lessonimage_progressbadge badge badge-pill badge-primary"
+              >
+                NaN%
+              </p>
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="card shadow-sm profile-submissions mt-3"
+        >
+          <div
+            class="card-body"
+          >
+            <h3>
+              Challenges
+            </h3>
+            <div
+              class="display_lessons"
+            >
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  />
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 0  Challenges completed
+                  </h6>
+                  <div />
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  />
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 0  Challenges completed
+                  </h6>
+                  <div />
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  />
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 0  Challenges completed
+                  </h6>
+                  <div />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer
+    class="mt-5 font-weight-light text-center pb-5 text-muted"
+  >
+    © Copyright 2020 GarageScript
+    <br />
+    All Rights Reserved
+  </footer>
+</div>
+`;
+
+exports[`user profile test Should render nulled submission lessonIds 1`] = `
+<div>
+  <nav
+    class="navbar navbar-expand-lg navbar-light justify-content-between bg-white"
+  >
+    <div
+      class="container"
+    >
+      <a
+        class="navbar-brand text-primary font-weight-bold"
+        href="/"
+      >
+        C0D3
+      </a>
+      <div
+        id="navbarNav"
+      >
+        <div
+          class="navbar-nav collapse navbar-collapse"
+        >
+          <div
+            class="navbar-nav collapse navbar-collapse"
+          >
+            <a
+              class="nav-item nav-link active"
+              href="/curriculum"
+            >
+              <span
+                class="sr-only"
+              >
+                (current)
+              </span>
+              Curriculum
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://github.com/garageScript/c0d3-app"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Repo
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://www.notion.so/Table-of-Contents-a83980f81560429faca3821a9af8a5e2"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Journey
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://chat.c0d3.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Help
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="/contributors"
+            >
+              Contributors
+            </a>
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-none"
+                type="button"
+              >
+                Admin
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="d-flex"
+      >
+        <a
+          class="btn btn-secondary border overflow-hidden p-2 text-truncate"
+          href="/profile/fakeusername"
+        >
+           fakeusername
+        </a>
+        <button
+          class="btn border ml-2"
+          style="color: rgb(41, 41, 41);"
+        >
+          Logout
+        </button>
+      </div>
+    </div>
+  </nav>
+  <div
+    class="container"
+  >
+    <div
+      class="row mt-4"
+    >
+      <div
+        class="col-4"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="ml-auto mr-auto mt-4 profile_image_container"
+          >
+            <div
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image"
+            >
+              fu
+            </div>
+          </div>
+          <h2
+            class="text-center mt-4"
+          >
+            fake user
+          </h2>
+          <h4
+            class="text-center text-muted mb-4"
+          >
+            @fake user
+          </h4>
+        </div>
+      </div>
+      <div
+        class="col-8"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="card-body"
+          >
+            <h3
+              class="profilelessons_title"
+            >
+              Lessons
+            </h3>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="card shadow-sm profile-submissions mt-3"
+        >
+          <div
+            class="card-body"
+          >
+            <h3>
+              Challenges
+            </h3>
+            <div
+              class="display_lessons"
+            >
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Foundations of JavaScript
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Variables & Functions
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    1 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-success"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Arrays
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Objects
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Front End Engineering
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 7  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    End To End
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 9  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    React, GraphQL, SocketIO
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 8  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    JavaScript Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Trees
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    General Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 5  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer
+    class="mt-5 font-weight-light text-center pb-5 text-muted"
+  >
+    © Copyright 2020 GarageScript
+    <br />
+    All Rights Reserved
+  </footer>
+</div>
+`;
+
+exports[`user profile test Should render nulles challenges 1`] = `
+<div>
+  <nav
+    class="navbar navbar-expand-lg navbar-light justify-content-between bg-white"
+  >
+    <div
+      class="container"
+    >
+      <a
+        class="navbar-brand text-primary font-weight-bold"
+        href="/"
+      >
+        C0D3
+      </a>
+      <div
+        id="navbarNav"
+      >
+        <div
+          class="navbar-nav collapse navbar-collapse"
+        >
+          <div
+            class="navbar-nav collapse navbar-collapse"
+          >
+            <a
+              class="nav-item nav-link active"
+              href="/curriculum"
+            >
+              <span
+                class="sr-only"
+              >
+                (current)
+              </span>
+              Curriculum
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://github.com/garageScript/c0d3-app"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Repo
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://www.notion.so/Table-of-Contents-a83980f81560429faca3821a9af8a5e2"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Journey
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://chat.c0d3.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Help
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="/contributors"
+            >
+              Contributors
+            </a>
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-none"
+                type="button"
+              >
+                Admin
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="d-flex"
+      >
+        <a
+          class="btn btn-secondary border overflow-hidden p-2 text-truncate"
+          href="/profile/fakeusername"
+        >
+           fakeusername
+        </a>
+        <button
+          class="btn border ml-2"
+          style="color: rgb(41, 41, 41);"
+        >
+          Logout
+        </button>
+      </div>
+    </div>
+  </nav>
+  <div
+    class="container"
+  >
+    <div
+      class="row mt-4"
+    >
+      <div
+        class="col-4"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="ml-auto mr-auto mt-4 profile_image_container"
+          >
+            <div
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image"
+            >
+              fu
+            </div>
+          </div>
+          <h2
+            class="text-center mt-4"
+          >
+            fake user
+          </h2>
+          <h4
+            class="text-center text-muted mb-4"
+          >
+            @fake user
+          </h4>
+        </div>
+      </div>
+      <div
+        class="col-8"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="card-body"
+          >
+            <h3
+              class="profilelessons_title"
+            >
+              Lessons
+            </h3>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="card shadow-sm profile-submissions mt-3"
+        >
+          <div
+            class="card-body"
+          >
+            <h3>
+              Challenges
+            </h3>
+            <div
+              class="display_lessons"
+            >
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Foundations of JavaScript
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Variables & Functions
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Arrays
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Objects
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Front End Engineering
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 7  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    End To End
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 9  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    React, GraphQL, SocketIO
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 8  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    JavaScript Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Trees
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    General Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 5  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  />
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 3  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer
+    class="mt-5 font-weight-light text-center pb-5 text-muted"
+  >
+    © Copyright 2020 GarageScript
+    <br />
+    All Rights Reserved
+  </footer>
+</div>
+`;
+
+exports[`user profile test Should render profile 1`] = `
+<div>
+  <nav
+    class="navbar navbar-expand-lg navbar-light justify-content-between bg-white"
+  >
+    <div
+      class="container"
+    >
+      <a
+        class="navbar-brand text-primary font-weight-bold"
+        href="/"
+      >
+        C0D3
+      </a>
+      <div
+        id="navbarNav"
+      >
+        <div
+          class="navbar-nav collapse navbar-collapse"
+        >
+          <div
+            class="navbar-nav collapse navbar-collapse"
+          >
+            <a
+              class="nav-item nav-link active"
+              href="/curriculum"
+            >
+              <span
+                class="sr-only"
+              >
+                (current)
+              </span>
+              Curriculum
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://github.com/garageScript/c0d3-app"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Repo
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://www.notion.so/Table-of-Contents-a83980f81560429faca3821a9af8a5e2"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Journey
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="https://chat.c0d3.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Help
+            </a>
+            <a
+              class="nav-item nav-link"
+              href="/contributors"
+            >
+              Contributors
+            </a>
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-none"
+                type="button"
+              >
+                Admin
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="d-flex"
+      >
+        <a
+          class="btn btn-secondary border overflow-hidden p-2 text-truncate"
+          href="/profile/fakeusername"
+        >
+           fakeusername
+        </a>
+        <button
+          class="btn border ml-2"
+          style="color: rgb(41, 41, 41);"
+        >
+          Logout
+        </button>
+      </div>
+    </div>
+  </nav>
+  <div
+    class="container"
+  >
+    <div
+      class="row mt-4"
+    >
+      <div
+        class="col-4"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="ml-auto mr-auto mt-4 profile_image_container"
+          >
+            <div
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image"
+            >
+              fu
+            </div>
+          </div>
+          <h2
+            class="text-center mt-4"
+          >
+            fake user
+          </h2>
+          <h4
+            class="text-center text-muted mb-4"
+          >
+            @fake user
+          </h4>
+        </div>
+      </div>
+      <div
+        class="col-8"
+      >
+        <div
+          class="card shadow-sm"
+        >
+          <div
+            class="card-body"
+          >
+            <h3
+              class="profilelessons_title"
+            >
+              Lessons
+            </h3>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_container"
+            >
+              <p
+                class="lessonimage_progressbadge badge badge-pill badge-primary"
+              >
+                16%
+              </p>
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+              />
+            </div>
+            <div
+              class="lessonimage_opacity_container"
+            >
+              <img
+                src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="card shadow-sm profile-submissions mt-3"
+        >
+          <div
+            class="card-body"
+          >
+            <h3>
+              Challenges
+            </h3>
+            <div
+              class="display_lessons"
+            >
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-0-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Foundations of JavaScript
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-1-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Variables & Functions
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    2 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-success"
+                    />
+                    <span
+                      class="challenge_status bg-success"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-2-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Arrays
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-3-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Objects
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 10  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-4-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Front End Engineering
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 7  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-5-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    End To End
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 9  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-6-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    React, GraphQL, SocketIO
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 8  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-7-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    JavaScript Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 11  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-8-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    Trees
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 12  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="lesson_challenges"
+              >
+                <div
+                  class="lesson_image_container"
+                >
+                  <img
+                    src="/curriculumAssets/lessonCoversSvg/js-9-cover.svg"
+                  />
+                </div>
+                <div
+                  class="lesson_title_container"
+                >
+                  <h6
+                    class="lesson_title"
+                  >
+                    General Algorithms
+                  </h6>
+                  <h6
+                    class="challenges_stats"
+                  >
+                    0 of 5  Challenges completed
+                  </h6>
+                  <div>
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                    <span
+                      class="challenge_status bg-gray"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer
+    class="mt-5 font-weight-light text-center pb-5 text-muted"
+  >
+    © Copyright 2020 GarageScript
+    <br />
+    All Rights Reserved
+  </footer>
+</div>
+`;

--- a/__tests__/pages/profile/username.test.js
+++ b/__tests__/pages/profile/username.test.js
@@ -54,8 +54,9 @@ describe('user profile test', () => {
         }
       }
     )
-    const { container, findByRole } = render(tree)
+    const { container, findByRole, queryByText } = render(tree)
     await findByRole('heading', { name: /loading/i })
+    await waitForElementToBeRemoved(() => queryByText('Loading...'))
     expect(container).toMatchSnapshot()
   })
   test('Should render profile', async () => {

--- a/__tests__/pages/profile/username.test.js
+++ b/__tests__/pages/profile/username.test.js
@@ -1,0 +1,397 @@
+import React from 'react'
+import { render, waitForElementToBeRemoved } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import GET_APP from '../../../graphql/queries/getApp'
+import USER_INFO from '../../../graphql/queries/userInfo'
+import UserProfile from '../../../pages/profile/[username]'
+import { MockedProvider } from '@apollo/client/testing'
+import dummyLessonData from '../../../__dummy__/lessonData'
+import dummySessionData from '../../../__dummy__/sessionData'
+import { useRouter } from 'next/router'
+import { withTestRouter } from '../../../testUtil/withNextRouter'
+jest.mock('next/router')
+
+useRouter.mockImplementation(() => ({
+  query: {
+    username: 'fake user'
+  },
+  push: jest.fn()
+}))
+describe('user profile test', () => {
+  test('Should render loading spinner if data is not ready', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session: dummySessionData,
+            lessons: dummyLessonData,
+            alerts: []
+          }
+        }
+      },
+      {
+        request: {
+          query: USER_INFO,
+          variables: {
+            username: 'fake user'
+          }
+        },
+        result: {
+          data: {
+            userInfo: dummySessionData
+          }
+        }
+      }
+    ]
+    const tree = withTestRouter(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserProfile />
+      </MockedProvider>,
+      {
+        query: {
+          username: 'fake user'
+        }
+      }
+    )
+    const { container, findByRole } = render(tree)
+    await findByRole('heading', { name: /loading/i })
+    expect(container).toMatchSnapshot()
+  })
+  test('Should render profile', async () => {
+    const session = {
+      ...dummySessionData,
+      submissions: [
+        {
+          id: '1',
+          status: 'passed',
+          mrUrl: '',
+          diff: '',
+          viewCount: 0,
+          comment: '',
+          order: 0,
+          challengeId: '146',
+          lessonId: '2',
+          reviewer: {
+            id: '1',
+            username: 'fake reviewer'
+          },
+          createdAt: '123',
+          updatedAt: '123'
+        },
+        {
+          id: '2',
+          status: 'passed',
+          mrUrl: '',
+          diff: '',
+          viewCount: 0,
+          comment: '',
+          order: 0,
+          challengeId: '145',
+          lessonId: '2',
+          reviewer: {
+            id: '1',
+            username: 'fake reviewer'
+          },
+          createdAt: '123',
+          updatedAt: '123'
+        }
+      ],
+      lessonStatus: [
+        {
+          lessonId: '5',
+          isPassed: true,
+          isTeaching: true,
+          isEnrolled: false,
+          starGiven: null,
+          starsReceived: null
+        },
+        {
+          lessonId: '2',
+          isPassed: true,
+          isTeaching: true,
+          isEnrolled: false,
+          starGiven: null,
+          starsReceived: null
+        },
+        {
+          lessonId: '1',
+          isPassed: true,
+          isTeaching: true,
+          isEnrolled: false,
+          starGiven: null,
+          starsReceived: null
+        }
+      ]
+    }
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session,
+            lessons: dummyLessonData,
+            alerts: []
+          }
+        }
+      },
+      {
+        request: {
+          query: USER_INFO,
+          variables: {
+            username: 'fake user'
+          }
+        },
+        result: {
+          data: {
+            userInfo: session
+          }
+        }
+      }
+    ]
+    const tree = withTestRouter(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserProfile />
+      </MockedProvider>,
+      {
+        query: {
+          username: 'fake user'
+        }
+      }
+    )
+    const { container, findByRole, queryByText } = render(tree)
+    await waitForElementToBeRemoved(() => queryByText('Loading...'))
+    await findByRole('heading', { name: /@fake user/i })
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Should return error on error', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        error: new Error('error')
+      }
+    ]
+
+    const { findByRole } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserProfile />
+      </MockedProvider>
+    )
+
+    const element = await findByRole('heading', { name: /error/i })
+    expect(element).toBeTruthy()
+  })
+  test('Should render anonymous users', async () => {
+    const anonymous = {
+      ...dummySessionData,
+      user: {
+        id: 1,
+        username: 'fakeusername',
+        name: '',
+        isAdmin: 'true'
+      }
+    }
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session: dummySessionData,
+            lessons: dummyLessonData,
+            alerts: []
+          }
+        }
+      },
+      {
+        request: {
+          query: USER_INFO,
+          variables: {
+            username: 'fake user'
+          }
+        },
+        result: {
+          data: {
+            userInfo: anonymous
+          }
+        }
+      }
+    ]
+    const tree = withTestRouter(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserProfile />
+      </MockedProvider>,
+      {
+        query: {
+          username: 'fake user'
+        }
+      }
+    )
+    const { container, findByRole, queryByText } = render(tree)
+    await waitForElementToBeRemoved(() => queryByText('Loading...'))
+    await findByRole('heading', { name: /@fake user/i })
+    expect(container).toMatchSnapshot()
+  })
+  test('Should render nulled lessons', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session: dummySessionData,
+            lessons: [null, null, null],
+            alerts: []
+          }
+        }
+      },
+      {
+        request: {
+          query: USER_INFO,
+          variables: {
+            username: 'fake user'
+          }
+        },
+        result: {
+          data: {
+            userInfo: dummySessionData
+          }
+        }
+      }
+    ]
+    const tree = withTestRouter(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserProfile />
+      </MockedProvider>,
+      {
+        query: {
+          username: 'newbie'
+        }
+      }
+    )
+    const { container, findByRole, queryByText } = render(tree)
+    await waitForElementToBeRemoved(() => queryByText('Loading...'))
+    await findByRole('heading', { name: /@fake user/i })
+    expect(container).toMatchSnapshot()
+  })
+  test('Should render nulles challenges', async () => {
+    const lessons = [
+      ...dummyLessonData,
+      {
+        id: '2',
+        title: null,
+        description: 'A super simple introduction to help you get started!',
+        docUrl:
+          'https://www.notion.so/garagescript/JS-0-Foundations-a43ca620e54945b2b620bcda5f3cf672',
+        githubUrl: '',
+        videoUrl:
+          'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
+        order: null,
+        challenges: [null, null, null],
+        chatUrl: 'https://chat.c0d3.com/c0d3/channels/js1-variablesfunction'
+      }
+    ]
+
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session: dummySessionData,
+            lessons: lessons,
+            alerts: []
+          }
+        }
+      },
+      {
+        request: {
+          query: USER_INFO,
+          variables: {
+            username: 'fake user'
+          }
+        },
+        result: {
+          data: {
+            userInfo: dummySessionData
+          }
+        }
+      }
+    ]
+    const tree = withTestRouter(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserProfile />
+      </MockedProvider>,
+      {
+        query: {
+          username: 'fake user'
+        }
+      }
+    )
+    const { container, findByRole, queryByText } = render(tree)
+    await waitForElementToBeRemoved(() => queryByText('Loading...'))
+    await findByRole('heading', { name: /@fake user/i })
+    expect(container).toMatchSnapshot()
+  })
+  test('Should render nulled submission lessonIds', async () => {
+    const session = {
+      ...dummySessionData,
+      submissions: [
+        {
+          id: 1,
+          status: 'passed',
+          mrUrl: '',
+          diff: '',
+          viewCount: 0,
+          comment: '',
+          order: 0,
+          challengeId: '146',
+          lessonId: null,
+          reviewer: {
+            id: '1',
+            username: 'fake reviewer'
+          },
+          createdAt: '123',
+          updatedAt: '123'
+        }
+      ]
+    }
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session: dummySessionData,
+            lessons: dummyLessonData,
+            alerts: []
+          }
+        }
+      },
+      {
+        request: {
+          query: USER_INFO,
+          variables: {
+            username: 'fake user'
+          }
+        },
+        result: {
+          data: {
+            userInfo: session
+          }
+        }
+      }
+    ]
+    const tree = withTestRouter(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <UserProfile />
+      </MockedProvider>,
+      {
+        query: {
+          username: 'newbie'
+        }
+      }
+    )
+    const { container, findByRole, queryByText } = render(tree)
+    await waitForElementToBeRemoved(() => queryByText('Loading...'))
+    await findByRole('heading', { name: /@fake user/i })
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@storybook/addon-storysource": "^6",
     "@storybook/addon-viewport": "^6",
     "@storybook/react": "^6",
+    "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11",
     "@testing-library/user-event": "^12",
     "@types/bcrypt": "^3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,6 +2787,20 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/jest-dom@^5.11.9":
+  version "5.11.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz#e6b3cd687021f89f261bd53cbe367041fbd3e975"
+  integrity sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react@^11":
   version "11.2.3"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.3.tgz#9971ede1c8465a231d7982eeca3c39fc362d5443"
@@ -3306,6 +3320,13 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/uglify-js@*":
   version "3.11.1"
@@ -6265,7 +6286,7 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
   integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
 
-css.escape@1.5.1:
+css.escape@1.5.1, css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
@@ -6279,6 +6300,15 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -13446,6 +13476,14 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
 refractor@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.3.0.tgz#42a7d58f14a1d1bcda52a8c66123601a71e5d47d"
@@ -14373,6 +14411,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"


### PR DESCRIPTION
Adds test for `profile/username`. Part of #409 and #433. 

There are many tests for null values. Should we tighten up graphql types someday? Almost everything is optional for no reason. 
Also, in [userlesson](https://github.com/garageScript/c0d3-app/blob/master/pages/profile/%5Busername%5D.tsx#L60) file there is a comment about fixing id types and this expression ` status === 'passed' && parseInt(lessonId || '') === parseInt(lesson.id + ''`. Do we still need to cast these types into Ints? 

