### PR TITLE
Refactor alerts query resolver and alerts controller with Prisma

### DIFF
--- a/components/Alert.tsx
+++ b/components/Alert.tsx
@@ -11,7 +11,7 @@ type Props = {
   icon?: string
   type?: string
   prompt?: string
-  onDismiss?: (id: string) => void
+  onDismiss?: (id: number) => void
 }
 
 const alertIconMap: { [type: string]: string } = {
@@ -39,7 +39,7 @@ const Alert: React.FC<Props> = ({ alert, onDismiss }) => {
           </NavLink>
         )}
       </div>
-      {id && onDismiss && (
+      {onDismiss && (
         <button
           role="dismiss"
           className={`${styles['alert-dismiss']}`}

--- a/components/AlertsDisplay.tsx
+++ b/components/AlertsDisplay.tsx
@@ -21,7 +21,7 @@ const AlertsDisplay: React.FC<Props> = ({ alerts = [], page }) => {
     setLoading(false)
   }, [])
 
-  const dismissAlert = (id: string) => {
+  const dismissAlert = (id: number) => {
     onDismiss(prevDismissedAlerts => {
       const newDismissedAlerts = { ...prevDismissedAlerts, [id]: true }
       localStorage.setItem(

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -1,21 +1,24 @@
-import * as ApolloReactHooks from '@apollo/client'
-import { gql } from '@apollo/client'
 import {
   GraphQLResolveInfo,
   GraphQLScalarType,
   GraphQLScalarTypeConfig
 } from 'graphql'
-import * as ApolloReactCommon from '@apollo/client'
-import * as React from 'react'
-import * as ApolloReactComponents from '@apollo/client/react/components'
+import { gql } from '@apollo/client'
+import * as Apollo from '@apollo/client'
 import * as ApolloReactHoc from '@apollo/client/react/hoc'
 export type Maybe<T> = T | null
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] }
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K]
+}
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]?: Maybe<T[SubKey]> }
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]: Maybe<T[SubKey]> }
 export type RequireFields<T, K extends keyof T> = {
   [X in Exclude<keyof T, K>]?: T[X]
 } &
   { [P in K]-?: NonNullable<T[P]> }
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+const defaultOptions = {}
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string
@@ -29,7 +32,7 @@ export type Scalars = {
 
 export type Alert = {
   __typename?: 'Alert'
-  id: Scalars['String']
+  id: Scalars['Int']
   text?: Maybe<Scalars['String']>
   type?: Maybe<Scalars['String']>
   url?: Maybe<Scalars['String']>
@@ -134,7 +137,7 @@ export type MutationAddAlertArgs = {
 }
 
 export type MutationRemoveAlertArgs = {
-  id: Scalars['String']
+  id: Scalars['Int']
 }
 
 export type MutationCreateSubmissionArgs = {
@@ -585,7 +588,7 @@ export type RejectSubmissionMutation = { __typename?: 'Mutation' } & {
 }
 
 export type RemoveAlertMutationVariables = Exact<{
-  id: Scalars['String']
+  id: Scalars['Int']
 }>
 
 export type RemoveAlertMutation = { __typename?: 'Mutation' } & {
@@ -891,8 +894,9 @@ export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>
 
-export type IsTypeOfResolverFn<T = {}> = (
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
   obj: T,
+  context: TContext,
   info: GraphQLResolveInfo
 ) => boolean | Promise<boolean>
 
@@ -913,52 +917,64 @@ export type DirectiveResolverFn<
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Query: ResolverTypeWrapper<{}>
-  Lesson: ResolverTypeWrapper<Lesson>
-  String: ResolverTypeWrapper<Scalars['String']>
+  Alert: ResolverTypeWrapper<Alert>
   Int: ResolverTypeWrapper<Scalars['Int']>
+  String: ResolverTypeWrapper<Scalars['String']>
+  AuthResponse: ResolverTypeWrapper<AuthResponse>
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>
+  CacheControlScope: CacheControlScope
   Challenge: ResolverTypeWrapper<Challenge>
+  Lesson: ResolverTypeWrapper<Lesson>
+  Mutation: ResolverTypeWrapper<{}>
+  Query: ResolverTypeWrapper<{}>
+  Session: ResolverTypeWrapper<Session>
+  Star: ResolverTypeWrapper<Star>
+  Submission: ResolverTypeWrapper<Submission>
+  SuccessResponse: ResolverTypeWrapper<SuccessResponse>
+  TokenResponse: ResolverTypeWrapper<TokenResponse>
+  Upload: ResolverTypeWrapper<Scalars['Upload']>
   User: ResolverTypeWrapper<User>
   UserLesson: ResolverTypeWrapper<UserLesson>
-  Star: ResolverTypeWrapper<Star>
-  Session: ResolverTypeWrapper<Session>
-  Submission: ResolverTypeWrapper<Submission>
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>
-  Alert: ResolverTypeWrapper<Alert>
-  Mutation: ResolverTypeWrapper<{}>
-  SuccessResponse: ResolverTypeWrapper<SuccessResponse>
-  AuthResponse: ResolverTypeWrapper<AuthResponse>
-  TokenResponse: ResolverTypeWrapper<TokenResponse>
-  CacheControlScope: CacheControlScope
-  Upload: ResolverTypeWrapper<Scalars['Upload']>
 }
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Query: {}
-  Lesson: Lesson
-  String: Scalars['String']
-  Int: Scalars['Int']
-  Challenge: Challenge
-  User: User
-  UserLesson: UserLesson
-  Star: Star
-  Session: Session
-  Submission: Submission
-  Boolean: Scalars['Boolean']
   Alert: Alert
-  Mutation: {}
-  SuccessResponse: SuccessResponse
+  Int: Scalars['Int']
+  String: Scalars['String']
   AuthResponse: AuthResponse
+  Boolean: Scalars['Boolean']
+  Challenge: Challenge
+  Lesson: Lesson
+  Mutation: {}
+  Query: {}
+  Session: Session
+  Star: Star
+  Submission: Submission
+  SuccessResponse: SuccessResponse
   TokenResponse: TokenResponse
   Upload: Scalars['Upload']
+  User: User
+  UserLesson: UserLesson
 }
+
+export type CacheControlDirectiveArgs = {
+  maxAge?: Maybe<Scalars['Int']>
+  scope?: Maybe<CacheControlScope>
+}
+
+export type CacheControlDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = any,
+  Args = CacheControlDirectiveArgs
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>
 
 export type AlertResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Alert'] = ResolversParentTypes['Alert']
 > = {
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
   text?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
@@ -967,7 +983,7 @@ export type AlertResolvers<
     ParentType,
     ContextType
   >
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type AuthResponseResolvers<
@@ -978,7 +994,7 @@ export type AuthResponseResolvers<
   username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type ChallengeResolvers<
@@ -994,7 +1010,7 @@ export type ChallengeResolvers<
   lessonId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type LessonResolvers<
@@ -1024,7 +1040,7 @@ export type LessonResolvers<
   >
   currentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
   chatUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type MutationResolvers<
@@ -1190,7 +1206,7 @@ export type SessionResolvers<
     ParentType,
     ContextType
   >
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type StarResolvers<
@@ -1202,7 +1218,7 @@ export type StarResolvers<
   mentorId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
   lessonId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
   comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type SubmissionResolvers<
@@ -1237,7 +1253,7 @@ export type SubmissionResolvers<
   >
   createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type SuccessResponseResolvers<
@@ -1245,7 +1261,7 @@ export type SuccessResponseResolvers<
   ParentType extends ResolversParentTypes['SuccessResponse'] = ResolversParentTypes['SuccessResponse']
 > = {
   success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type TokenResponseResolvers<
@@ -1254,7 +1270,7 @@ export type TokenResponseResolvers<
 > = {
   success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
   token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export interface UploadScalarConfig
@@ -1277,7 +1293,7 @@ export type UserResolvers<
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type UserLessonResolvers<
@@ -1304,7 +1320,7 @@ export type UserLessonResolvers<
     ContextType
   >
   starGiven?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
 export type Resolvers<ContextType = any> = {
@@ -1329,6 +1345,17 @@ export type Resolvers<ContextType = any> = {
  * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
  */
 export type IResolvers<ContextType = any> = Resolvers<ContextType>
+export type DirectiveResolvers<ContextType = any> = {
+  cacheControl?: CacheControlDirectiveResolver<any, any, ContextType>
+}
+
+/**
+ * @deprecated
+ * Use "DirectiveResolvers" root object instead. If you wish to get "IDirectiveResolvers", add "typesPrefix: I" to your config.
+ */
+export type IDirectiveResolvers<
+  ContextType = any
+> = DirectiveResolvers<ContextType>
 
 export const AcceptSubmissionDocument = gql`
   mutation acceptSubmission($submissionId: String!, $comment: String!) {
@@ -1339,35 +1366,15 @@ export const AcceptSubmissionDocument = gql`
     }
   }
 `
-export type AcceptSubmissionMutationFn = ApolloReactCommon.MutationFunction<
+export type AcceptSubmissionMutationFn = Apollo.MutationFunction<
   AcceptSubmissionMutation,
   AcceptSubmissionMutationVariables
 >
-export type AcceptSubmissionComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >,
-  'mutation'
->
-
-export const AcceptSubmissionComponent = (
-  props: AcceptSubmissionComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    AcceptSubmissionMutation,
-    AcceptSubmissionMutationVariables
-  >
-    mutation={AcceptSubmissionDocument}
-    {...props}
-  />
-)
-
 export type AcceptSubmissionProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     AcceptSubmissionMutation,
     AcceptSubmissionMutationVariables
   >
@@ -1415,21 +1422,22 @@ export function withAcceptSubmission<
  * });
  */
 export function useAcceptSubmissionMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     AcceptSubmissionMutation,
     AcceptSubmissionMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
     AcceptSubmissionMutation,
     AcceptSubmissionMutationVariables
-  >(AcceptSubmissionDocument, baseOptions)
+  >(AcceptSubmissionDocument, options)
 }
 export type AcceptSubmissionMutationHookResult = ReturnType<
   typeof useAcceptSubmissionMutation
 >
-export type AcceptSubmissionMutationResult = ApolloReactCommon.MutationResult<AcceptSubmissionMutation>
-export type AcceptSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type AcceptSubmissionMutationResult = Apollo.MutationResult<AcceptSubmissionMutation>
+export type AcceptSubmissionMutationOptions = Apollo.BaseMutationOptions<
   AcceptSubmissionMutation,
   AcceptSubmissionMutationVariables
 >
@@ -1449,30 +1457,15 @@ export const AddAlertDocument = gql`
     }
   }
 `
-export type AddAlertMutationFn = ApolloReactCommon.MutationFunction<
+export type AddAlertMutationFn = Apollo.MutationFunction<
   AddAlertMutation,
   AddAlertMutationVariables
 >
-export type AddAlertComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >,
-  'mutation'
->
-
-export const AddAlertComponent = (props: AddAlertComponentProps) => (
-  <ApolloReactComponents.Mutation<AddAlertMutation, AddAlertMutationVariables>
-    mutation={AddAlertDocument}
-    {...props}
-  />
-)
-
 export type AddAlertProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     AddAlertMutation,
     AddAlertMutationVariables
   >
@@ -1522,19 +1515,20 @@ export function withAddAlert<
  * });
  */
 export function useAddAlertMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     AddAlertMutation,
     AddAlertMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
-    AddAlertMutation,
-    AddAlertMutationVariables
-  >(AddAlertDocument, baseOptions)
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<AddAlertMutation, AddAlertMutationVariables>(
+    AddAlertDocument,
+    options
+  )
 }
 export type AddAlertMutationHookResult = ReturnType<typeof useAddAlertMutation>
-export type AddAlertMutationResult = ApolloReactCommon.MutationResult<AddAlertMutation>
-export type AddAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type AddAlertMutationResult = Apollo.MutationResult<AddAlertMutation>
+export type AddAlertMutationOptions = Apollo.BaseMutationOptions<
   AddAlertMutation,
   AddAlertMutationVariables
 >
@@ -1550,18 +1544,6 @@ export const UsersDocument = gql`
     }
   }
 `
-export type UsersComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<UsersQuery, UsersQueryVariables>,
-  'query'
->
-
-export const UsersComponent = (props: UsersComponentProps) => (
-  <ApolloReactComponents.Query<UsersQuery, UsersQueryVariables>
-    query={UsersDocument}
-    {...props}
-  />
-)
-
 export type UsersProps<TChildProps = {}, TDataName extends string = 'data'> = {
   [key in TDataName]: ApolloReactHoc.DataValue<UsersQuery, UsersQueryVariables>
 } &
@@ -1605,30 +1587,26 @@ export function withUsers<
  * });
  */
 export function useUsersQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    UsersQuery,
-    UsersQueryVariables
-  >
+  baseOptions?: Apollo.QueryHookOptions<UsersQuery, UsersQueryVariables>
 ) {
-  return ApolloReactHooks.useQuery<UsersQuery, UsersQueryVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<UsersQuery, UsersQueryVariables>(
     UsersDocument,
-    baseOptions
+    options
   )
 }
 export function useUsersLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    UsersQuery,
-    UsersQueryVariables
-  >
+  baseOptions?: Apollo.LazyQueryHookOptions<UsersQuery, UsersQueryVariables>
 ) {
-  return ApolloReactHooks.useLazyQuery<UsersQuery, UsersQueryVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<UsersQuery, UsersQueryVariables>(
     UsersDocument,
-    baseOptions
+    options
   )
 }
 export type UsersQueryHookResult = ReturnType<typeof useUsersQuery>
 export type UsersLazyQueryHookResult = ReturnType<typeof useUsersLazyQuery>
-export type UsersQueryResult = ApolloReactCommon.QueryResult<
+export type UsersQueryResult = Apollo.QueryResult<
   UsersQuery,
   UsersQueryVariables
 >
@@ -1639,35 +1617,15 @@ export const ChangeAdminRightsDocument = gql`
     }
   }
 `
-export type ChangeAdminRightsMutationFn = ApolloReactCommon.MutationFunction<
+export type ChangeAdminRightsMutationFn = Apollo.MutationFunction<
   ChangeAdminRightsMutation,
   ChangeAdminRightsMutationVariables
 >
-export type ChangeAdminRightsComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    ChangeAdminRightsMutation,
-    ChangeAdminRightsMutationVariables
-  >,
-  'mutation'
->
-
-export const ChangeAdminRightsComponent = (
-  props: ChangeAdminRightsComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    ChangeAdminRightsMutation,
-    ChangeAdminRightsMutationVariables
-  >
-    mutation={ChangeAdminRightsDocument}
-    {...props}
-  />
-)
-
 export type ChangeAdminRightsProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     ChangeAdminRightsMutation,
     ChangeAdminRightsMutationVariables
   >
@@ -1715,21 +1673,22 @@ export function withChangeAdminRights<
  * });
  */
 export function useChangeAdminRightsMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     ChangeAdminRightsMutation,
     ChangeAdminRightsMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
     ChangeAdminRightsMutation,
     ChangeAdminRightsMutationVariables
-  >(ChangeAdminRightsDocument, baseOptions)
+  >(ChangeAdminRightsDocument, options)
 }
 export type ChangeAdminRightsMutationHookResult = ReturnType<
   typeof useChangeAdminRightsMutation
 >
-export type ChangeAdminRightsMutationResult = ApolloReactCommon.MutationResult<ChangeAdminRightsMutation>
-export type ChangeAdminRightsMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type ChangeAdminRightsMutationResult = Apollo.MutationResult<ChangeAdminRightsMutation>
+export type ChangeAdminRightsMutationOptions = Apollo.BaseMutationOptions<
   ChangeAdminRightsMutation,
   ChangeAdminRightsMutationVariables
 >
@@ -1764,35 +1723,15 @@ export const CreateChallengeDocument = gql`
     }
   }
 `
-export type CreateChallengeMutationFn = ApolloReactCommon.MutationFunction<
+export type CreateChallengeMutationFn = Apollo.MutationFunction<
   CreateChallengeMutation,
   CreateChallengeMutationVariables
 >
-export type CreateChallengeComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    CreateChallengeMutation,
-    CreateChallengeMutationVariables
-  >,
-  'mutation'
->
-
-export const CreateChallengeComponent = (
-  props: CreateChallengeComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    CreateChallengeMutation,
-    CreateChallengeMutationVariables
-  >
-    mutation={CreateChallengeDocument}
-    {...props}
-  />
-)
-
 export type CreateChallengeProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     CreateChallengeMutation,
     CreateChallengeMutationVariables
   >
@@ -1842,21 +1781,22 @@ export function withCreateChallenge<
  * });
  */
 export function useCreateChallengeMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     CreateChallengeMutation,
     CreateChallengeMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
     CreateChallengeMutation,
     CreateChallengeMutationVariables
-  >(CreateChallengeDocument, baseOptions)
+  >(CreateChallengeDocument, options)
 }
 export type CreateChallengeMutationHookResult = ReturnType<
   typeof useCreateChallengeMutation
 >
-export type CreateChallengeMutationResult = ApolloReactCommon.MutationResult<CreateChallengeMutation>
-export type CreateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type CreateChallengeMutationResult = Apollo.MutationResult<CreateChallengeMutation>
+export type CreateChallengeMutationOptions = Apollo.BaseMutationOptions<
   CreateChallengeMutation,
   CreateChallengeMutationVariables
 >
@@ -1897,33 +1837,15 @@ export const CreateLessonDocument = gql`
     }
   }
 `
-export type CreateLessonMutationFn = ApolloReactCommon.MutationFunction<
+export type CreateLessonMutationFn = Apollo.MutationFunction<
   CreateLessonMutation,
   CreateLessonMutationVariables
 >
-export type CreateLessonComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    CreateLessonMutation,
-    CreateLessonMutationVariables
-  >,
-  'mutation'
->
-
-export const CreateLessonComponent = (props: CreateLessonComponentProps) => (
-  <ApolloReactComponents.Mutation<
-    CreateLessonMutation,
-    CreateLessonMutationVariables
-  >
-    mutation={CreateLessonDocument}
-    {...props}
-  />
-)
-
 export type CreateLessonProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     CreateLessonMutation,
     CreateLessonMutationVariables
   >
@@ -1976,21 +1898,22 @@ export function withCreateLesson<
  * });
  */
 export function useCreateLessonMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     CreateLessonMutation,
     CreateLessonMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
     CreateLessonMutation,
     CreateLessonMutationVariables
-  >(CreateLessonDocument, baseOptions)
+  >(CreateLessonDocument, options)
 }
 export type CreateLessonMutationHookResult = ReturnType<
   typeof useCreateLessonMutation
 >
-export type CreateLessonMutationResult = ApolloReactCommon.MutationResult<CreateLessonMutation>
-export type CreateLessonMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type CreateLessonMutationResult = Apollo.MutationResult<CreateLessonMutation>
+export type CreateLessonMutationOptions = Apollo.BaseMutationOptions<
   CreateLessonMutation,
   CreateLessonMutationVariables
 >
@@ -2053,21 +1976,6 @@ export const GetAppDocument = gql`
     }
   }
 `
-export type GetAppComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >,
-  'query'
->
-
-export const GetAppComponent = (props: GetAppComponentProps) => (
-  <ApolloReactComponents.Query<GetAppQuery, GetAppQueryVariables>
-    query={GetAppDocument}
-    {...props}
-  />
-)
-
 export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
   [key in TDataName]: ApolloReactHoc.DataValue<
     GetAppQuery,
@@ -2114,30 +2022,26 @@ export function withGetApp<
  * });
  */
 export function useGetAppQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >
+  baseOptions?: Apollo.QueryHookOptions<GetAppQuery, GetAppQueryVariables>
 ) {
-  return ApolloReactHooks.useQuery<GetAppQuery, GetAppQueryVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetAppQuery, GetAppQueryVariables>(
     GetAppDocument,
-    baseOptions
+    options
   )
 }
 export function useGetAppLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    GetAppQuery,
-    GetAppQueryVariables
-  >
+  baseOptions?: Apollo.LazyQueryHookOptions<GetAppQuery, GetAppQueryVariables>
 ) {
-  return ApolloReactHooks.useLazyQuery<GetAppQuery, GetAppQueryVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetAppQuery, GetAppQueryVariables>(
     GetAppDocument,
-    baseOptions
+    options
   )
 }
 export type GetAppQueryHookResult = ReturnType<typeof useGetAppQuery>
 export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>
-export type GetAppQueryResult = ApolloReactCommon.QueryResult<
+export type GetAppQueryResult = Apollo.QueryResult<
   GetAppQuery,
   GetAppQueryVariables
 >
@@ -2150,25 +2054,6 @@ export const LessonMentorsDocument = gql`
     }
   }
 `
-export type LessonMentorsComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >,
-  'query'
-> &
-  (
-    | { variables: LessonMentorsQueryVariables; skip?: boolean }
-    | { skip: boolean }
-  )
-
-export const LessonMentorsComponent = (props: LessonMentorsComponentProps) => (
-  <ApolloReactComponents.Query<LessonMentorsQuery, LessonMentorsQueryVariables>
-    query={LessonMentorsDocument}
-    {...props}
-  />
-)
-
 export type LessonMentorsProps<
   TChildProps = {},
   TDataName extends string = 'data'
@@ -2219,26 +2104,28 @@ export function withLessonMentors<
  * });
  */
 export function useLessonMentorsQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
+  baseOptions: Apollo.QueryHookOptions<
     LessonMentorsQuery,
     LessonMentorsQueryVariables
   >
 ) {
-  return ApolloReactHooks.useQuery<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >(LessonMentorsDocument, baseOptions)
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<LessonMentorsQuery, LessonMentorsQueryVariables>(
+    LessonMentorsDocument,
+    options
+  )
 }
 export function useLessonMentorsLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+  baseOptions?: Apollo.LazyQueryHookOptions<
     LessonMentorsQuery,
     LessonMentorsQueryVariables
   >
 ) {
-  return ApolloReactHooks.useLazyQuery<
-    LessonMentorsQuery,
-    LessonMentorsQueryVariables
-  >(LessonMentorsDocument, baseOptions)
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<LessonMentorsQuery, LessonMentorsQueryVariables>(
+    LessonMentorsDocument,
+    options
+  )
 }
 export type LessonMentorsQueryHookResult = ReturnType<
   typeof useLessonMentorsQuery
@@ -2246,7 +2133,7 @@ export type LessonMentorsQueryHookResult = ReturnType<
 export type LessonMentorsLazyQueryHookResult = ReturnType<
   typeof useLessonMentorsLazyQuery
 >
-export type LessonMentorsQueryResult = ApolloReactCommon.QueryResult<
+export type LessonMentorsQueryResult = Apollo.QueryResult<
   LessonMentorsQuery,
   LessonMentorsQueryVariables
 >
@@ -2271,22 +2158,6 @@ export const SubmissionsDocument = gql`
     }
   }
 `
-export type SubmissionsComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >,
-  'query'
-> &
-  ({ variables: SubmissionsQueryVariables; skip?: boolean } | { skip: boolean })
-
-export const SubmissionsComponent = (props: SubmissionsComponentProps) => (
-  <ApolloReactComponents.Query<SubmissionsQuery, SubmissionsQueryVariables>
-    query={SubmissionsDocument}
-    {...props}
-  />
-)
-
 export type SubmissionsProps<
   TChildProps = {},
   TDataName extends string = 'data'
@@ -2337,32 +2208,34 @@ export function withSubmissions<
  * });
  */
 export function useSubmissionsQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
+  baseOptions: Apollo.QueryHookOptions<
     SubmissionsQuery,
     SubmissionsQueryVariables
   >
 ) {
-  return ApolloReactHooks.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<SubmissionsQuery, SubmissionsQueryVariables>(
     SubmissionsDocument,
-    baseOptions
+    options
   )
 }
 export function useSubmissionsLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+  baseOptions?: Apollo.LazyQueryHookOptions<
     SubmissionsQuery,
     SubmissionsQueryVariables
   >
 ) {
-  return ApolloReactHooks.useLazyQuery<
-    SubmissionsQuery,
-    SubmissionsQueryVariables
-  >(SubmissionsDocument, baseOptions)
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<SubmissionsQuery, SubmissionsQueryVariables>(
+    SubmissionsDocument,
+    options
+  )
 }
 export type SubmissionsQueryHookResult = ReturnType<typeof useSubmissionsQuery>
 export type SubmissionsLazyQueryHookResult = ReturnType<
   typeof useSubmissionsLazyQuery
 >
-export type SubmissionsQueryResult = ApolloReactCommon.QueryResult<
+export type SubmissionsQueryResult = Apollo.QueryResult<
   SubmissionsQuery,
   SubmissionsQueryVariables
 >
@@ -2376,30 +2249,15 @@ export const LoginDocument = gql`
     }
   }
 `
-export type LoginMutationFn = ApolloReactCommon.MutationFunction<
+export type LoginMutationFn = Apollo.MutationFunction<
   LoginMutation,
   LoginMutationVariables
 >
-export type LoginComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    LoginMutation,
-    LoginMutationVariables
-  >,
-  'mutation'
->
-
-export const LoginComponent = (props: LoginComponentProps) => (
-  <ApolloReactComponents.Mutation<LoginMutation, LoginMutationVariables>
-    mutation={LoginDocument}
-    {...props}
-  />
-)
-
 export type LoginProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     LoginMutation,
     LoginMutationVariables
   >
@@ -2447,19 +2305,20 @@ export function withLogin<
  * });
  */
 export function useLoginMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     LoginMutation,
     LoginMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<LoginMutation, LoginMutationVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<LoginMutation, LoginMutationVariables>(
     LoginDocument,
-    baseOptions
+    options
   )
 }
 export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>
-export type LoginMutationResult = ApolloReactCommon.MutationResult<LoginMutation>
-export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type LoginMutationResult = Apollo.MutationResult<LoginMutation>
+export type LoginMutationOptions = Apollo.BaseMutationOptions<
   LoginMutation,
   LoginMutationVariables
 >
@@ -2472,30 +2331,15 @@ export const LogoutDocument = gql`
     }
   }
 `
-export type LogoutMutationFn = ApolloReactCommon.MutationFunction<
+export type LogoutMutationFn = Apollo.MutationFunction<
   LogoutMutation,
   LogoutMutationVariables
 >
-export type LogoutComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    LogoutMutation,
-    LogoutMutationVariables
-  >,
-  'mutation'
->
-
-export const LogoutComponent = (props: LogoutComponentProps) => (
-  <ApolloReactComponents.Mutation<LogoutMutation, LogoutMutationVariables>
-    mutation={LogoutDocument}
-    {...props}
-  />
-)
-
 export type LogoutProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     LogoutMutation,
     LogoutMutationVariables
   >
@@ -2541,19 +2385,20 @@ export function withLogout<
  * });
  */
 export function useLogoutMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     LogoutMutation,
     LogoutMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<LogoutMutation, LogoutMutationVariables>(
     LogoutDocument,
-    baseOptions
+    options
   )
 }
 export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>
-export type LogoutMutationResult = ApolloReactCommon.MutationResult<LogoutMutation>
-export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type LogoutMutationResult = Apollo.MutationResult<LogoutMutation>
+export type LogoutMutationOptions = Apollo.BaseMutationOptions<
   LogoutMutation,
   LogoutMutationVariables
 >
@@ -2566,35 +2411,15 @@ export const RejectSubmissionDocument = gql`
     }
   }
 `
-export type RejectSubmissionMutationFn = ApolloReactCommon.MutationFunction<
+export type RejectSubmissionMutationFn = Apollo.MutationFunction<
   RejectSubmissionMutation,
   RejectSubmissionMutationVariables
 >
-export type RejectSubmissionComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >,
-  'mutation'
->
-
-export const RejectSubmissionComponent = (
-  props: RejectSubmissionComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    RejectSubmissionMutation,
-    RejectSubmissionMutationVariables
-  >
-    mutation={RejectSubmissionDocument}
-    {...props}
-  />
-)
-
 export type RejectSubmissionProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     RejectSubmissionMutation,
     RejectSubmissionMutationVariables
   >
@@ -2642,58 +2467,41 @@ export function withRejectSubmission<
  * });
  */
 export function useRejectSubmissionMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     RejectSubmissionMutation,
     RejectSubmissionMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
     RejectSubmissionMutation,
     RejectSubmissionMutationVariables
-  >(RejectSubmissionDocument, baseOptions)
+  >(RejectSubmissionDocument, options)
 }
 export type RejectSubmissionMutationHookResult = ReturnType<
   typeof useRejectSubmissionMutation
 >
-export type RejectSubmissionMutationResult = ApolloReactCommon.MutationResult<RejectSubmissionMutation>
-export type RejectSubmissionMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type RejectSubmissionMutationResult = Apollo.MutationResult<RejectSubmissionMutation>
+export type RejectSubmissionMutationOptions = Apollo.BaseMutationOptions<
   RejectSubmissionMutation,
   RejectSubmissionMutationVariables
 >
 export const RemoveAlertDocument = gql`
-  mutation removeAlert($id: String!) {
+  mutation removeAlert($id: Int!) {
     removeAlert(id: $id) {
       success
     }
   }
 `
-export type RemoveAlertMutationFn = ApolloReactCommon.MutationFunction<
+export type RemoveAlertMutationFn = Apollo.MutationFunction<
   RemoveAlertMutation,
   RemoveAlertMutationVariables
 >
-export type RemoveAlertComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    RemoveAlertMutation,
-    RemoveAlertMutationVariables
-  >,
-  'mutation'
->
-
-export const RemoveAlertComponent = (props: RemoveAlertComponentProps) => (
-  <ApolloReactComponents.Mutation<
-    RemoveAlertMutation,
-    RemoveAlertMutationVariables
-  >
-    mutation={RemoveAlertDocument}
-    {...props}
-  />
-)
-
 export type RemoveAlertProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     RemoveAlertMutation,
     RemoveAlertMutationVariables
   >
@@ -2740,21 +2548,22 @@ export function withRemoveAlert<
  * });
  */
 export function useRemoveAlertMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     RemoveAlertMutation,
     RemoveAlertMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
-    RemoveAlertMutation,
-    RemoveAlertMutationVariables
-  >(RemoveAlertDocument, baseOptions)
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<RemoveAlertMutation, RemoveAlertMutationVariables>(
+    RemoveAlertDocument,
+    options
+  )
 }
 export type RemoveAlertMutationHookResult = ReturnType<
   typeof useRemoveAlertMutation
 >
-export type RemoveAlertMutationResult = ApolloReactCommon.MutationResult<RemoveAlertMutation>
-export type RemoveAlertMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type RemoveAlertMutationResult = Apollo.MutationResult<RemoveAlertMutation>
+export type RemoveAlertMutationOptions = Apollo.BaseMutationOptions<
   RemoveAlertMutation,
   RemoveAlertMutationVariables
 >
@@ -2766,33 +2575,15 @@ export const ReqPwResetDocument = gql`
     }
   }
 `
-export type ReqPwResetMutationFn = ApolloReactCommon.MutationFunction<
+export type ReqPwResetMutationFn = Apollo.MutationFunction<
   ReqPwResetMutation,
   ReqPwResetMutationVariables
 >
-export type ReqPwResetComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >,
-  'mutation'
->
-
-export const ReqPwResetComponent = (props: ReqPwResetComponentProps) => (
-  <ApolloReactComponents.Mutation<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >
-    mutation={ReqPwResetDocument}
-    {...props}
-  />
-)
-
 export type ReqPwResetProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     ReqPwResetMutation,
     ReqPwResetMutationVariables
   >
@@ -2839,21 +2630,22 @@ export function withReqPwReset<
  * });
  */
 export function useReqPwResetMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     ReqPwResetMutation,
     ReqPwResetMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
-    ReqPwResetMutation,
-    ReqPwResetMutationVariables
-  >(ReqPwResetDocument, baseOptions)
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<ReqPwResetMutation, ReqPwResetMutationVariables>(
+    ReqPwResetDocument,
+    options
+  )
 }
 export type ReqPwResetMutationHookResult = ReturnType<
   typeof useReqPwResetMutation
 >
-export type ReqPwResetMutationResult = ApolloReactCommon.MutationResult<ReqPwResetMutation>
-export type ReqPwResetMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type ReqPwResetMutationResult = Apollo.MutationResult<ReqPwResetMutation>
+export type ReqPwResetMutationOptions = Apollo.BaseMutationOptions<
   ReqPwResetMutation,
   ReqPwResetMutationVariables
 >
@@ -2864,30 +2656,15 @@ export const SetStarDocument = gql`
     }
   }
 `
-export type SetStarMutationFn = ApolloReactCommon.MutationFunction<
+export type SetStarMutationFn = Apollo.MutationFunction<
   SetStarMutation,
   SetStarMutationVariables
 >
-export type SetStarComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    SetStarMutation,
-    SetStarMutationVariables
-  >,
-  'mutation'
->
-
-export const SetStarComponent = (props: SetStarComponentProps) => (
-  <ApolloReactComponents.Mutation<SetStarMutation, SetStarMutationVariables>
-    mutation={SetStarDocument}
-    {...props}
-  />
-)
-
 export type SetStarProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     SetStarMutation,
     SetStarMutationVariables
   >
@@ -2936,19 +2713,20 @@ export function withSetStar<
  * });
  */
 export function useSetStarMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     SetStarMutation,
     SetStarMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
-    SetStarMutation,
-    SetStarMutationVariables
-  >(SetStarDocument, baseOptions)
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<SetStarMutation, SetStarMutationVariables>(
+    SetStarDocument,
+    options
+  )
 }
 export type SetStarMutationHookResult = ReturnType<typeof useSetStarMutation>
-export type SetStarMutationResult = ApolloReactCommon.MutationResult<SetStarMutation>
-export type SetStarMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type SetStarMutationResult = Apollo.MutationResult<SetStarMutation>
+export type SetStarMutationOptions = Apollo.BaseMutationOptions<
   SetStarMutation,
   SetStarMutationVariables
 >
@@ -2971,30 +2749,15 @@ export const SignupDocument = gql`
     }
   }
 `
-export type SignupMutationFn = ApolloReactCommon.MutationFunction<
+export type SignupMutationFn = Apollo.MutationFunction<
   SignupMutation,
   SignupMutationVariables
 >
-export type SignupComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    SignupMutation,
-    SignupMutationVariables
-  >,
-  'mutation'
->
-
-export const SignupComponent = (props: SignupComponentProps) => (
-  <ApolloReactComponents.Mutation<SignupMutation, SignupMutationVariables>
-    mutation={SignupDocument}
-    {...props}
-  />
-)
-
 export type SignupProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     SignupMutation,
     SignupMutationVariables
   >
@@ -3044,19 +2807,20 @@ export function withSignup<
  * });
  */
 export function useSignupMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     SignupMutation,
     SignupMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<SignupMutation, SignupMutationVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<SignupMutation, SignupMutationVariables>(
     SignupDocument,
-    baseOptions
+    options
   )
 }
 export type SignupMutationHookResult = ReturnType<typeof useSignupMutation>
-export type SignupMutationResult = ApolloReactCommon.MutationResult<SignupMutation>
-export type SignupMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type SignupMutationResult = Apollo.MutationResult<SignupMutation>
+export type SignupMutationOptions = Apollo.BaseMutationOptions<
   SignupMutation,
   SignupMutationVariables
 >
@@ -3093,35 +2857,15 @@ export const UpdateChallengeDocument = gql`
     }
   }
 `
-export type UpdateChallengeMutationFn = ApolloReactCommon.MutationFunction<
+export type UpdateChallengeMutationFn = Apollo.MutationFunction<
   UpdateChallengeMutation,
   UpdateChallengeMutationVariables
 >
-export type UpdateChallengeComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    UpdateChallengeMutation,
-    UpdateChallengeMutationVariables
-  >,
-  'mutation'
->
-
-export const UpdateChallengeComponent = (
-  props: UpdateChallengeComponentProps
-) => (
-  <ApolloReactComponents.Mutation<
-    UpdateChallengeMutation,
-    UpdateChallengeMutationVariables
-  >
-    mutation={UpdateChallengeDocument}
-    {...props}
-  />
-)
-
 export type UpdateChallengeProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     UpdateChallengeMutation,
     UpdateChallengeMutationVariables
   >
@@ -3172,21 +2916,22 @@ export function withUpdateChallenge<
  * });
  */
 export function useUpdateChallengeMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     UpdateChallengeMutation,
     UpdateChallengeMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
     UpdateChallengeMutation,
     UpdateChallengeMutationVariables
-  >(UpdateChallengeDocument, baseOptions)
+  >(UpdateChallengeDocument, options)
 }
 export type UpdateChallengeMutationHookResult = ReturnType<
   typeof useUpdateChallengeMutation
 >
-export type UpdateChallengeMutationResult = ApolloReactCommon.MutationResult<UpdateChallengeMutation>
-export type UpdateChallengeMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type UpdateChallengeMutationResult = Apollo.MutationResult<UpdateChallengeMutation>
+export type UpdateChallengeMutationOptions = Apollo.BaseMutationOptions<
   UpdateChallengeMutation,
   UpdateChallengeMutationVariables
 >
@@ -3229,33 +2974,15 @@ export const UpdateLessonDocument = gql`
     }
   }
 `
-export type UpdateLessonMutationFn = ApolloReactCommon.MutationFunction<
+export type UpdateLessonMutationFn = Apollo.MutationFunction<
   UpdateLessonMutation,
   UpdateLessonMutationVariables
 >
-export type UpdateLessonComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    UpdateLessonMutation,
-    UpdateLessonMutationVariables
-  >,
-  'mutation'
->
-
-export const UpdateLessonComponent = (props: UpdateLessonComponentProps) => (
-  <ApolloReactComponents.Mutation<
-    UpdateLessonMutation,
-    UpdateLessonMutationVariables
-  >
-    mutation={UpdateLessonDocument}
-    {...props}
-  />
-)
-
 export type UpdateLessonProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     UpdateLessonMutation,
     UpdateLessonMutationVariables
   >
@@ -3309,21 +3036,22 @@ export function withUpdateLesson<
  * });
  */
 export function useUpdateLessonMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     UpdateLessonMutation,
     UpdateLessonMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
     UpdateLessonMutation,
     UpdateLessonMutationVariables
-  >(UpdateLessonDocument, baseOptions)
+  >(UpdateLessonDocument, options)
 }
 export type UpdateLessonMutationHookResult = ReturnType<
   typeof useUpdateLessonMutation
 >
-export type UpdateLessonMutationResult = ApolloReactCommon.MutationResult<UpdateLessonMutation>
-export type UpdateLessonMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type UpdateLessonMutationResult = Apollo.MutationResult<UpdateLessonMutation>
+export type UpdateLessonMutationOptions = Apollo.BaseMutationOptions<
   UpdateLessonMutation,
   UpdateLessonMutationVariables
 >
@@ -3334,30 +3062,15 @@ export const ChangePwDocument = gql`
     }
   }
 `
-export type ChangePwMutationFn = ApolloReactCommon.MutationFunction<
+export type ChangePwMutationFn = Apollo.MutationFunction<
   ChangePwMutation,
   ChangePwMutationVariables
 >
-export type ChangePwComponentProps = Omit<
-  ApolloReactComponents.MutationComponentOptions<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >,
-  'mutation'
->
-
-export const ChangePwComponent = (props: ChangePwComponentProps) => (
-  <ApolloReactComponents.Mutation<ChangePwMutation, ChangePwMutationVariables>
-    mutation={ChangePwDocument}
-    {...props}
-  />
-)
-
 export type ChangePwProps<
   TChildProps = {},
   TDataName extends string = 'mutate'
 > = {
-  [key in TDataName]: ApolloReactCommon.MutationFunction<
+  [key in TDataName]: Apollo.MutationFunction<
     ChangePwMutation,
     ChangePwMutationVariables
   >
@@ -3405,19 +3118,20 @@ export function withChangePw<
  * });
  */
 export function useChangePwMutation(
-  baseOptions?: ApolloReactHooks.MutationHookOptions<
+  baseOptions?: Apollo.MutationHookOptions<
     ChangePwMutation,
     ChangePwMutationVariables
   >
 ) {
-  return ApolloReactHooks.useMutation<
-    ChangePwMutation,
-    ChangePwMutationVariables
-  >(ChangePwDocument, baseOptions)
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<ChangePwMutation, ChangePwMutationVariables>(
+    ChangePwDocument,
+    options
+  )
 }
 export type ChangePwMutationHookResult = ReturnType<typeof useChangePwMutation>
-export type ChangePwMutationResult = ApolloReactCommon.MutationResult<ChangePwMutation>
-export type ChangePwMutationOptions = ApolloReactCommon.BaseMutationOptions<
+export type ChangePwMutationResult = Apollo.MutationResult<ChangePwMutation>
+export type ChangePwMutationOptions = Apollo.BaseMutationOptions<
   ChangePwMutation,
   ChangePwMutationVariables
 >
@@ -3475,22 +3189,6 @@ export const UserInfoDocument = gql`
     }
   }
 `
-export type UserInfoComponentProps = Omit<
-  ApolloReactComponents.QueryComponentOptions<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >,
-  'query'
-> &
-  ({ variables: UserInfoQueryVariables; skip?: boolean } | { skip: boolean })
-
-export const UserInfoComponent = (props: UserInfoComponentProps) => (
-  <ApolloReactComponents.Query<UserInfoQuery, UserInfoQueryVariables>
-    query={UserInfoDocument}
-    {...props}
-  />
-)
-
 export type UserInfoProps<
   TChildProps = {},
   TDataName extends string = 'data'
@@ -3541,32 +3239,31 @@ export function withUserInfo<
  * });
  */
 export function useUserInfoQuery(
-  baseOptions?: ApolloReactHooks.QueryHookOptions<
-    UserInfoQuery,
-    UserInfoQueryVariables
-  >
+  baseOptions: Apollo.QueryHookOptions<UserInfoQuery, UserInfoQueryVariables>
 ) {
-  return ApolloReactHooks.useQuery<UserInfoQuery, UserInfoQueryVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<UserInfoQuery, UserInfoQueryVariables>(
     UserInfoDocument,
-    baseOptions
+    options
   )
 }
 export function useUserInfoLazyQuery(
-  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+  baseOptions?: Apollo.LazyQueryHookOptions<
     UserInfoQuery,
     UserInfoQueryVariables
   >
 ) {
-  return ApolloReactHooks.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<UserInfoQuery, UserInfoQueryVariables>(
     UserInfoDocument,
-    baseOptions
+    options
   )
 }
 export type UserInfoQueryHookResult = ReturnType<typeof useUserInfoQuery>
 export type UserInfoLazyQueryHookResult = ReturnType<
   typeof useUserInfoLazyQuery
 >
-export type UserInfoQueryResult = ApolloReactCommon.QueryResult<
+export type UserInfoQueryResult = Apollo.QueryResult<
   UserInfoQuery,
   UserInfoQueryVariables
 >

--- a/graphql/queries/removeAlert.ts
+++ b/graphql/queries/removeAlert.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 const REMOVE_ALERT = gql`
-  mutation removeAlert($id: String!) {
+  mutation removeAlert($id: Int!) {
     removeAlert(id: $id) {
       success
     }

--- a/graphql/queryResolvers/alerts.test.js
+++ b/graphql/queryResolvers/alerts.test.js
@@ -1,15 +1,14 @@
 import { alerts } from './alerts'
-import db from '../../helpers/dbload'
+import { prisma } from '../../prisma'
 
 describe('Alerts resolver', () => {
-  const { Alert } = db
   test('should return empty array if no alerts', async () => {
-    Alert.findAll = jest.fn().mockReturnValue([])
+    prisma.alert.findMany = jest.fn().mockReturnValue([])
     expect(alerts()).toEqual([])
   })
 
   test('should return list of alerts', async () => {
-    Alert.findAll = jest.fn().mockReturnValue([
+    prisma.alert.findMany = jest.fn().mockReturnValue([
       {
         id: 0,
         text: 'Set up your computer to submit challenges.',

--- a/graphql/queryResolvers/alerts.ts
+++ b/graphql/queryResolvers/alerts.ts
@@ -1,7 +1,3 @@
-import db from '../../helpers/dbload'
+import { prisma } from '../../prisma'
 
-const { Alert } = db
-
-export const alerts = () => {
-  return Alert.findAll()
-}
+export const alerts = () => prisma.alert.findMany()

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -37,7 +37,7 @@ export default gql`
       url: String
       urlCaption: String
     ): [Alert]
-    removeAlert(id: String!): SuccessResponse
+    removeAlert(id: Int!): SuccessResponse
     createSubmission(
       lessonId: String!
       challengeId: String!
@@ -160,7 +160,7 @@ export default gql`
   }
 
   type Alert {
-    id: String!
+    id: Int!
     text: String
     type: String
     url: String

--- a/helpers/controllers/alertController.test.js
+++ b/helpers/controllers/alertController.test.js
@@ -1,11 +1,12 @@
 jest.mock('../dbload')
 jest.mock('../mattermost')
+jest.mock('../../graphql/queryResolvers/alerts')
+import { alerts } from '../../graphql/queryResolvers/alerts'
 import db from '../dbload'
 import { addAlert, removeAlert } from './alertController'
 
-const { Alert } = db
 const mockAlerts = ['excuse me sir', 'did u just', 'turn into a potato?']
-Alert.findAll = jest.fn().mockReturnValue(mockAlerts)
+alerts.mockReturnValue(mockAlerts)
 
 describe('Alert controller tests', () => {
   const ctx = {

--- a/helpers/controllers/alertController.test.js
+++ b/helpers/controllers/alertController.test.js
@@ -1,52 +1,45 @@
-jest.mock('../dbload')
 jest.mock('../mattermost')
 jest.mock('../../graphql/queryResolvers/alerts')
 import { alerts } from '../../graphql/queryResolvers/alerts'
-import db from '../dbload'
+import { prisma } from '../../prisma'
 import { addAlert, removeAlert } from './alertController'
 
 const mockAlerts = ['excuse me sir', 'did u just', 'turn into a potato?']
-alerts.mockReturnValue(mockAlerts)
+const context = {
+  req: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    session: {},
+    user: { isAdmin: 'true' }
+  }
+}
+
+alerts.mockResolvedValue(mockAlerts)
+prisma.alert.create = jest.fn().mockImplementation(a => Promise.resolve(a))
+prisma.alert.delete = jest.fn().mockImplementation(a => Promise.resolve(a))
 
 describe('Alert controller tests', () => {
-  const ctx = {
-    req: {
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      session: {},
-      user: { isAdmin: 'true' }
-    }
+  let ctx
+
+  const newAlert = {
+    text: 'Set up your computer to submit challenges.',
+    type: 'info',
+    url:
+      'https://www.notion.so/JS-0-Foundations-a43ca620e54945b2b620bcda5f3cf672#b45ed85a95e24c9d9fb784afb7a46bcc',
+    urlCaption: 'View Instructions'
   }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ctx = { ...context }
+  })
+
   test('Should add alert', async () => {
-    expect(
-      addAlert(
-        {},
-        {
-          text: 'Set up your computer to submit challenges.',
-          type: 'info',
-          url:
-            'https://www.notion.so/JS-0-Foundations-a43ca620e54945b2b620bcda5f3cf672#b45ed85a95e24c9d9fb784afb7a46bcc',
-          urlCaption: 'View Instructions'
-        },
-        ctx
-      )
-    ).resolves.toEqual(mockAlerts)
+    expect(addAlert({}, newAlert, ctx)).resolves.toEqual(mockAlerts)
   })
   test('Should add alert with url and caption', async () => {
-    expect(
-      addAlert(
-        {},
-        {
-          text: 'Set up your computer to submit challenges.',
-          type: 'info',
-          url:
-            'https://www.notion.so/JS-0-Foundations-a43ca620e54945b2b620bcda5f3cf672#b45ed85a95e24c9d9fb784afb7a46bcc',
-          urlCaption: 'View Instructions'
-        },
-        ctx
-      )
-    ).resolves.toEqual(mockAlerts)
+    expect(addAlert({}, newAlert, ctx)).resolves.toEqual(mockAlerts)
   })
   test('Should throw error if missing parameters', async () => {
     expect(
@@ -58,7 +51,9 @@ describe('Alert controller tests', () => {
     expect(removeAlert({}, { id: 5 }, ctx)).resolves.toEqual({ success: true })
   })
   test('Should throw error if no id provided when removing alert', async () => {
-    db.Alert.destroy = jest.fn().mockRejectedValueOnce('No alert id provided')
+    prisma.alert.delete = jest
+      .fn()
+      .mockRejectedValueOnce('No alert id provided')
     expect(removeAlert({}, {}, ctx)).rejects.toThrowError(
       'No alert id provided'
     )

--- a/pages/admin/alerts.tsx
+++ b/pages/admin/alerts.tsx
@@ -19,7 +19,7 @@ type AlertRowProps = {
 const AlertRow: React.FC<AlertRowProps> = ({ alerts, alert, setAlerts }) => {
   const [removeAlert] = useMutation(REMOVE_ALERT)
 
-  const removeDatAlert = async (id: string) => {
+  const removeDatAlert = async (id: number) => {
     try {
       await removeAlert({ variables: { id } })
       const newAlerts = alerts.filter((alert: AlertType) => alert.id !== id)

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -23,7 +23,7 @@ const ErrorMessages: React.FC<ErrorDisplayProps> = ({ loginErrors }) => {
     return (
       <Alert
         key={idx}
-        alert={{ id: '-1', text: formattedMessage, type: 'urgent' }}
+        alert={{ id: -1, text: formattedMessage, type: 'urgent' }}
       />
     )
   })

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,7 @@ model Session {
   expires   DateTime? @db.Timestamptz(6)
   data      String?
   createdAt DateTime  @db.Timestamptz(6)
-  updatedAt DateTime  @db.Timestamptz(6)
+  updatedAt DateTime  @updatedAt @db.Timestamptz(6)
 }
 
 model Alert {
@@ -23,7 +23,7 @@ model Alert {
   url        String?  @db.VarChar(255)
   urlCaption String?  @db.VarChar(255)
   createdAt  DateTime @db.Timestamptz(6)
-  updatedAt  DateTime @db.Timestamptz(6)
+  updatedAt  DateTime @updatedAt @db.Timestamptz(6)
 
   @@map("alerts")
 }
@@ -35,7 +35,7 @@ model Challenge {
   title       String?      @db.VarChar(255)
   order       Int?
   createdAt   DateTime     @db.Timestamptz(6)
-  updatedAt   DateTime     @db.Timestamptz(6)
+  updatedAt   DateTime     @updatedAt @db.Timestamptz(6)
   lessonId    Int?
   lesson      Lesson?      @relation(fields: [lessonId], references: [id])
   submissions Submission[]
@@ -52,7 +52,7 @@ model Lesson {
   order       Int?
   title       String?      @db.VarChar(255)
   createdAt   DateTime     @db.Timestamptz(6)
-  updatedAt   DateTime     @db.Timestamptz(6)
+  updatedAt   DateTime     @updatedAt @db.Timestamptz(6)
   chatUrl     String?      @db.VarChar(255)
   challenges  Challenge[]
   submissions Submission[]
@@ -65,7 +65,7 @@ model Star {
   id        Int      @id @default(autoincrement())
   lessonId  Int?
   createdAt DateTime @db.Timestamptz(6)
-  updatedAt DateTime @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @db.Timestamptz(6)
   studentId Int?
   mentorId  Int?
   comment   String?  @db.VarChar(255)
@@ -83,7 +83,7 @@ model Submission {
   status      String?    @db.VarChar(255)
   viewCount   Int?       @default(0)
   createdAt   DateTime   @db.Timestamptz(6)
-  updatedAt   DateTime   @db.Timestamptz(6)
+  updatedAt   DateTime   @updatedAt @db.Timestamptz(6)
   userId      Int?
   reviewerId  Int?
   challengeId Int?
@@ -101,7 +101,7 @@ model UserLesson {
   isTeaching String?  @db.VarChar(255)
   isEnrolled String?  @db.VarChar(255)
   createdAt  DateTime @db.Timestamptz(6)
-  updatedAt  DateTime @db.Timestamptz(6)
+  updatedAt  DateTime @updatedAt @db.Timestamptz(6)
   lessonId   Int
   userId     Int
   lesson     Lesson   @relation(fields: [lessonId], references: [id])
@@ -120,7 +120,7 @@ model User {
   gsId                   Int?
   isOnline               Boolean?
   createdAt              DateTime     @db.Timestamptz(6)
-  updatedAt              DateTime     @db.Timestamptz(6)
+  updatedAt              DateTime     @updatedAt @db.Timestamptz(6)
   isAdmin                String?      @default(dbgenerated("false")) @db.VarChar(255)
   forgotToken            String?      @db.VarChar(255)
   cliToken               String?      @db.VarChar(255)

--- a/stories/components/Alert.stories.tsx
+++ b/stories/components/Alert.stories.tsx
@@ -11,7 +11,7 @@ export default {
 export const Info: React.FC = () => (
   <Alert
     alert={{
-      id: '0',
+      id: 0,
       text: 'Set up your computer to submit challenges.',
       type: 'info'
     }}
@@ -21,7 +21,7 @@ export const Info: React.FC = () => (
 export const Urgent: React.FC = () => (
   <Alert
     alert={{
-      id: '-1',
+      id: -1,
       text: 'Invalid password',
       type: 'urgent'
     }}
@@ -31,7 +31,7 @@ export const Urgent: React.FC = () => (
 export const infoWithLinkAndDismiss: React.FC = () => (
   <Alert
     alert={{
-      id: '0',
+      id: 0,
       text: 'Set up your computer to submit challenges.',
       type: 'info',
       url:
@@ -45,7 +45,7 @@ export const infoWithLinkAndDismiss: React.FC = () => (
 export const urgentWithIconAndDismiss: React.FC = () => (
   <Alert
     alert={{
-      id: '0',
+      id: 0,
       text: 'Please upgrade your CLI client by running npm update c0d3.',
       type: 'urgent',
       url: 'https://www.npmjs.com/package/c0d3',


### PR DESCRIPTION
Part of #545

# Changes in this PR

- Refactored `alerts` query resolver with Prisma, replacing Sequelize.
- Refactored `alertsController` file with Prisma, replacing Sequelize.
  - Also changed types to use the ones from `graphql/index.tsx`, generated from the query and mutation.
- Change GraphQL's `Alert` type and `removeAlert` mutation to make the id as `Int!` instead of `String!`
  - Updated related React components to use the new type to fix type errors from Typescript.
- Regenerated `graphql/index.tsx` file
- Updated tests

# TODO

- Because the `createdAt` columns in the database tables does not have a default value, currently we need to include it in the entity creation data by calling `new Date()` since it expects a `string` or `Date` value, and `Date.now()` returns a `number`. This requires writing a mutation to add a default value on the tables so we don't need to do that anymore.