### PR TITLE
Remove `babel-plugin-inline-react-svg`

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -524,21 +524,13 @@ exports[`Storyshots Components/Card With Fail 1`] = `
     <div
       className="card-body text-center pt-5 pb-5"
     >
-      <svg
+      <img
+        alt="Dark red circle with a exclamation sign inside."
         className="mb-4"
         height="100px"
-        viewBox="0 0 180 180"
+        src="/assets/curriculum/icons/exclamation.svg"
         width="100px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M89 9a81 81 0 102 0 NaN NaNzm1 38v58m0 25v1"
-          fill="none"
-          stroke="#721c24"
-          strokeLinecap="round"
-          strokeWidth="16"
-        />
-      </svg>
+      />
       <h1
         className="card-title h2 font-weight-bold mb-5"
       >
@@ -587,24 +579,13 @@ exports[`Storyshots Components/Card With Success 1`] = `
     <div
       className="card-body text-center pt-5 pb-5"
     >
-      <svg
+      <img
+        alt="Green circle with a checkmark inside."
         className="mb-4"
         height="100px"
-        viewBox="0 0 426.667 426.667"
+        src="/assets/curriculum/icons/checked.svg"
         width="100px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          className="active-path"
-          d="M293.333 135.04L190.08 240.213l-52.907-53.12-28.373 28.374 83.413 83.2 133.974-129.92z"
-          fill="#00CF92"
-        />
-        <path
-          className="active-path"
-          d="M213.333 0C95.513 0 0 95.513 0 213.333s95.513 213.333 213.333 213.333 213.333-95.513 213.333-213.333S331.154 0 213.333 0zm0 388.053c-96.495 0-174.72-78.225-174.72-174.72s78.225-174.72 174.72-174.72c96.446.117 174.602 78.273 174.72 174.72 0 96.496-78.224 174.72-174.72 174.72z"
-          fill="#00CF92"
-        />
-      </svg>
+      />
       <h1
         className="card-title h2 font-weight-bold mb-5"
       >
@@ -9652,24 +9633,13 @@ exports[`Storyshots Pages/Signup Signup Success 1`] = `
     <div
       className="card-body text-center pt-5 pb-5"
     >
-      <svg
+      <img
+        alt="Green circle with a checkmark inside."
         className="mb-4"
         height="100px"
-        viewBox="0 0 426.667 426.667"
+        src="/assets/curriculum/icons/checked.svg"
         width="100px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          className="active-path"
-          d="M293.333 135.04L190.08 240.213l-52.907-53.12-28.373 28.374 83.413 83.2 133.974-129.92z"
-          fill="#00CF92"
-        />
-        <path
-          className="active-path"
-          d="M213.333 0C95.513 0 0 95.513 0 213.333s95.513 213.333 213.333 213.333 213.333-95.513 213.333-213.333S331.154 0 213.333 0zm0 388.053c-96.495 0-174.72-78.225-174.72-174.72s78.225-174.72 174.72-174.72c96.446.117 174.602 78.273 174.72 174.72 0 96.496-78.224 174.72-174.72 174.72z"
-          fill="#00CF92"
-        />
-      </svg>
+      />
       <h1
         className="card-title h2 font-weight-bold mb-5"
       >

--- a/__tests__/pages/__snapshots__/forgotpassword.test.js.snap
+++ b/__tests__/pages/__snapshots__/forgotpassword.test.js.snap
@@ -237,24 +237,13 @@ exports[`ForgotPassword Page Should render password reset instructions on succes
         <div
           class="card-body text-center pt-5 pb-5"
         >
-          <svg
+          <img
+            alt="Green circle with a checkmark inside."
             class="mb-4"
             height="100px"
-            viewBox="0 0 426.667 426.667"
+            src="/assets/curriculum/icons/checked.svg"
             width="100px"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="active-path"
-              d="M293.333 135.04L190.08 240.213l-52.907-53.12-28.373 28.374 83.413 83.2 133.974-129.92z"
-              fill="#00CF92"
-            />
-            <path
-              class="active-path"
-              d="M213.333 0C95.513 0 0 95.513 0 213.333s95.513 213.333 213.333 213.333 213.333-95.513 213.333-213.333S331.154 0 213.333 0zm0 388.053c-96.495 0-174.72-78.225-174.72-174.72s78.225-174.72 174.72-174.72c96.446.117 174.602 78.273 174.72 174.72 0 96.496-78.224 174.72-174.72 174.72z"
-              fill="#00CF92"
-            />
-          </svg>
+          />
           <h1
             class="card-title h2 font-weight-bold mb-5"
           >

--- a/__tests__/pages/__snapshots__/reset.test.js.snap
+++ b/__tests__/pages/__snapshots__/reset.test.js.snap
@@ -90,21 +90,13 @@ exports[`ResetPassword Page Should render alert on error 1`] = `
         <div
           class="card-body text-center pt-5 pb-5"
         >
-          <svg
+          <img
+            alt="Dark red circle with a exclamation sign inside."
             class="mb-4"
             height="100px"
-            viewBox="0 0 180 180"
+            src="/assets/curriculum/icons/exclamation.svg"
             width="100px"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M89 9a81 81 0 102 0 NaN NaNzm1 38v58m0 25v1"
-              fill="none"
-              stroke="#721c24"
-              stroke-linecap="round"
-              stroke-width="16"
-            />
-          </svg>
+          />
           <h1
             class="card-title h2 font-weight-bold mb-5"
           >
@@ -223,24 +215,13 @@ exports[`ResetPassword Page Should render confirm success on success 1`] = `
         <div
           class="card-body text-center pt-5 pb-5"
         >
-          <svg
+          <img
+            alt="Green circle with a checkmark inside."
             class="mb-4"
             height="100px"
-            viewBox="0 0 426.667 426.667"
+            src="/assets/curriculum/icons/checked.svg"
             width="100px"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="active-path"
-              d="M293.333 135.04L190.08 240.213l-52.907-53.12-28.373 28.374 83.413 83.2 133.974-129.92z"
-              fill="#00CF92"
-            />
-            <path
-              class="active-path"
-              d="M213.333 0C95.513 0 0 95.513 0 213.333s95.513 213.333 213.333 213.333 213.333-95.513 213.333-213.333S331.154 0 213.333 0zm0 388.053c-96.495 0-174.72-78.225-174.72-174.72s78.225-174.72 174.72-174.72c96.446.117 174.602 78.273 174.72 174.72 0 96.496-78.224 174.72-174.72 174.72z"
-              fill="#00CF92"
-            />
-          </svg>
+          />
           <h1
             class="card-title h2 font-weight-bold mb-5"
           >

--- a/__tests__/pages/__snapshots__/signup.test.js.snap
+++ b/__tests__/pages/__snapshots__/signup.test.js.snap
@@ -269,24 +269,13 @@ exports[`Signup Page Should render success component on success 1`] = `
         <div
           class="card-body text-center pt-5 pb-5"
         >
-          <svg
+          <img
+            alt="Green circle with a checkmark inside."
             class="mb-4"
             height="100px"
-            viewBox="0 0 426.667 426.667"
+            src="/assets/curriculum/icons/checked.svg"
             width="100px"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="active-path"
-              d="M293.333 135.04L190.08 240.213l-52.907-53.12-28.373 28.374 83.413 83.2 133.974-129.92z"
-              fill="#00CF92"
-            />
-            <path
-              class="active-path"
-              d="M213.333 0C95.513 0 0 95.513 0 213.333s95.513 213.333 213.333 213.333 213.333-95.513 213.333-213.333S331.154 0 213.333 0zm0 388.053c-96.495 0-174.72-78.225-174.72-174.72s78.225-174.72 174.72-174.72c96.446.117 174.602 78.273 174.72 174.72 0 96.496-78.224 174.72-174.72 174.72z"
-              fill="#00CF92"
-            />
-          </svg>
+          />
           <h1
             class="card-title h2 font-weight-bold mb-5"
           >

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,21 +1,3 @@
-const inlineReactSvg = [
-  // We are disabling svg optimization because it breaks tests.
-  // Issue: https://github.com/garageScript/c0d3-app/issues/104
-  'inline-react-svg',
-  {
-    svgo: {
-      plugins: [
-        {
-          removeAttrs: { attrs: '(data-name)' }
-        },
-        {
-          cleanupIDs: true
-        }
-      ]
-    }
-  }
-]
-
 const prismJs = [
   'prismjs',
   {
@@ -29,5 +11,5 @@ module.exports = {
     '@babel/preset-react',
     '@babel/preset-typescript'
   ],
-  plugins: [inlineReactSvg, prismJs, '@babel/syntax-dynamic-import']
+  plugins: [prismJs, '@babel/syntax-dynamic-import']
 }

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,25 +1,28 @@
 import React from 'react'
-import { ReactComponent as Checked } from '../public/assets/curriculum/icons/checked.svg'
-import { ReactComponent as Fail } from '../public/assets/curriculum/icons/exclamation.svg'
 
 type Props = {
   primary?: boolean
-  children?: React.ReactNode
   type?: 'success' | 'fail'
   text?: string
   classes?: string
   title: string
 }
 
-const iconProps: { [type: string]: string } = {
+const iconProps = {
   className: 'mb-4',
   width: '100px',
   height: '100px'
 }
 
-const icons: { [type: string]: React.FC } = {
-  success: Checked,
-  fail: Fail
+const icons = {
+  success: {
+    src: '/assets/curriculum/icons/checked.svg',
+    alt: 'Green circle with a checkmark inside.'
+  },
+  fail: {
+    src: '/assets/curriculum/icons/exclamation.svg',
+    alt: 'Dark red circle with a exclamation sign inside.'
+  }
 }
 
 const Card: React.FC<Props> = ({
@@ -32,15 +35,15 @@ const Card: React.FC<Props> = ({
 }) => {
   const classesList =
     classes || 'col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0'
-  const Icon = type ? icons[type] : null
   const titleClasses =
     'card-title h2 font-weight-bold mb-5' + (primary ? ' text-primary' : '')
+  const icon = type && icons[type]
 
   return (
     <div className="row mt-5">
       <div className={`card shadow-sm ${classesList}`}>
         <div className="card-body text-center pt-5 pb-5">
-          {Icon && <Icon {...iconProps} />}
+          {icon && <img src={icon.src} alt={icon.alt} {...iconProps} />}
           <h1 className={titleClasses}>{title}</h1>
           <p className="card-text">{text}</p>
           {children}

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "@typescript-eslint/parser": "^4.20.0",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
-    "babel-plugin-inline-react-svg": "^1.1.2",
     "babel-plugin-prismjs": "^2.0.1",
     "babel-preset-react-app": "^10.0.0",
     "eslint": "^7.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4969,17 +4969,6 @@ babel-plugin-extract-import-names@1.6.22:
   dependencies:
     "@babel/helper-plugin-utils" "7.10.4"
 
-babel-plugin-inline-react-svg@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-1.1.2.tgz#f2090de7404982deaeb5d7ac9c16078a61ca6486"
-  integrity sha512-oDR/eraFbMtvg4bDxv4W8bQWTDxLVkKpIYKx0cey/J2QqFyogyQOvEz9SjSYmNK3jI+yZdVMAshTwkKnj6J/Aw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/parser" "^7.0.0"
-    lodash.isplainobject "^4.0.6"
-    resolve "^1.10.0"
-    svgo "^0.7.2"
-
 babel-plugin-istanbul@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
@@ -6017,13 +6006,6 @@ cjs-module-lexer@^0.6.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"
   integrity sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==
 
-clap@^1.0.9:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"
-  integrity sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==
-  dependencies:
-    chalk "^1.1.3"
-
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -6148,13 +6130,6 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-coa@~1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.4.tgz#a9ef153660d6a86a8bdec0289a5c684d217432fd"
-  integrity sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=
-  dependencies:
-    q "^1.1.2"
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -6227,11 +6202,6 @@ colors@^1.1.2, colors@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
-colors@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
-  integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
 
 colorspace@1.1.x:
   version "1.1.2"
@@ -6706,14 +6676,6 @@ csso@^4.2.0:
   integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
     css-tree "^1.1.2"
-
-csso@~2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-2.3.2.tgz#ddd52c587033f49e94b71fc55569f252e8ff5f85"
-  integrity sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=
-  dependencies:
-    clap "^1.0.9"
-    source-map "^0.5.3"
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -7662,11 +7624,6 @@ esprima@3.x.x:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
-
-esprima@^2.6.0:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
-  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -10379,14 +10336,6 @@ js-yaml@^4.0.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@~3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
-  integrity sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
-
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -11524,7 +11473,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -13037,11 +12986,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-q@^1.1.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
-  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
-
 qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
@@ -14069,7 +14013,7 @@ sass@^1.32.8:
   dependencies:
     chokidar ">=2.0.0 <4.0.0"
 
-sax@^1.2.4, sax@~1.2.1:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -14503,7 +14447,7 @@ source-map@0.8.0-beta.0:
   dependencies:
     whatwg-url "^7.0.0"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -14989,19 +14933,6 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
-
-svgo@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
-  integrity sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=
-  dependencies:
-    coa "~1.0.1"
-    colors "~1.1.2"
-    csso "~2.3.1"
-    js-yaml "~3.7.0"
-    mkdirp "~0.5.1"
-    sax "~1.2.1"
-    whet.extend "~0.9.9"
 
 svgo@^2.3.0:
   version "2.3.0"
@@ -16163,11 +16094,6 @@ whatwg-url@^8.0.0:
     lodash "^4.7.0"
     tr46 "^2.0.2"
     webidl-conversions "^6.1.0"
-
-whet.extend@~0.9.9:
-  version "0.9.9"
-  resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
-  integrity sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=
 
 which-boxed-primitive@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Removed the [`babel-plugin-inline-react-svg`](https://github.com/airbnb/babel-plugin-inline-react-svg) dependency since it was being used basically for a single component: `Card`.

Replaced the inline svgs for the card icons with `<img></img>` tags.

That plugin is used to generate inline SVGs when transpiling with Babel, while also applying optimizations to the SVG image. But since we already have all our SVGs optimized with `svgo` this plugin is kinda useless. The `img` tag also helps with accessibility by having the `alt` attribute.