### PR TITLE
[Migration] Change user `isAdmin` column type to boolean

### DIFF
--- a/__dummy__/sessionData.js
+++ b/__dummy__/sessionData.js
@@ -3,7 +3,7 @@ export default {
     id: 1,
     username: 'fakeusername',
     name: 'fake user',
-    isAdmin: 'true'
+    isAdmin: true
   },
   submissions: [],
   lessonStatus: []

--- a/__tests__/pages/admin/users.test.js
+++ b/__tests__/pages/admin/users.test.js
@@ -18,7 +18,7 @@ const dummyUsersData = [
     cliToken: 'WRyzWxDc_DqR3Avi7xcGD',
     email: 'some@mail.com',
     id: '5',
-    isAdmin: 'true',
+    isAdmin: true,
     name: 'admin admin',
     username: 'admin'
   },
@@ -26,7 +26,7 @@ const dummyUsersData = [
     cliToken: 'acRy_p-HK9sTU8H1GfrJV',
     email: 'some@mail.com',
     id: '6',
-    isAdmin: 'false',
+    isAdmin: false,
     name: 'newbie newbie',
     username: 'newbie',
     id: '2'

--- a/__tests__/pages/profile/username.test.js
+++ b/__tests__/pages/profile/username.test.js
@@ -124,7 +124,7 @@ describe('user profile test', () => {
         id: 1,
         username: 'fakeusername',
         name: '',
-        isAdmin: 'true'
+        isAdmin: true
       }
     }
     const mocks = [

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -42,7 +42,7 @@ const navItems: NavItem[] = [
 
 const NavBar: React.FC<AuthLinkProps> = ({ session }) => {
   const router = useRouter()
-  const isAdmin = _.get(session, 'user.isAdmin', '')
+  const isAdmin = _.get(session, 'user.isAdmin', false) as boolean
   const location = '/' + router.asPath.split('/')[1]
 
   return (
@@ -57,9 +57,7 @@ const NavBar: React.FC<AuthLinkProps> = ({ session }) => {
           {button.name}
         </NavLink>
       ))}
-      {isAdmin === 'true' && (
-        <DropdownMenu title="Admin" items={dropdownMenuItems} />
-      )}
+      {isAdmin && <DropdownMenu title="Admin" items={dropdownMenuItems} />}
     </div>
   )
 }

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -3,7 +3,7 @@ import NavLink, { NavLinkProps } from './NavLink'
 import { Button } from './theme/Button'
 import { useRouter } from 'next/router'
 import { DropdownMenu } from './DropdownMenu'
-import { useLogoutMutation, useGetAppQuery, Session } from '../graphql'
+import { useLogoutMutation, useGetAppQuery, GetAppQuery } from '../graphql'
 import _ from 'lodash'
 import styles from '../scss/appNav.module.scss'
 
@@ -111,7 +111,9 @@ const UnAuthButton = () => (
 )
 
 const AppNav: React.FC<{}> = () => {
-  const [session, setSession] = useState<Session>({ lessonStatus: [] })
+  const [session, setSession] = useState<GetAppQuery['session']>({
+    lessonStatus: []
+  })
   const { data } = useGetAppQuery()
   useEffect(() => {
     if (data && data.session) {

--- a/components/admin/AdminLayout.test.js
+++ b/components/admin/AdminLayout.test.js
@@ -35,7 +35,7 @@ describe('AdminLayout test', () => {
           data={{
             session: {
               user: {
-                isAdmin: 'true'
+                isAdmin: true
               }
             }
           }}

--- a/components/admin/AdminLayout.tsx
+++ b/components/admin/AdminLayout.tsx
@@ -19,9 +19,9 @@ export const AdminLayout: React.FC<GetAppProps> = ({ data, children }) => {
 
   if (!session) router.push('/login')
 
-  const isAdmin = _.get(session, 'user.isAdmin', false)
+  const isAdmin = _.get(session, 'user.isAdmin', false) as boolean
 
-  if (isAdmin !== 'true') {
+  if (!isAdmin) {
     return (
       <Layout>
         <h1>You must be admin to access this page</h1>

--- a/components/admin/users/AdminUsersTable.test.js
+++ b/components/admin/users/AdminUsersTable.test.js
@@ -8,7 +8,7 @@ const dummyUsersData = [
     cliToken: 'WRyzWxDc_DqR3Avi7xcGD',
     email: 'some@mail.com',
     id: 5,
-    isAdmin: 'true',
+    isAdmin: true,
     name: 'admin admin',
     username: 'admin'
   },
@@ -16,7 +16,7 @@ const dummyUsersData = [
     cliToken: 'acRy_p-HK9sTU8H1GfrJV',
     email: 'some@mail.com',
     id: 6,
-    isAdmin: 'false',
+    isAdmin: false,
     name: 'newbie newbie',
     username: 'newbie'
   }
@@ -26,7 +26,7 @@ const mocks = [
   {
     request: {
       query: CHANGE_ADMIN_RIGHTS,
-      variables: { id: 6, status: 'true' }
+      variables: { id: 6, status: true }
     },
     result: {
       data: { changeAdminRights: { success: true } }
@@ -42,7 +42,7 @@ describe('AdminUsersTable test', () => {
           users={dummyUsersData}
           searchOption={{
             option: 'username',
-            admin: 'None',
+            admin: undefined,
             searchTerm: ''
           }}
           setUsers={jest.fn()}
@@ -61,8 +61,8 @@ describe('AdminUsersTable test', () => {
           users={dummyUsersData}
           searchOption={{
             option: 'username',
-            admin: 'Non-Admins',
-            searchTerm: 'admin'
+            admin: false,
+            searchTerm: ''
           }}
           setUsers={jest.fn()}
         />
@@ -77,8 +77,8 @@ describe('AdminUsersTable test', () => {
           users={dummyUsersData}
           searchOption={{
             option: 'username',
-            admin: 'Admins',
-            searchTerm: 'newbie'
+            admin: true,
+            searchTerm: ''
           }}
           setUsers={jest.fn()}
         />
@@ -93,7 +93,7 @@ describe('AdminUsersTable test', () => {
           users={dummyUsersData}
           searchOption={{
             option: 'username',
-            admin: 'None',
+            admin: undefined,
             searchTerm: 'newbie'
           }}
           setUsers={jest.fn()}

--- a/components/admin/users/AdminUsersTable.tsx
+++ b/components/admin/users/AdminUsersTable.tsx
@@ -91,7 +91,7 @@ const RowData: React.FC<RowDataProps> = ({
     if (property === 'isAdmin')
       value = (
         <AdminOption
-          isAdmin={user[property] === 'true'}
+          isAdmin={user[property]}
           setUsers={setUsers}
           usersIndex={usersIndex}
           users={users}
@@ -115,26 +115,20 @@ const UsersList: React.FC<UsersListProps> = ({
   searchOption
 }) => {
   const { searchTerm, admin } = searchOption
-  let { option } = searchOption
-  option = option.toLowerCase()
+  const option: any = searchOption.option.toLowerCase()
 
   // usersIndex is needed for the RowData component to function properly
   const usersListIndex: any = []
+  const searchTermRegex = new RegExp(searchTerm.toLowerCase(), 'i')
 
   // remove all users from list that are not going to be rendered
-  const list: User[] = users.filter((user: any, usersIndex: number) => {
+  const list: User[] = users.filter((user: any, usersIndex) => {
     let bool = true
 
-    /* 
-      Need to make searchTerm and value of user[option] lowercase, 
-      to ensure both lower and uppercase characters can be searched for
-    */
-    const lowerCaseSearchTerm = searchTerm.toLowerCase()
-    const lowerCaseOptionValue = user[option].toLowerCase()
-
-    if (searchTerm) bool = lowerCaseOptionValue.includes(lowerCaseSearchTerm)
-    if (bool && admin === 'Non-Admins') bool = user.isAdmin === 'false'
-    if (bool && admin === 'Admins') bool = user.isAdmin === 'true'
+    if (searchTerm) bool = searchTermRegex.test(user[option])
+    if (bool && admin !== undefined) {
+      bool = admin === user.isAdmin
+    }
 
     bool && usersListIndex.push(usersIndex)
     return bool

--- a/components/admin/users/AdminUsersTable.tsx
+++ b/components/admin/users/AdminUsersTable.tsx
@@ -48,7 +48,7 @@ const AdminOption: React.FC<AdminOptionProps> = ({
 }) => {
   const [changeRights] = useMutation(changeAdminRights)
 
-  const newAdminRights = isAdmin ? 'false' : 'true'
+  const newAdminRights = !isAdmin
 
   const mutationVariable = {
     variables: {

--- a/components/admin/users/__snapshots__/AdminUsersTable.test.js.snap
+++ b/components/admin/users/__snapshots__/AdminUsersTable.test.js.snap
@@ -294,7 +294,42 @@ exports[`AdminUsersTable test Should search by admin role 1`] = `
         </th>
       </tr>
     </thead>
-    <tbody />
+    <tbody>
+      <tr
+        class="text-center"
+      >
+        <td
+          class="align-middle"
+        >
+          5
+        </td>
+        <td
+          class="align-middle"
+        >
+          admin
+        </td>
+        <td
+          class="align-middle"
+        >
+          admin admin
+        </td>
+        <td
+          class="align-middle"
+        >
+          some@mail.com
+        </td>
+        <td
+          class="align-middle"
+        >
+          <button
+            class="btn bg-danger"
+            style="color: rgb(41, 41, 41);"
+          >
+            Remove
+          </button>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </div>
 `;
@@ -325,7 +360,42 @@ exports[`AdminUsersTable test Should search by non-admin role 1`] = `
         </th>
       </tr>
     </thead>
-    <tbody />
+    <tbody>
+      <tr
+        class="text-center"
+      >
+        <td
+          class="align-middle"
+        >
+          6
+        </td>
+        <td
+          class="align-middle"
+        >
+          newbie
+        </td>
+        <td
+          class="align-middle"
+        >
+          newbie newbie
+        </td>
+        <td
+          class="align-middle"
+        >
+          some@mail.com
+        </td>
+        <td
+          class="align-middle"
+        >
+          <button
+            class="btn bg-success"
+            style="color: rgb(41, 41, 41);"
+          >
+            Add
+          </button>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </div>
 `;

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -118,7 +118,7 @@ export type MutationChangePwArgs = {
 
 export type MutationChangeAdminRightsArgs = {
   id: Scalars['Int']
-  status: Scalars['String']
+  status: Scalars['Boolean']
 }
 
 export type MutationSignupArgs = {
@@ -342,7 +342,7 @@ export type UsersQuery = { __typename?: 'Query' } & {
 
 export type ChangeAdminRightsMutationVariables = Exact<{
   id: Scalars['Int']
-  status: Scalars['String']
+  status: Scalars['Boolean']
 }>
 
 export type ChangeAdminRightsMutation = { __typename?: 'Mutation' } & {
@@ -1611,7 +1611,7 @@ export type UsersQueryResult = Apollo.QueryResult<
   UsersQueryVariables
 >
 export const ChangeAdminRightsDocument = gql`
-  mutation changeAdminRights($id: Int!, $status: String!) {
+  mutation changeAdminRights($id: Int!, $status: Boolean!) {
     changeAdminRights(id: $id, status: $status) {
       success
     }

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -275,7 +275,7 @@ export type User = {
   userLesson?: Maybe<UserLesson>
   email?: Maybe<Scalars['String']>
   name?: Maybe<Scalars['String']>
-  isAdmin?: Maybe<Scalars['String']>
+  isAdmin: Scalars['Boolean']
   cliToken?: Maybe<Scalars['String']>
 }
 
@@ -1291,7 +1291,7 @@ export type UserResolvers<
   >
   email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  isAdmin?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  isAdmin?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
   cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }

--- a/graphql/queries/changeAdminRights.ts
+++ b/graphql/queries/changeAdminRights.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 const CHANGE_ADMIN_RIGHTS = gql`
-  mutation changeAdminRights($id: Int!, $status: String!) {
+  mutation changeAdminRights($id: Int!, $status: Boolean!) {
     changeAdminRights(id: $id, status: $status) {
       success
     }

--- a/graphql/queryResolvers/allUsers.test.js
+++ b/graphql/queryResolvers/allUsers.test.js
@@ -14,7 +14,7 @@ const mockUsers = [
 
 const ctx = {
   req: {
-    user: { isAdmin: 'true' }
+    user: { isAdmin: true }
   }
 }
 
@@ -27,7 +27,7 @@ describe('allUsers resolver', () => {
   })
 
   test('Should return null when user is not an admin when querying allUsers', () => {
-    ctx.req.user.isAdmin = 'false'
+    ctx.req.user.isAdmin = false
     expect(allUsers(null, null, ctx)).toBeNull
   })
 })

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -23,7 +23,7 @@ export default gql`
     logout: AuthResponse
     reqPwReset(userOrEmail: String!): TokenResponse
     changePw(token: String!, password: String!): AuthResponse
-    changeAdminRights(id: Int!, status: String!): SuccessResponse
+    changeAdminRights(id: Int!, status: Boolean!): SuccessResponse
     signup(
       firstName: String!
       lastName: String!

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -116,7 +116,7 @@ export default gql`
     userLesson: UserLesson
     email: String
     name: String
-    isAdmin: String
+    isAdmin: Boolean!
     cliToken: String
   }
 

--- a/helpers/controllers/adminController.test.js
+++ b/helpers/controllers/adminController.test.js
@@ -1,28 +1,26 @@
-jest.mock('../dbload')
 jest.mock('../mattermost')
-import db from '../dbload'
+import { prisma } from '../../prisma'
 import { changeAdminRights } from './adminController'
-
-const { User } = db
 
 const mockUser = { username: 'penelope', status: true }
 
 describe('Admin controller tests', () => {
   const ctx = {
     req: {
-      user: { isAdmin: 'true' }
+      user: { isAdmin: true }
     }
   }
 
+  prisma.user.update = jest.fn().mockResolvedValue(true)
+
   test('Should change admin rights', async () => {
-    User.update = jest.fn().mockReturnValue(true)
     expect(changeAdminRights(null, mockUser, ctx)).resolves.toEqual({
       success: true
     })
   })
 
   test('Should throw error when user is not an admin', async () => {
-    ctx.req.user.isAdmin = 'false'
+    ctx.req.user.isAdmin = false
     expect(changeAdminRights(null, mockUser, ctx)).rejects.toThrowError(
       'User is not an admin'
     )

--- a/helpers/controllers/adminController.ts
+++ b/helpers/controllers/adminController.ts
@@ -1,18 +1,12 @@
-import db from '../dbload'
 import { Context } from '../../@types/helpers'
 import _ from 'lodash'
 import { isAdmin } from '../isAdmin'
-
-const { User } = db
-
-type adminData = {
-  id: number
-  status: string
-}
+import { ChangeAdminRightsMutationVariables } from '../../graphql'
+import { prisma } from '../../prisma'
 
 export const changeAdminRights = async (
   _parent: void,
-  arg: adminData,
+  arg: ChangeAdminRightsMutationVariables,
   ctx: Context
 ) => {
   const { req } = ctx
@@ -23,7 +17,7 @@ export const changeAdminRights = async (
 
     const { id, status } = arg
 
-    await User.update({ isAdmin: status }, { where: { id } })
+    await prisma.user.update({ where: { id }, data: { isAdmin: status } })
 
     return {
       success: true

--- a/helpers/controllers/alertController.test.js
+++ b/helpers/controllers/alertController.test.js
@@ -11,7 +11,7 @@ const context = {
     warn: jest.fn(),
     error: jest.fn(),
     session: {},
-    user: { isAdmin: 'true' }
+    user: { isAdmin: true }
   }
 }
 
@@ -59,13 +59,13 @@ describe('Alert controller tests', () => {
     )
   })
   test('Should throw Error when user is not an admin when adding Alert', async () => {
-    ctx.req.user.isAdmin = 'false'
+    ctx.req.user.isAdmin = false
     expect(
       addAlert({}, { url: 'https://google.com' }, ctx)
     ).rejects.toThrowError('User is not an admin')
   })
   test('Should throw Error when user is not an admin when removing Alert', async () => {
-    ctx.req.user.isAdmin = 'false'
+    ctx.req.user.isAdmin = false
     expect(
       removeAlert({}, { url: 'https://google.com' }, ctx)
     ).rejects.toThrowError('User is not an admin')

--- a/helpers/controllers/challengesController.test.js
+++ b/helpers/controllers/challengesController.test.js
@@ -27,7 +27,7 @@ describe('Challenges controller tests', () => {
   })
   const ctx = {
     req: {
-      user: { isAdmin: 'true' }
+      user: { isAdmin: true }
     }
   }
 
@@ -67,7 +67,7 @@ describe('Challenges controller tests', () => {
 
   test('Should throw "User is not admin" error if user is not an admin \
   when updating challenge', async () => {
-    ctx.req.user.isAdmin = 'false'
+    ctx.req.user.isAdmin = false
     await expect(
       updateChallenge(null, mockChallengeData, ctx)
     ).rejects.toThrowError('User is not an admin')
@@ -75,7 +75,7 @@ describe('Challenges controller tests', () => {
 
   test('Should throw "User is not an admin" error if user is not an admin when \
   creating challenge', async () => {
-    ctx.req.user.isAdmin = 'false'
+    ctx.req.user.isAdmin = false
     await expect(
       createChallenge(null, mockChallengeData, ctx)
     ).rejects.toThrowError('User is not an admin')

--- a/helpers/controllers/lessonsController.test.js
+++ b/helpers/controllers/lessonsController.test.js
@@ -33,7 +33,7 @@ describe('Lessons controller tests', () => {
   })
   const ctx = {
     req: {
-      user: { isAdmin: 'true' }
+      user: { isAdmin: true }
     }
   }
 
@@ -58,14 +58,14 @@ describe('Lessons controller tests', () => {
   })
 
   test('Should throw "User is not an admin" error when user is not an admin when updating lesson', async () => {
-    ctx.req.user.isAdmin = 'false'
+    ctx.req.user.isAdmin = false
     await expect(createLesson(null, mockLessonData, ctx)).rejects.toThrowError(
       'User is not an admin'
     )
   })
 
   test('Should throw "User is not an admin" error when user is not an admin when creating lesson', async () => {
-    ctx.req.user.isAdmin = 'false'
+    ctx.req.user.isAdmin = false
     await expect(updateLesson(null, mockLessonData, ctx)).rejects.toThrowError(
       'User is not an admin'
     )

--- a/helpers/isAdmin.ts
+++ b/helpers/isAdmin.ts
@@ -1,6 +1,5 @@
 import { LoggedRequest } from '../@types/helpers'
 import _ from 'lodash'
 
-export const isAdmin = (req: LoggedRequest) => {
-  return _.get(req, 'user.isAdmin', false) === 'true'
-}
+export const isAdmin = (req: LoggedRequest) =>
+  _.get(req, 'user.isAdmin', false) as boolean

--- a/helpers/middleware/user.test.js
+++ b/helpers/middleware/user.test.js
@@ -10,7 +10,7 @@ const mockUserInfo = {
     username: 'moreThanFake',
     password: '$2b$10$W9KwQ6Sbi0RJjD2GZYX9BugAtgSm/W999gNW1f/XiRcI6NiC9pTdK',
     email: 'superduperkamehameha@gmail.com',
-    isAdmin: 'false',
+    isAdmin: false,
     cliToken: 'KfizzIlWp111fizzDbuzzr'
   }
 }

--- a/helpers/models/User.ts
+++ b/helpers/models/User.ts
@@ -26,7 +26,7 @@ export const UserTypes = {
   gsId: DataTypes.INTEGER,
   isOnline: DataTypes.BOOLEAN,
   isAdmin: {
-    type: DataTypes.STRING,
+    type: DataTypes.BOOLEAN,
     defaultValue: false
   },
   forgotToken: DataTypes.STRING,

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -18,17 +18,17 @@ type AllUsersData = {
 
 export type filter = {
   option: string
-  admin: string
+  admin?: boolean
   searchTerm: string
 }
 
 const initialSearchOptions: filter = {
   option: 'Username',
-  admin: 'None',
+  admin: undefined,
   searchTerm: ''
 }
 
-const adminFilters = ['Admins', 'Non-Admins', 'None']
+const adminFilters = { Admins: true, 'Non-Admins': false, None: undefined }
 
 const searchHeaders = [...headerTitles]
 
@@ -53,9 +53,9 @@ const AdminUsers: React.FC<QueryDataProps<AllUsersData>> = ({ queryData }) => {
     run(newSearchOption)
   }
 
-  const changeFilter = (str: string, type: string) => {
+  const changeFilter = (value: string | boolean | undefined, type: string) => {
     const newSearchOption: any = { ...searchOption }
-    newSearchOption[type] = str
+    newSearchOption[type] = value
     setSearchOption(newSearchOption)
   }
 
@@ -80,10 +80,22 @@ const AdminUsers: React.FC<QueryDataProps<AllUsersData>> = ({ queryData }) => {
         onChange={handleChange}
       />
       <div className="mt-2 mb-2">
+        {/*
+         * TODO this is very ugly but it is what worked,
+         * definetely could use some refactoring
+         */}
         <FilterButtons
-          options={adminFilters}
-          onClick={(value: string) => changeFilter(value, 'admin')}
-          currentOption={searchOption.admin}
+          options={Object.keys(adminFilters)}
+          onClick={(value: keyof typeof adminFilters) =>
+            changeFilter(adminFilters[value], 'admin')
+          }
+          currentOption={
+            Object.keys(adminFilters).find(
+              k =>
+                adminFilters[k as keyof typeof adminFilters] ===
+                searchOption.admin
+            )!
+          }
         >
           Filter By:
         </FilterButtons>

--- a/prisma/migrations/20210410201232_user_isAdmin_boolean/migration.sql
+++ b/prisma/migrations/20210410201232_user_isAdmin_boolean/migration.sql
@@ -1,0 +1,9 @@
+-- Alter table changing the column type, converting the values to booleans
+ALTER TABLE "users" ALTER COLUMN "isAdmin" TYPE boolean
+USING CASE "isAdmin" WHEN 'true' THEN TRUE ELSE FALSE END;
+
+-- Set the default value for the column
+ALTER TABLE "users" ALTER COLUMN "isAdmin" SET DEFAULT false;
+
+-- Make the column not nullable
+ALTER TABLE "users" ALTER COLUMN "isAdmin" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,7 +121,7 @@ model User {
   isOnline               Boolean?
   createdAt              DateTime     @default(now()) @db.Timestamptz(6)
   updatedAt              DateTime     @updatedAt @db.Timestamptz(6)
-  isAdmin                String?      @default(dbgenerated("false")) @db.VarChar(255)
+  isAdmin                Boolean      @default(false)
   forgotToken            String?      @db.VarChar(255)
   cliToken               String?      @db.VarChar(255)
   emailVerificationToken String?      @db.VarChar(255)

--- a/stories/pages/Curriculum.stories.tsx
+++ b/stories/pages/Curriculum.stories.tsx
@@ -60,7 +60,7 @@ export const CompletedLessons: React.FC<{}> = () => {
       id: 1,
       username: 'fakeusername',
       name: 'fake user',
-      isAdmin: 'true'
+      isAdmin: true
     },
     submissions: [],
     lessonStatus: [


### PR DESCRIPTION
Part of #545

The time has finally come to fix this stupid thing! We had enough about this boolean being saved as a string! A real boolean should be `true` and not `'true'`!

Jokes aside, here's what this PR does:

- Added a migration to convert the `isAdmin` column to a boolean, also converting the values to the corresponding boolean ones, and set the column to `NOT NULL` too.
- Changed the Prisma schema and Sequelize model to reflect this change.
- Updated the `User` type-def for GraphQL too, and regenerated the `index.tsx` file.
- Fixed the type errors that came up after this.
- Fixed the admin/users page.
  - Filtering stopped working after the type change.
  - Made a kind of a ugly fix around this, the admin components definitively could use some refactoring.
  - Also simplified the filtering a little bit.
  - **The tests didn't catch that this page was broken**, gotta pay more attention to this.