### PR TITLE
Fix Give Star feature

### DIFF
--- a/graphql/queryResolvers/getLessonMentors.test.js
+++ b/graphql/queryResolvers/getLessonMentors.test.js
@@ -3,6 +3,7 @@ jest.mock('../../helpers/validateLessonId')
 import { getLessonMentors } from './getLessonMentors'
 import { User, UserLesson } from '../../helpers/dbload'
 import { validateLessonId } from '../../helpers/validateLessonId'
+import { Op } from 'sequelize'
 describe('getLessonMentors resolver', () => {
   beforeEach(() => {
     validateLessonId.mockReturnValue(true)
@@ -49,5 +50,23 @@ describe('getLessonMentors resolver', () => {
     //rejects: checks for promise rejection
     //which would be the case if an error was thrown in a Promise
     await expect(getLessonMentors(null, { lessonId: '3' })).rejects.toThrow()
+  })
+
+  test('should include userId in the query if session exists', async () => {
+    UserLesson.findAll = jest
+      .fn()
+      .mockReturnValue([{ user: { username: 'user1', name: 'lol', id: 2 } }])
+    const res = await getLessonMentors(
+      null,
+      { lessonId: '3' },
+      { req: { user: { id: 1 } } }
+    )
+    expect(res).toEqual([{ username: 'user1', name: 'lol', id: 2 }])
+    expect(UserLesson.findAll).toHaveBeenCalledWith({
+      where: { lessonId: '3', userId: { [Op.ne]: 1 } },
+      include: [
+        { model: User, as: 'user', attributes: ['username', 'name', 'id'] }
+      ]
+    })
   })
 })

--- a/graphql/queryResolvers/getLessonMentors.test.js
+++ b/graphql/queryResolvers/getLessonMentors.test.js
@@ -10,11 +10,10 @@ describe('getLessonMentors resolver', () => {
 
   test('should return an array of User objects', async () => {
     UserLesson.findAll = jest.fn().mockReturnValue([
-      { User: { username: 'user1', email: 'abc@mail', name: 'lol', id: 2 } },
+      { user: { username: 'user1', name: 'lol', id: 2 } },
       {
-        User: {
+        user: {
           username: 'user2',
-          email: 'xyz@mail',
           name: 'potato',
           id: 240
         }
@@ -27,7 +26,9 @@ describe('getLessonMentors resolver', () => {
     ])
     expect(UserLesson.findAll).toHaveBeenCalledWith({
       where: { lessonId: '3' },
-      include: [{ model: User }]
+      include: [
+        { model: User, as: 'user', attributes: ['username', 'name', 'id'] }
+      ]
     })
   })
 

--- a/graphql/queryResolvers/getLessonMentors.ts
+++ b/graphql/queryResolvers/getLessonMentors.ts
@@ -1,5 +1,8 @@
 import { User, UserLesson } from '../../helpers/dbload'
 import { validateLessonId } from '../../helpers/validateLessonId'
+import { Op } from 'sequelize'
+import { Context } from '../../@types/helpers'
+import _ from 'lodash'
 
 type ArgsGetLessonMentors = {
   lessonId: string
@@ -7,14 +10,17 @@ type ArgsGetLessonMentors = {
 
 export const getLessonMentors = async (
   _parent: void,
-  args: ArgsGetLessonMentors
+  args: ArgsGetLessonMentors,
+  context: Context
 ): Promise<User[]> => {
   const { lessonId } = args
+  const userId: number | undefined = _.get(context, 'req.user.id', undefined)
   try {
     await validateLessonId(parseInt(lessonId))
     const results: [UserLesson & { user: User }] = await UserLesson.findAll({
       where: {
-        lessonId
+        lessonId,
+        ...(userId && { userId: { [Op.ne]: userId } })
       },
       include: [
         { model: User, as: 'user', attributes: ['username', 'name', 'id'] }

--- a/graphql/queryResolvers/getLessonMentors.ts
+++ b/graphql/queryResolvers/getLessonMentors.ts
@@ -8,18 +8,19 @@ type ArgsGetLessonMentors = {
 export const getLessonMentors = async (
   _parent: void,
   args: ArgsGetLessonMentors
-): Promise<[User]> => {
+): Promise<User[]> => {
   const { lessonId } = args
   try {
     await validateLessonId(parseInt(lessonId))
-    const results = await UserLesson.findAll({
-      where: { lessonId },
-      include: [{ model: User }]
+    const results: [UserLesson & { user: User }] = await UserLesson.findAll({
+      where: {
+        lessonId
+      },
+      include: [
+        { model: User, as: 'user', attributes: ['username', 'name', 'id'] }
+      ]
     })
-
-    return results.map(({ User: { username, name, id } }: { User: User }) => {
-      return { username, name, id }
-    })
+    return results.map(({ user }) => user)
   } catch (err) {
     throw new Error(err)
   }

--- a/helpers/dbload.ts
+++ b/helpers/dbload.ts
@@ -96,7 +96,8 @@ User.hasMany(UserLesson, {
 })
 
 UserLesson.belongsTo(User, {
-  foreignKey: 'userId'
+  foreignKey: 'userId',
+  as: 'user'
 })
 
 sequelize.sync({ alter: !!process.env.ALTER_DB })


### PR DESCRIPTION
Closes #492

The issue with the linked issue was that the webpack build step replaces the model names in the transpiled script file. Examining the built file, the `User` model was renamed into `User_User` for some reason I'm not aware of. So this resulted in the entity from the sequelize query having a property `User_User` instead of `User`, to get the user entity from the table join.

To solve this, I added an alias to the sequelize association, so the user instance is always called `user`.

What this PR does:

- Adds an alias for the `User` model in the `UserLesson -> belongs to -> User` sequelize association.
- Changes the sequelize query to include the alias and only the required attributes (username, name and id) for the user.
- Fixes the tests that broke because of this.
- Filters out the current user so you don't see your own name in the list.