### PR TITLE
fix admin/lessons page

### DIFF
--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -152,7 +152,7 @@ export const AdminLessonInfo: React.FC<LessonInfoProps> = ({
   selectedLesson
 }) => {
   // true when user clicks on `create new lesson` button
-  if (lessons && selectedLesson === lessons.length - 1) {
+  if (lessons && selectedLesson === lessons.length) {
     return <NewLesson setLessons={setLessons} />
   }
 

--- a/components/admin/lessons/AdminLessonsSideBar.tsx
+++ b/components/admin/lessons/AdminLessonsSideBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import _ from 'lodash'
 import { Lesson } from '../../../graphql/index'
 
 type SideBarLessonProps = {
@@ -13,14 +14,17 @@ export const AdminLessonsSideBar: React.FC<SideBarLessonProps> = ({
   setSelectedLesson,
   selectedLesson
 }) => {
-  const lessonListData = lessons || []
-
+  const lessonListData = _.cloneDeep(lessons) || []
+  if (lessonListData.length === 0) {
+    lessonListData.push({ title: 'Create New Lesson' })
+  }
   //check if create new lesson has already been pushed to the lessons array
   const lastIndex = lessonListData.length - 1
   const { title } = lessonListData[lastIndex]
   if (title !== 'Create New Lesson') {
     lessonListData.push({ title: 'Create New Lesson' })
   }
+
   const lessonList = lessonListData.map((obj: any, arrIndex: number) => (
     <a
       key={arrIndex}

--- a/helpers/admin/adminHelpers.ts
+++ b/helpers/admin/adminHelpers.ts
@@ -1,4 +1,5 @@
 import { reach } from 'yup'
+import _ from 'lodash'
 import { DROP_DOWN, TEXT_AREA, MD_INPUT } from '../../components/FormCard'
 
 // creates usuable array from graphql data to use as a prop when using FormCard component
@@ -7,8 +8,9 @@ export const getPropertyArr = (
   deleteProps?: string[],
   dropdownChange?: Function
 ) => {
-  ;(deleteProps || []).forEach(prop => delete options[prop])
-  const keys = Object.keys(options)
+  const cloneOptions = _.cloneDeep(options)
+  ;(deleteProps || []).forEach(prop => delete cloneOptions[prop])
+  const keys = Object.keys(cloneOptions)
 
   const res = keys.map((type: any, index: number) => {
     const optionValue = options[type]

--- a/pages/admin/lessons.tsx
+++ b/pages/admin/lessons.tsx
@@ -4,18 +4,11 @@ import { AdminLessonsSideBar } from '../../components/admin/lessons/AdminLessons
 import { withGetApp, GetAppProps } from '../../graphql'
 import { Lesson } from '../../graphql/index'
 import { AdminLayout } from '../../components/admin/AdminLayout'
-import Error, { StatusCode } from '../../components/Error'
-import LoadingSpinner from '../../components/LoadingSpinner'
+
 const Lessons: React.FC<GetAppProps> = ({ data }) => {
-  const { loading, error, lessons } = data
-  if (loading) return <LoadingSpinner />
-  if (error) {
-    return (
-      <Error code={StatusCode.INTERNAL_SERVER_ERROR} message={error.message} />
-    )
-  }
   const [selectedLesson, setSelectedLesson] = useState(0)
   const [lessonsList, setLessons] = useState<null | Lesson[]>(null)
+  const { lessons } = data
   return (
     <AdminLayout data={data}>
       <div className="row mt-4">

--- a/pages/admin/lessons.tsx
+++ b/pages/admin/lessons.tsx
@@ -4,11 +4,18 @@ import { AdminLessonsSideBar } from '../../components/admin/lessons/AdminLessons
 import { withGetApp, GetAppProps } from '../../graphql'
 import { Lesson } from '../../graphql/index'
 import { AdminLayout } from '../../components/admin/AdminLayout'
-
+import Error, { StatusCode } from '../../components/Error'
+import LoadingSpinner from '../../components/LoadingSpinner'
 const Lessons: React.FC<GetAppProps> = ({ data }) => {
+  const { loading, error, lessons } = data
+  if (loading) return <LoadingSpinner />
+  if (error) {
+    return (
+      <Error code={StatusCode.INTERNAL_SERVER_ERROR} message={error.message} />
+    )
+  }
   const [selectedLesson, setSelectedLesson] = useState(0)
   const [lessonsList, setLessons] = useState<null | Lesson[]>(null)
-  const { lessons } = data
   return (
     <AdminLayout data={data}>
       <div className="row mt-4">


### PR DESCRIPTION
This is part of #409. As it is production works fine but development build fails because of runtime typescript type errors (trying to change useState value directly instead of creating a copy). I guess typescript or hooks were added later and since there were no tests nobody noticed. Production also won't be able to render empty lessons. 
Without fixing this first I won't be able to submit tests (they will fail, first from of type errors, second from incorrect index errors). 