### PR TITLE
Remove swr from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "react-feather": "^2.0.9",
     "sass": "^1.32.8",
     "sequelize": "^5.22.3",
-    "swr": "^0.4.2",
     "winston": "^3.3.3",
     "winston-transport-sentry-node": "^1.0.2",
     "yup": "^0.32.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6841,11 +6841,6 @@ deprecated-decorator@^0.1.6:
   resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
   integrity sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=
 
-dequal@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
-  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
-
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -14910,13 +14905,6 @@ swap-case@^2.0.1:
   integrity sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==
   dependencies:
     tslib "^2.0.3"
-
-swr@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-0.4.2.tgz#4a9ed5e9948088af145c79d716d294cb99712a29"
-  integrity sha512-SKGxcAfyijj/lE5ja5zVMDqJNudASH3WZPRUakDVOePTM18FnsXgugndjl9BSRwj+jokFCulMDe7F2pQL+VhEw==
-  dependencies:
-    dequal "2.0.2"
 
 symbol-observable@^1.0.4, symbol-observable@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
`swr` is a React hooks library for data fetching developed by Vercel, it helps in caching data from fetch requests. 

https://swr.vercel.app/

Because we use Apollo Client to work with our API, and because it already does caching for us, this dependency is useless for our project. `swr` is also not used anywhere in the code.

