### PR TITLE
add AdminLessonChallenges test

### DIFF
--- a/components/admin/lessons/AdminLessonChallenges.test.js
+++ b/components/admin/lessons/AdminLessonChallenges.test.js
@@ -1,0 +1,238 @@
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as Sentry from '@sentry/browser'
+import { MockedProvider } from '@apollo/client/testing'
+import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
+import dummyLessonData from '../../../__dummy__/lessonData'
+import updateChallenge from '../../../graphql/queries/updateChallenge'
+import createNewChallenge from '../../../graphql/queries/createChallenge'
+jest.spyOn(Sentry, 'captureException').mockImplementation(() => {})
+const challenges = [
+  {
+    id: '107',
+    title: 'Sum of 2 Numbers',
+    description:
+      "Write a function that takes in 2 numbers and returns their sum.\n\nHere's how another developer might use your function:\n\n```\nsolution(5,9) // Should return 14\nsolution(4,1) // Should return 5\n```",
+    order: 1
+  },
+  {
+    id: '108',
+    title: 'Sum of 3 Numbers',
+    description:
+      "Write a function that takes in 3 numbers and returns their sum.\n\nHere's how another developer might use your function:\n\n```\nsolution(5,9,2) // Should return 16\nsolution(4,1,9) // Should return 14\n```",
+    order: 2
+  }
+]
+const updateChallengeMock = {
+  request: {
+    query: updateChallenge,
+    variables: {
+      id: 107,
+      title: 'New title',
+      description: 'New description',
+      order: 15,
+      lessonId: 0
+    }
+  },
+  result: {
+    data: { updateChallenge: dummyLessonData[0] }
+  }
+}
+const createNewChallengeMock = {
+  request: {
+    query: createNewChallenge,
+    variables: {
+      title: 'New challenge',
+      description: 'New challenge description',
+      order: 2,
+      lessonId: 0
+    }
+  },
+  result: {
+    data: { createChallenge: dummyLessonData[0] }
+  }
+}
+
+const mocks = [updateChallengeMock, createNewChallengeMock]
+
+describe('AdminLessonChallenges component', () => {
+  delete window.location
+  const reload = jest.fn()
+  window.location = { reload }
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  test('Should update challenge', async () => {
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <AdminLessonChallenges
+          challenges={challenges}
+          lessonId={0}
+          setLessons={() => true}
+        />
+      </MockedProvider>
+    )
+    expect(container).toMatchSnapshot()
+    const titles = screen.getAllByTestId('input1')
+    const descriptions = screen.getAllByTestId('textbox')
+    const orders = screen.getAllByTestId('input3')
+    userEvent.clear(titles[0])
+    userEvent.clear(descriptions[0])
+    userEvent.clear(orders[0])
+    await userEvent.type(titles[0], 'New title', { delay: 1 })
+    await userEvent.type(descriptions[0], 'New description', { delay: 1 })
+    await userEvent.type(orders[0], '15', { delay: 1 })
+    await waitFor(() =>
+      userEvent.click(screen.getAllByText('Update Challenge')[0])
+    )
+    await waitFor(() => expect(reload).toBeCalled())
+    await waitFor(() => expect(container).toMatchSnapshot())
+  })
+  test('Should create challenge', async () => {
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NewChallenge
+          challenges={challenges}
+          lessonId={0}
+          setLessons={() => true}
+        />
+      </MockedProvider>
+    )
+    const title = screen.getByTestId('input0')
+    const description = screen.getByTestId('textbox')
+    const order = screen.getByTestId('input2')
+    await userEvent.type(title, 'New challenge', { delay: 1 })
+    await userEvent.type(description, 'New challenge description', { delay: 1 })
+    await userEvent.type(order, '2', { delay: 1 })
+    await waitFor(() => userEvent.click(screen.getByText('Create Challenge')))
+    await waitFor(() => expect(reload).toBeCalledTimes(1))
+    await waitFor(() => expect(container).toMatchSnapshot())
+  })
+  test('Should refuse updating challenge with incorrect info', async () => {
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <AdminLessonChallenges
+          challenges={challenges}
+          lessonId={0}
+          setLessons={() => true}
+        />
+      </MockedProvider>
+    )
+    const titles = screen.getAllByTestId('input1')
+    const descriptions = screen.getAllByTestId('textbox')
+    const orders = screen.getAllByTestId('input3')
+    userEvent.clear(titles[0])
+    userEvent.clear(descriptions[0])
+    userEvent.clear(orders[0])
+    await userEvent.type(titles[0], 'New title', { delay: 1 })
+    await userEvent.type(descriptions[0], 'New description', { delay: 1 })
+    await userEvent.type(orders[0], '', { delay: 1 })
+    await waitFor(() =>
+      userEvent.click(screen.getAllByText('Update Challenge')[0])
+    )
+    await waitFor(() => expect(reload).not.toBeCalled())
+    await waitFor(() => expect(screen.getByText('Required')).toBeTruthy())
+    expect(container).toMatchSnapshot()
+  })
+  test('Should refuse creating  new challenge with incorrect info', async () => {
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <NewChallenge
+          challenges={challenges}
+          lessonId={0}
+          setLessons={() => true}
+        />
+      </MockedProvider>
+    )
+    const title = screen.getByTestId('input0')
+    const description = screen.getByTestId('textbox')
+    const order = screen.getByTestId('input2')
+    await userEvent.type(title, 'New challenge', { delay: 1 })
+    await userEvent.type(description, 'New challenge description', { delay: 1 })
+    await userEvent.type(order, '', { delay: 1 })
+    await waitFor(() => userEvent.click(screen.getByText('Create Challenge')))
+    await waitFor(() => expect(reload).not.toBeCalled())
+    await waitFor(() => expect(screen.getByText('Required')).toBeTruthy())
+    await waitFor(() => expect(container).toMatchSnapshot())
+  })
+  test('Should capture error when updating', async () => {
+    const errorMock = { ...updateChallengeMock, error: new Error('fail') }
+    render(
+      <MockedProvider mocks={[errorMock]} addTypename={false}>
+        <AdminLessonChallenges
+          challenges={challenges}
+          lessonId={0}
+          setLessons={() => true}
+        />
+      </MockedProvider>
+    )
+    const titles = screen.getAllByTestId('input1')
+    const descriptions = screen.getAllByTestId('textbox')
+    const orders = screen.getAllByTestId('input3')
+    userEvent.clear(titles[0])
+    userEvent.clear(descriptions[0])
+    userEvent.clear(orders[0])
+    await userEvent.type(titles[0], 'New title', { delay: 1 })
+    await userEvent.type(descriptions[0], 'New description', { delay: 1 })
+    await userEvent.type(orders[0], '15', { delay: 1 })
+    await waitFor(() =>
+      userEvent.click(screen.getAllByText('Update Challenge')[0])
+    )
+    await waitFor(() => expect(Sentry.captureException).toBeCalled())
+  })
+  test('Should capture error when creating new challenge', async () => {
+    const errorMock = { ...createNewChallengeMock, error: new Error('fail') }
+    render(
+      <MockedProvider mocks={[errorMock]} addTypename={false}>
+        <NewChallenge
+          challenges={challenges}
+          lessonId={0}
+          setLessons={() => true}
+        />
+      </MockedProvider>
+    )
+    const title = screen.getByTestId('input0')
+    const description = screen.getByTestId('textbox')
+    const order = screen.getByTestId('input2')
+    await userEvent.type(title, 'New challenge', { delay: 1 })
+    await userEvent.type(description, 'New challenge description', { delay: 1 })
+    await userEvent.type(order, '2', { delay: 1 })
+    await waitFor(() => userEvent.click(screen.getByText('Create Challenge')))
+    await waitFor(() => expect(Sentry.captureException).toBeCalled())
+  })
+  test('Should render undefined challenges', async () => {
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <AdminLessonChallenges lessonId={0} setLessons={() => true} />
+      </MockedProvider>
+    )
+    expect(container).toMatchSnapshot()
+  })
+  test('Should render nulled challenges', async () => {
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <AdminLessonChallenges
+          lessonId={0}
+          challenges={[null, null]}
+          setLessons={() => true}
+        />
+      </MockedProvider>
+    )
+    expect(container).toMatchSnapshot()
+  })
+  test('Should render a challenge without title', async () => {
+    const titlessChallenge = { ...challenges[0] }
+    delete titlessChallenge.title
+    const { container } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <AdminLessonChallenges
+          challenges={[titlessChallenge]}
+          lessonId={0}
+          setLessons={() => true}
+        />
+      </MockedProvider>
+    )
+    await waitFor(() => expect(container).toMatchSnapshot())
+  })
+})

--- a/components/admin/lessons/__snapshots__/AdminLessonChallenges.test.js.snap
+++ b/components/admin/lessons/__snapshots__/AdminLessonChallenges.test.js.snap
@@ -1,0 +1,955 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AdminLessonChallenges component Should create challenge 1`] = `
+<div>
+  <div
+    class="mb-2"
+  >
+    <div
+      class="mb-3 text-center"
+    >
+      <span
+        class="text-primary font-weight-bold display-3"
+      >
+        Create New Challenge
+      </span>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        />
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5title0"
+            >
+              Title
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input0"
+              placeholder=""
+              type="text"
+              value="New challenge"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description1"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                New challenge description
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order2"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input2"
+              placeholder=""
+              type="text"
+              value="2"
+            />
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Create Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdminLessonChallenges component Should refuse creating  new challenge with incorrect info 1`] = `
+<div>
+  <div
+    class="mb-2"
+  >
+    <div
+      class="mb-3 text-center"
+    >
+      <span
+        class="text-primary font-weight-bold display-3"
+      >
+        Create New Challenge
+      </span>
+    </div>
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        />
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5title0"
+            >
+              Title
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input0"
+              placeholder=""
+              type="text"
+              value="New challenge"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description1"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                New challenge description
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order2"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input2"
+              placeholder=""
+              type="text"
+              value=""
+            />
+            <h6
+              class="text-danger mb-0"
+            >
+              Required
+            </h6>
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Create Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdminLessonChallenges component Should refuse updating challenge with incorrect info 1`] = `
+<div>
+  <div
+    class="mt-3"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        >
+          <h2
+            class="card-title font-weight-bold mb-3"
+          >
+            Sum of 2 Numbers
+          </h2>
+        </div>
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5title1"
+            >
+              Title
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input1"
+              placeholder=""
+              type="text"
+              value="New title"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description2"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                New description
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order3"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input3"
+              placeholder=""
+              type="text"
+              value=""
+            />
+            <h6
+              class="text-danger mb-0"
+            >
+              Required
+            </h6>
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Update Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="mt-3"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        >
+          <h2
+            class="card-title font-weight-bold mb-3"
+          >
+            Sum of 3 Numbers
+          </h2>
+        </div>
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5title1"
+            >
+              Title
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input1"
+              placeholder=""
+              type="text"
+              value="Sum of 3 Numbers"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description2"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                Write a function that takes in 3 numbers and returns their sum.
+
+Here's how another developer might use your function:
+
+\`\`\`
+solution(5,9,2) // Should return 16
+solution(4,1,9) // Should return 14
+\`\`\`
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order3"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input3"
+              placeholder=""
+              type="text"
+              value="2"
+            />
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Update Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdminLessonChallenges component Should render a challenge without title 1`] = `
+<div>
+  <div
+    class="mt-3"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        />
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description1"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                Write a function that takes in 2 numbers and returns their sum.
+
+Here's how another developer might use your function:
+
+\`\`\`
+solution(5,9) // Should return 14
+solution(4,1) // Should return 5
+\`\`\`
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order2"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input2"
+              placeholder=""
+              type="text"
+              value="1"
+            />
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Update Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdminLessonChallenges component Should render nulled challenges 1`] = `<div />`;
+
+exports[`AdminLessonChallenges component Should render undefined challenges 1`] = `<div />`;
+
+exports[`AdminLessonChallenges component Should update challenge 1`] = `
+<div>
+  <div
+    class="mt-3"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        >
+          <h2
+            class="card-title font-weight-bold mb-3"
+          >
+            Sum of 2 Numbers
+          </h2>
+        </div>
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5title1"
+            >
+              Title
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input1"
+              placeholder=""
+              type="text"
+              value="Sum of 2 Numbers"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description2"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                Write a function that takes in 2 numbers and returns their sum.
+
+Here's how another developer might use your function:
+
+\`\`\`
+solution(5,9) // Should return 14
+solution(4,1) // Should return 5
+\`\`\`
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order3"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input3"
+              placeholder=""
+              type="text"
+              value="1"
+            />
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Update Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="mt-3"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        >
+          <h2
+            class="card-title font-weight-bold mb-3"
+          >
+            Sum of 3 Numbers
+          </h2>
+        </div>
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5title1"
+            >
+              Title
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input1"
+              placeholder=""
+              type="text"
+              value="Sum of 3 Numbers"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description2"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                Write a function that takes in 3 numbers and returns their sum.
+
+Here's how another developer might use your function:
+
+\`\`\`
+solution(5,9,2) // Should return 16
+solution(4,1,9) // Should return 14
+\`\`\`
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order3"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input3"
+              placeholder=""
+              type="text"
+              value="2"
+            />
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Update Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdminLessonChallenges component Should update challenge 2`] = `
+<div>
+  <div
+    class="mt-3"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        >
+          <h2
+            class="card-title font-weight-bold mb-3"
+          >
+            Sum of 2 Numbers
+          </h2>
+        </div>
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5title1"
+            >
+              Title
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input1"
+              placeholder=""
+              type="text"
+              value="New title"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description2"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                New description
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order3"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input3"
+              placeholder=""
+              type="text"
+              value="15"
+            />
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Update Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="mt-3"
+  >
+    <div
+      class="row"
+    >
+      <div
+        class="card shadow-sm col-12"
+      >
+        <div
+          class="card-body text-center"
+        >
+          <h2
+            class="card-title font-weight-bold mb-3"
+          >
+            Sum of 3 Numbers
+          </h2>
+        </div>
+        <div
+          class="text-left"
+        >
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5title1"
+            >
+              Title
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input1"
+              placeholder=""
+              type="text"
+              value="Sum of 3 Numbers"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5description2"
+            >
+              Description
+            </h5>
+            <div
+              style="background-color: white;"
+            >
+              <button
+                class="btn"
+                style="color: rgb(41, 41, 41);"
+              >
+                Write
+              </button>
+              <button
+                class="btn"
+                style="color: rgb(142, 142, 142);"
+              >
+                Preview
+              </button>
+              <textarea
+                data-testid="textbox"
+                placeholder="Type something..."
+                style="padding: 1rem; width: 100%;"
+              >
+                Write a function that takes in 3 numbers and returns their sum.
+
+Here's how another developer might use your function:
+
+\`\`\`
+solution(5,9,2) // Should return 16
+solution(4,1,9) // Should return 14
+\`\`\`
+              </textarea>
+            </div>
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5order3"
+            >
+              Order
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input3"
+              placeholder=""
+              type="text"
+              value="2"
+            />
+          </div>
+        </div>
+        <div
+          class="text-center mb-4"
+        >
+          <button
+            class="btn bg-primary"
+            style="color: rgb(255, 255, 255);"
+          >
+            Update Challenge
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Adds test for `admin/AdminLessonChallenges` component. Part of #409 and #433.

`try{someMutation}catch(e){throw new Error(e)}` pattern was very hard to test, most of the time it crashed the whole test suit, so I logged error to Sentry straight away. This should not change anything as far as logging goes, just some duplicate code. Right now every uncaught error is handled by `_error` page which uses the same `Sentry.catchException` method. Also, with manual logging we can show notifications for user if something went wrong. 