### PR TITLE
Fix package.json scripts not working on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "db:init": "prisma migrate reset",
     "db:seed": "prisma db seed --preview-feature",
-    "dev": "next -p $PORT",
+    "db:up": "docker-compose --file docker/docker-compose.yml up --detach postgres",
+    "db:down": "docker-compose --file docker/docker-compose.yml down",
+    "dev": "next --port $PORT",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .js --ext .ts --ext .tsx",
@@ -14,12 +16,12 @@
     "storybook": "start-storybook -p $STORY_PORT -c .storybook -s ./public",
     "build-storybook": "build-storybook -c .storybook -s ./public",
     "test": "jest --coverage",
-    "ts-node": "ts-node --compiler-options '{\"module\":\"CommonJS\"}'",
+    "ts-node": "ts-node --compiler-options '{\\\"module\\\":\\\"CommonJS\\\"}'",
     "type-check": "tsc",
     "generate": "graphql-codegen --config codegen.yml",
-    "postinstall": "./scripts/prismaUtils.js setup && prisma generate",
+    "postinstall": "node scripts/prismaUtils.js setup && prisma generate",
     "prepare": "husky install",
-    "vercel-build": "./scripts/prismaUtils.js baseline migrate && next build"
+    "vercel-build": "node scripts/prismaUtils.js baseline migrate && next build"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mdx}": "eslint --fix",


### PR DESCRIPTION
Simple PR just to fix some scripts that fails if trying to develop on Windows.

Trying to run `db:init` or `db:seed` gives the following error.

![image](https://user-images.githubusercontent.com/16023489/114966018-1c9fca00-9e48-11eb-89be-5afa69e457c9.png)

Also included some docker helper commands so we don't have to write too much to get the db container started :P