### PR TITLE
closes #571 - fix css in user profiles

### DIFF
--- a/components/ProfileSubmissions.tsx
+++ b/components/ProfileSubmissions.tsx
@@ -41,7 +41,7 @@ export const SubmissionStatus: React.FC<ChallengeStatusProps> = ({
       return (
         <span
           key={challengeId}
-          className={`challenge_status ${challengeStatus}`}
+          className={`${styles['challenge_status']} ${challengeStatus}`}
         />
       )
     }
@@ -58,7 +58,9 @@ const ProfileSubmissions: React.FC<LessonChallengeProps> = ({ lessons }) => {
     let starBadge = <></>
     if (lesson.starsReceived && lesson.starsReceived.length) {
       starBadge = (
-        <p className={`lesson_image_star_badge badge badge-pill badge-primary`}>
+        <p
+          className={`${styles['lesson_image_star_badge']} badge badge-pill badge-primary`}
+        >
           {lesson.starsReceived && lesson.starsReceived.length}
           <span className="ml-1">
             <Star size={15} fill="yellow" />
@@ -67,14 +69,14 @@ const ProfileSubmissions: React.FC<LessonChallengeProps> = ({ lessons }) => {
       )
     }
     return (
-      <div key={lessonId} className="lesson_challenges">
-        <div className="lesson_image_container">
+      <div key={lessonId} className={`${styles['lesson_challenges']}`}>
+        <div className={`${styles['lesson_image_container']}`}>
           {starBadge}
           <img src={`/assets/curriculum/js-${lesson.order}-cover.svg`} />
         </div>
-        <div className="lesson_title_container">
-          <h6 className="lesson_title">{lesson.title}</h6>
-          <h6 className="challenges_stats">
+        <div className={`${styles['lesson_title_container']}`}>
+          <h6 className={`${styles['lesson_title']}`}>{lesson.title}</h6>
+          <h6 className={`${styles['challenges_stats']}`}>
             {`${filterPassedChallenges.length} of ${lesson.challenges.length}  Challenges completed`}
           </h6>
           <SubmissionStatus challengesData={lesson.challenges} />
@@ -86,7 +88,9 @@ const ProfileSubmissions: React.FC<LessonChallengeProps> = ({ lessons }) => {
     <div className={`card shadow-sm ${styles['profile-submissions']} mt-3`}>
       <div className="card-body">
         <h3>Challenges</h3>
-        <div className="display_lessons">{displaySubmissions}</div>
+        <div className={`${styles['display_lessons']}`}>
+          {displaySubmissions}
+        </div>
       </div>
     </div>
   )

--- a/scss/profileSubmissions.module.scss
+++ b/scss/profileSubmissions.module.scss
@@ -23,7 +23,6 @@
     margin-top: 15px;
   }
 
-
   .lesson_title{
     margin-top: 10px;
     color: grey;


### PR DESCRIPTION
### What does this PR do?
It fixes css styling under user profiles. 
After merging #556 nested css styles became broken. 
If you have css like this:
```
foo{
  someStyles
      .bar{
        anotherStyle
}
```
I assumed that it was enough to specify cssModules in foo classname. Turns out it wasn't and you need to add styles into children elements as well. So instead of:
```
<div className = {styles.foo}>
  <div className = "bar"/>
</div>
```
You need to do something like this:
```
<div className = {styles.foo}>
  <div className = {styles.bar}/>
</div>
```