### PR TITLE
update #677 - add separate aws config

### DIFF
--- a/helpers/dbload.ts
+++ b/helpers/dbload.ts
@@ -7,6 +7,7 @@ import { ChallengeTypes, Challenge } from './models/Challenge'
 import { AlertTypes, Alert } from './models/Alert'
 import { StarTypes, Star } from './models/Star'
 
+/* istanbul ignore next */
 const sequelize = new Sequelize(
   process.env.DB_NAME as string,
   process.env.DB_USER as string,
@@ -17,10 +18,10 @@ const sequelize = new Sequelize(
     port: parseInt(process.env.DB_PORT as string),
     dialect: 'postgres',
     pool: {
-      max: 5,
+      max: process.env.VERCEL_REGION ? 1 : 5,
       min: 0,
-      acquire: 30000,
-      idle: 10000
+      acquire: process.env.VERCEL_REGION ? 3000 : 30000,
+      idle: process.env.VERCEL_REGION ? 0 : 10000
     }
   }
 )


### PR DESCRIPTION
Server side rendering uses AWS lambda which needs to be properly configured to work correctly. Lamda functions spawn/freeze/thaw containers according to their internal logic which in our case causes problems with db pooling. Most likely frozen containers don't release their connections properly.

I found a few articles about sequelize and aws. Both [recommend](https://github.com/sequelize/sequelize/blob/114c10eb09353cd32a630e42454a5d587ab0aed3/docs/manual/other-topics/aws-lambda.md) using lower connection count. 

**I can't properly test correctness of this PR**
I can't even reproduce landing page error on production server. Yes, it's there and if you refresh the page at random times you will get one eventually. But it depends on some internal AWS logic and I can't control it. Thankfully it shouldn't affect non-aws production config at all. New config is using `VERCEL_REGION` as a check for aws container. 
From vercel [docs](https://vercel.com/docs/environment-variables):
```
The ID of the Region where the app is running. Example: cdg1. Note: This Variable is only exposed during Runtime for Serverless Functions.
```
So current plan is to merge this PR, see if error is still there and revert it back (and probably revert back landing page redirect logic). 