### PR TITLE
#close 598 - fix global modal css

### DIFF
--- a/scss/modalImage.module.scss
+++ b/scss/modalImage.module.scss
@@ -1,12 +1,14 @@
-.modal-content {
-  background-color: transparent;
-  border: none;
-}
-.modal-dialog {
-  max-width: 80%;
-  width: 80%;
-  text-align: center;
-}
 .mdx-modal-image {
-  overflow: scroll;
+  .modal-content {
+    background-color: transparent;
+    border: none;
+  }
+  .modal-dialog {
+    max-width: 80%;
+    width: 80%;
+    text-align: center;
+  }
+  .mdx-modal-image {
+    overflow: scroll;
+  }
 }


### PR DESCRIPTION
When #574 was merged it broke global css rules for all other modal images. I added wrapper to my custom styles so stars component should be untouched. 

CSS changes is a weak spot of our current testing system. It's very easy to break something without even noticing. Can it be improved somehow?