### PR TITLE
Revert Bcrypt to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@sentry/browser": "^5.30.0",
     "@zeit/next-sass": "^1.0.1",
     "apollo-server-micro": "^2.20.0",
-    "bcrypt": "5.0.0",
+    "bcrypt": "^5.0.1",
     "bootstrap": "^4.6.0",
     "connect-session-sequelize": "^6.1.1",
     "dayjs": "^1.10.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@sentry/browser": "^5.30.0",
     "@zeit/next-sass": "^1.0.1",
     "apollo-server-micro": "^2.20.0",
-    "bcrypt": "^5.0.1",
+    "bcrypt": "5.0.0",
     "bootstrap": "^4.6.0",
     "connect-session-sequelize": "^6.1.1",
     "dayjs": "^1.10.4",


### PR DESCRIPTION
There is a bug in the production deployment in Vercel that causes `bcrypt` to be `not found` when the version is bumped to 5.0.1. 
When deploying, a copy of the production application, I found that reverting bcrypt version to 5.0.0 resolves the issue. 

