### PR TITLE
fix curriculum highlighting

### DIFF
--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -24,14 +24,9 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -829,14 +824,9 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -1648,14 +1638,9 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/__snapshots__/forgotpassword.test.js.snap
+++ b/__tests__/pages/__snapshots__/forgotpassword.test.js.snap
@@ -24,14 +24,9 @@ exports[`ForgotPassword Page Should render invalid user/email form on error 1`] 
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -162,14 +157,9 @@ exports[`ForgotPassword Page Should render password reset instructions on succes
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/__snapshots__/login.test.js.snap
+++ b/__tests__/pages/__snapshots__/login.test.js.snap
@@ -24,14 +24,9 @@ exports[`Login Page Should set alert visible on invalid credentials 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/__snapshots__/reset.test.js.snap
+++ b/__tests__/pages/__snapshots__/reset.test.js.snap
@@ -24,14 +24,9 @@ exports[`ResetPassword Page Should render alert on error 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -162,14 +157,9 @@ exports[`ResetPassword Page Should render confirm success on success 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/__snapshots__/signup.test.js.snap
+++ b/__tests__/pages/__snapshots__/signup.test.js.snap
@@ -24,14 +24,9 @@ exports[`Signup Page Should render errors on fail 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -208,14 +203,9 @@ exports[`Signup Page Should render success component on success 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/admin/__snapshots__/alerts.test.js.snap
+++ b/__tests__/pages/admin/__snapshots__/alerts.test.js.snap
@@ -24,14 +24,9 @@ exports[`Alerts page Should remove alert 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -420,14 +415,9 @@ exports[`Alerts page Should remove alert 2`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/admin/__snapshots__/lessons.test.js.snap
+++ b/__tests__/pages/admin/__snapshots__/lessons.test.js.snap
@@ -24,14 +24,9 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 1`] 
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -1588,14 +1583,9 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 2`] 
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/admin/__snapshots__/users.test.js.snap
+++ b/__tests__/pages/admin/__snapshots__/users.test.js.snap
@@ -24,14 +24,9 @@ exports[`Users test Should be able to switch search options 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -344,14 +339,9 @@ exports[`Users test Should be able to switch search options 2`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -664,14 +654,9 @@ exports[`Users test Should be able to switch search options 3`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -984,14 +969,9 @@ exports[`Users test Should be able to switch search options 4`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
@@ -25,14 +25,9 @@ exports[`Lesson Page Should correctly render challenges page for students who ha
               class="navbar-nav collapse navbar-collapse"
             >
               <a
-                class="nav-item nav-link active"
+                class="nav-item nav-link"
                 href="/curriculum"
               >
-                <span
-                  class="sr-only"
-                >
-                  (current)
-                </span>
                 Curriculum
               </a>
               <a
@@ -437,14 +432,9 @@ exports[`Lesson Page Should render correctly with invalid lesson route 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -605,14 +595,9 @@ exports[`Lesson Page Should render correctly with valid lesson route 1`] = `
               class="navbar-nav collapse navbar-collapse"
             >
               <a
-                class="nav-item nav-link active"
+                class="nav-item nav-link"
                 href="/curriculum"
               >
-                <span
-                  class="sr-only"
-                >
-                  (current)
-                </span>
                 Curriculum
               </a>
               <a
@@ -1045,14 +1030,9 @@ exports[`Lesson Page Should return Internal server Error if alerts or lessons ar
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -24,14 +24,9 @@ exports[`user profile test Should render anonymous users 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -823,14 +818,9 @@ exports[`user profile test Should render loading spinner if data is not ready 1`
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -1622,14 +1612,9 @@ exports[`user profile test Should render nulled lessons 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -1904,14 +1889,9 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -2703,14 +2683,9 @@ exports[`user profile test Should render nulles challenges 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a
@@ -3543,14 +3518,9 @@ exports[`user profile test Should render profile 1`] = `
             class="navbar-nav collapse navbar-collapse"
           >
             <a
-              class="nav-item nav-link active"
+              class="nav-item nav-link"
               href="/curriculum"
             >
-              <span
-                class="sr-only"
-              >
-                (current)
-              </span>
               Curriculum
             </a>
             <a

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -370,14 +370,9 @@ exports[`Lesson Page Should render new submissions 1`] = `
               class="navbar-nav collapse navbar-collapse"
             >
               <a
-                class="nav-item nav-link active"
+                class="nav-item nav-link"
                 href="/curriculum"
               >
-                <span
-                  class="sr-only"
-                >
-                  (current)
-                </span>
                 Curriculum
               </a>
               <a

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -49,10 +49,9 @@ const NavBar: React.FC<AuthLinkProps> = ({ session }) => {
     <div className="navbar-nav collapse navbar-collapse">
       {navItems.map(button => (
         <NavLink
-          path={button.path}
+          {...button}
           className="nav-item nav-link"
           key={button.name}
-          external={button.external}
           activePath={location === button.path}
         >
           {button.name}

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import NavLink from './NavLink'
+import NavLink, { NavLinkProps } from './NavLink'
 import LoadingSpinner from './LoadingSpinner'
 import { Button } from './theme/Button'
 import { DropdownMenu } from './DropdownMenu'
@@ -17,47 +17,47 @@ type AuthLinkProps = {
   session: any
 }
 
+type NavItem = NavLinkProps & { name: string }
+
 const dropdownMenuItems = [
   { title: 'Lessons', path: '/admin/lessons' },
   { title: 'Users', path: '/admin/users' },
   { title: 'Alerts', path: '/admin/alerts' }
 ]
+const navItems: NavItem[] = [
+  { path: '/curriculum', name: 'Curriculum' },
+  {
+    path: 'https://github.com/garageScript/c0d3-app',
+    name: 'Repo',
+    external: true
+  },
+  {
+    path:
+      'https://www.notion.so/Table-of-Contents-a83980f81560429faca3821a9af8a5e2',
+    name: 'Journey',
+    external: true
+  },
+  { path: 'https://chat.c0d3.com', name: 'Help', external: true },
+  { path: '/contributors', name: 'Contributors' }
+]
 
 const NavBar: React.FC<AuthLinkProps> = ({ session }) => {
   const isAdmin = _.get(session, 'user.isAdmin', '')
+  const location = window && '/' + window.location.pathname.split('/')[1]
+
   return (
     <div className="navbar-nav collapse navbar-collapse">
-      <NavLink
-        path="/curriculum"
-        activePath="/curriculum"
-        className="nav-item nav-link"
-      >
-        Curriculum
-      </NavLink>
-      <NavLink
-        path="https://github.com/garageScript/c0d3-app"
-        className="nav-item nav-link"
-        external
-      >
-        Repo
-      </NavLink>
-      <NavLink
-        path="https://www.notion.so/Table-of-Contents-a83980f81560429faca3821a9af8a5e2"
-        className="nav-item nav-link"
-        external
-      >
-        Journey
-      </NavLink>
-      <NavLink
-        path="https://chat.c0d3.com"
-        className="nav-item nav-link"
-        external
-      >
-        Help
-      </NavLink>
-      <NavLink path="/contributors" className="nav-item nav-link">
-        Contributors
-      </NavLink>
+      {navItems.map(button => (
+        <NavLink
+          path={button.path}
+          className="nav-item nav-link"
+          key={button.name}
+          external={button.external}
+          activePath={location === button.path}
+        >
+          {button.name}
+        </NavLink>
+      ))}
       {isAdmin === 'true' && (
         <DropdownMenu title="Admin" items={dropdownMenuItems} />
       )}
@@ -69,9 +69,7 @@ const AuthButton: React.FC<AuthButtonProps> = ({ initial, username }) => {
   const [logoutUser, { data }] = useLogoutMutation()
   useEffect(() => {
     const success = _.get(data, 'logout.success', false)
-    if (success) {
-      window.location.pathname = '/'
-    }
+    if (success) window.location.pathname = '/'
   }, [data])
   return (
     <div className="d-flex">

--- a/components/NavLink.test.js
+++ b/components/NavLink.test.js
@@ -5,7 +5,7 @@ import NavLink from './NavLink'
 describe('NavLink Component', () => {
   test('Should render with active class when active', () => {
     const tree = (
-      <NavLink path="/" activePath="/">
+      <NavLink path="/" activePath={true}>
         Link
       </NavLink>
     )
@@ -15,7 +15,7 @@ describe('NavLink Component', () => {
 
   test('Should render without active class when not active', () => {
     const tree = (
-      <NavLink path="/" activePath="/other">
+      <NavLink path="/" activePath={false}>
         Link
       </NavLink>
     )

--- a/components/NavLink.tsx
+++ b/components/NavLink.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import Link from 'next/link'
 
-type NavLinkProps = {
+export type NavLinkProps = {
   path: string
-  activePath?: string
+  activePath?: boolean
   external?: true
   as?: string
   className?: string
@@ -18,10 +18,7 @@ const NavLink: React.FC<NavLinkProps> = ({
   className = ''
 }) => {
   if (!path) return null
-  const active = path === activePath
-  if (active) {
-    className += ' active'
-  }
+  if (activePath) className += ' active'
   if (external) {
     return (
       <a
@@ -37,7 +34,7 @@ const NavLink: React.FC<NavLinkProps> = ({
   return (
     <Link href={path} as={as}>
       <a className={className}>
-        {active && <span className="sr-only">(current)</span>}
+        {activePath && <span className="sr-only">(current)</span>}
         {children}
       </a>
     </Link>

--- a/stories/components/NavLink.stories.tsx
+++ b/stories/components/NavLink.stories.tsx
@@ -28,10 +28,10 @@ export const StyledLink: React.FC = () => (
 
 export const ActiveLink: React.FC = () => (
   <>
-    <NavLink path="/" activePath="/" className="btn btn-primary">
+    <NavLink path="/" activePath={true} className="btn btn-primary">
       Active Link
     </NavLink>
-    <NavLink path="/other" activePath="/" className="btn btn-primary">
+    <NavLink path="/other" activePath={false} className="btn btn-primary">
       Non-Active Link
     </NavLink>
   </>


### PR DESCRIPTION
This is the lighter version of #509. There are a lot of snapshot changes but they are exactly the same (change styling of `curriculum` button). So there are only small 2 files which need reviewing - `AppNav` and `NavLink`.
I used `window.location.pathname` instead of `router` because latter requires a lot of mocking changes for every test and turns this PR into #509 (and there shouldn't be any difference between `window` and `router` anyways in this case). I won't close #509 so you can review whatever is easier for you. 