### PR TITLE
update #669 - fix curriculum page

### DIFF
--- a/__tests__/pages/curriculum/[lesson].test.js
+++ b/__tests__/pages/curriculum/[lesson].test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { render, waitFor, screen } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import GET_APP from '../../../graphql/queries/getApp'
 import Lesson from '../../../pages/curriculum/[lesson]'
@@ -166,5 +166,30 @@ describe('Lesson Page', () => {
     expect(element).toBeTruthy()
 
     await waitFor(() => expect(container).toMatchSnapshot())
+  })
+  test('Should render with nulled submissions', async () => {
+    query['lesson'] = '2'
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session: { ...session, submissions: null },
+            lessons: dummyLessonData,
+            alerts: dummyAlertData
+          }
+        }
+      }
+    ]
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Lesson />
+      </MockedProvider>
+    )
+
+    await waitFor(() =>
+      screen.getByRole('heading', { name: /Variables & Functions/i })
+    )
   })
 })

--- a/pages/curriculum/[lesson].tsx
+++ b/pages/curriculum/[lesson].tsx
@@ -27,7 +27,8 @@ const Challenges: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
   if (!currentLesson) {
     return <Error code={StatusCode.NOT_FOUND} message="Lesson not found" />
   }
-  const userSubmissions: UserSubmission[] = _.get(session, 'submissions', [])
+  const userSubmissions: UserSubmission[] =
+    _.get(session, 'submissions', []) || []
   const lessonStatus: LessonStatus[] = _.get(session, 'lessonStatus', [])
 
   const currentLessonStatus: LessonStatus = lessonStatus.find(


### PR DESCRIPTION
Quick fix to make curriculum page usable. Go to `https://www.c0d3.com/curriculum/2` in production and on[ Vercel](https://c0d3-app-hwbxydymg-c0d3.vercel.app/curriculum/2). Prod is broken, Vercel works. 

I'll figure out what was causing it later.  