### PR TITLE
Fix review page redirecting to curriculum

### DIFF
--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -53,7 +53,7 @@ const Review: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
   }
   if (
     !session.lessonStatus.find((status: LessonStatus) => {
-      return status.lessonId === currentLesson.id && status.isPassed === 'true'
+      return status.lessonId === currentLesson.id && status.isPassed
     })
   ) {
     router.push('/curriculum')


### PR DESCRIPTION
Fix a bug that prevented going to the review page.

The bug was this check: `status.isPassed === 'true'`

`status.isPassed` actually holds a timestamp of when the user completed the lesson, and not a boolean value. If the user has not completed then the value is `null` on the database.