### PR TITLE
closes #494 - Fix setStar resolver so people can't give themselves a star

### DIFF
--- a/helpers/controllers/starsController.test.js
+++ b/helpers/controllers/starsController.test.js
@@ -28,7 +28,7 @@ describe('setStar resolver', () => {
   test('should throw error if studentId and mentorId is the same', async () => {
     await expect(
       setStar(null, { lessonId: 52226, mentorId: 1337 }, ctx)
-    ).rejects.toThrowError('Unable to give error to yourself')
+    ).rejects.toThrowError('Unable to give star to yourself')
     expect(Star.create).toHaveBeenCalledTimes(0)
     expect(ctx.req.error).toHaveBeenCalledTimes(1)
   })

--- a/helpers/controllers/starsController.test.js
+++ b/helpers/controllers/starsController.test.js
@@ -25,6 +25,14 @@ describe('setStar resolver', () => {
     Star.create = jest.fn().mockReturnValue({ success: true })
   })
 
+  test('should throw error if studentId and mentorId is the same', async () => {
+    await expect(
+      setStar(null, { lessonId: 52226, mentorId: 1337 }, ctx)
+    ).rejects.toThrowError('Unable to give error to yourself')
+    expect(Star.create).toHaveBeenCalledTimes(0)
+    expect(ctx.req.error).toHaveBeenCalledTimes(1)
+  })
+
   test('should return success object if no errors are thrown, and Star.create is called', async () => {
     const res = await setStar(null, { lessonId: 52226, mentorId: 815 }, ctx)
     expect(Star.create).toHaveBeenCalledTimes(1)

--- a/helpers/controllers/starsController.ts
+++ b/helpers/controllers/starsController.ts
@@ -19,7 +19,7 @@ export const setStar = async (
     const { lessonId, mentorId } = arg
 
     if (studentId === mentorId) {
-      throw new Error('Unable to give error to yourself')
+      throw new Error('Unable to give star to yourself')
     }
     await validateLessonId(lessonId)
 

--- a/helpers/controllers/starsController.ts
+++ b/helpers/controllers/starsController.ts
@@ -17,6 +17,10 @@ export const setStar = async (
   try {
     const studentId = validateStudentId(req)
     const { lessonId, mentorId } = arg
+
+    if (studentId === mentorId) {
+      throw new Error('Unable to give error to yourself')
+    }
     await validateLessonId(lessonId)
 
     const lookupData = { where: { studentId, lessonId } }


### PR DESCRIPTION
closes #494 

Right now, people can give themselves a star, because the `setStar` resolver does not check for that edge case. 

## This PR will:
* Throw and error if someone tries to give themself a star, by checking if `studentId === mentorId`
* Update test file to reflect change in setStar resolver