### PR TITLE
close #687 - add next image to curriculum page

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -4742,11 +4742,14 @@ exports[`Storyshots Components/LessonCard Basic 1`] = `
   >
     <img
       alt="js-4-cover.svg"
-      className="lesson-card__image"
+      className="img-fluid"
+      height="165"
+      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
+      width="116"
     />
     <div
-      className="w-100 pl-4"
+      className="lesson-card__description pl-4"
     >
       <div>
         <h4
@@ -4779,7 +4782,7 @@ exports[`Storyshots Components/LessonCard Basic 1`] = `
           </div>
         </div>
         <p
-          className="lesson-card__description mt-2"
+          className="mt-2"
         >
           Create basic Front-End Mini-Projects that demonstrate User Interface logic and understanding of Web Development.
         </p>
@@ -4798,11 +4801,14 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
   >
     <img
       alt="js-4-cover.svg"
-      className="lesson-card__image"
+      className="img-fluid"
+      height="165"
+      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
+      width="116"
     />
     <div
-      className="w-100 pl-4"
+      className="lesson-card__description pl-4"
     >
       <span
         className="badge badge-pill badge-success float-right mt-2 mr-2 p-2 d-flex align-items-center"
@@ -4867,7 +4873,7 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
           </div>
         </div>
         <p
-          className="lesson-card__description mt-2"
+          className="mt-2"
         >
           Create basic Front-End Mini-Projects that demonstrate User Interface logic and understanding of Web Development.
         </p>
@@ -4897,11 +4903,14 @@ exports[`Storyshots Components/LessonCard With In Progress 1`] = `
   >
     <img
       alt="js-4-cover.svg"
-      className="lesson-card__image"
+      className="img-fluid"
+      height="165"
+      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
+      width="116"
     />
     <div
-      className="w-100 pl-4"
+      className="lesson-card__description pl-4"
     >
       <div>
         <h4
@@ -4934,7 +4943,7 @@ exports[`Storyshots Components/LessonCard With In Progress 1`] = `
           </div>
         </div>
         <p
-          className="lesson-card__description mt-2"
+          className="mt-2"
         >
           Create basic Front-End Mini-Projects that demonstrate User Interface logic and understanding of Web Development.
         </p>
@@ -8392,11 +8401,14 @@ Array [
           >
             <img
               alt="js-0-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8429,7 +8441,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   A super simple introduction to help you get started!
                 </p>
@@ -8445,11 +8457,14 @@ Array [
           >
             <img
               alt="js-1-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8482,7 +8497,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Learn how to solve simple algorithm problems recursively with the following exercises. 
                 </p>
@@ -8498,11 +8513,14 @@ Array [
           >
             <img
               alt="js-2-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8535,7 +8553,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.
                 </p>
@@ -8551,11 +8569,14 @@ Array [
           >
             <img
               alt="js-3-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8588,7 +8609,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will test your understanding of objects, which includes linked lists and trees
                 </p>
@@ -8604,11 +8625,14 @@ Array [
           >
             <img
               alt="js-4-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8641,7 +8665,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)
                 </p>
@@ -8657,11 +8681,14 @@ Array [
           >
             <img
               alt="js-5-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8694,7 +8721,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will help you build a strong understanding of how the web works.
                 </p>
@@ -8710,11 +8737,14 @@ Array [
           >
             <img
               alt="js-6-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8747,7 +8777,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   React and GraphQL Lessons
                 </p>
@@ -8763,11 +8793,14 @@ Array [
           >
             <img
               alt="js-7-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8800,7 +8833,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Problems that are commonly asked to test your JavaScript knowledge
                 </p>
@@ -8816,11 +8849,14 @@ Array [
           >
             <img
               alt="js-8-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8853,7 +8889,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Tree problems with high difficulty
                 </p>
@@ -8869,11 +8905,14 @@ Array [
           >
             <img
               alt="js-9-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -8906,7 +8945,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   General Algorithm from interviews
                 </p>
@@ -9265,11 +9304,14 @@ Array [
           >
             <img
               alt="js-0-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9302,7 +9344,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   A super simple introduction to help you get started!
                 </p>
@@ -9318,11 +9360,14 @@ Array [
           >
             <img
               alt="js-1-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9355,7 +9400,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Learn how to solve simple algorithm problems recursively with the following exercises. 
                 </p>
@@ -9371,11 +9416,14 @@ Array [
           >
             <img
               alt="js-2-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9408,7 +9456,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.
                 </p>
@@ -9424,11 +9472,14 @@ Array [
           >
             <img
               alt="js-3-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9461,7 +9512,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will test your understanding of objects, which includes linked lists and trees
                 </p>
@@ -9477,11 +9528,14 @@ Array [
           >
             <img
               alt="js-4-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9514,7 +9568,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)
                 </p>
@@ -9530,11 +9584,14 @@ Array [
           >
             <img
               alt="js-5-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9567,7 +9624,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will help you build a strong understanding of how the web works.
                 </p>
@@ -9583,11 +9640,14 @@ Array [
           >
             <img
               alt="js-6-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9620,7 +9680,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   React and GraphQL Lessons
                 </p>
@@ -9636,11 +9696,14 @@ Array [
           >
             <img
               alt="js-7-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9673,7 +9736,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Problems that are commonly asked to test your JavaScript knowledge
                 </p>
@@ -9689,11 +9752,14 @@ Array [
           >
             <img
               alt="js-8-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9726,7 +9792,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Tree problems with high difficulty
                 </p>
@@ -9742,11 +9808,14 @@ Array [
           >
             <img
               alt="js-9-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -9779,7 +9848,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   General Algorithm from interviews
                 </p>
@@ -10138,11 +10207,14 @@ Array [
           >
             <img
               alt="js-0-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10175,7 +10247,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   A super simple introduction to help you get started!
                 </p>
@@ -10191,11 +10263,14 @@ Array [
           >
             <img
               alt="js-1-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10228,7 +10303,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Learn how to solve simple algorithm problems recursively with the following exercises. 
                 </p>
@@ -10244,11 +10319,14 @@ Array [
           >
             <img
               alt="js-2-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10281,7 +10359,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.
                 </p>
@@ -10297,11 +10375,14 @@ Array [
           >
             <img
               alt="js-3-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10334,7 +10415,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will test your understanding of objects, which includes linked lists and trees
                 </p>
@@ -10350,11 +10431,14 @@ Array [
           >
             <img
               alt="js-4-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10387,7 +10471,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)
                 </p>
@@ -10403,11 +10487,14 @@ Array [
           >
             <img
               alt="js-5-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10440,7 +10527,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   These exercises will help you build a strong understanding of how the web works.
                 </p>
@@ -10456,11 +10543,14 @@ Array [
           >
             <img
               alt="js-6-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10493,7 +10583,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   React and GraphQL Lessons
                 </p>
@@ -10509,11 +10599,14 @@ Array [
           >
             <img
               alt="js-7-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10546,7 +10639,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Problems that are commonly asked to test your JavaScript knowledge
                 </p>
@@ -10562,11 +10655,14 @@ Array [
           >
             <img
               alt="js-8-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10599,7 +10695,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   Tree problems with high difficulty
                 </p>
@@ -10615,11 +10711,14 @@ Array [
           >
             <img
               alt="js-9-cover.svg"
-              className="lesson-card__image"
+              className="img-fluid"
+              height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
+              width="116"
             />
             <div
-              className="w-100 pl-4"
+              className="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -10652,7 +10751,7 @@ Array [
                   </div>
                 </div>
                 <p
-                  className="lesson-card__description mt-2"
+                  className="mt-2"
                 >
                   General Algorithm from interviews
                 </p>

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -96,13 +96,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-0-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-0-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-0-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -133,7 +151,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   A super simple introduction to help you get started!
                 </p>
@@ -147,13 +165,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-1-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-1-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-1-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -184,7 +220,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Learn how to solve simple algorithm problems recursively with the following exercises. 
                 </p>
@@ -198,13 +234,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-2-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-2-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-2-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -235,7 +289,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.
                 </p>
@@ -249,13 +303,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-3-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-3-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-3-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -286,7 +358,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will test your understanding of objects, which includes linked lists and trees
                 </p>
@@ -300,13 +372,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-4-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-4-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-4-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -337,7 +427,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)
                 </p>
@@ -351,13 +441,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-5-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-5-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-5-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -388,7 +496,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will help you build a strong understanding of how the web works.
                 </p>
@@ -402,13 +510,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-6-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-6-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-6-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -439,7 +565,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   React and GraphQL Lessons
                 </p>
@@ -453,13 +579,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-7-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-7-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-7-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -490,7 +634,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Problems that are commonly asked to test your JavaScript knowledge
                 </p>
@@ -504,13 +648,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-8-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-8-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-8-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -541,7 +703,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Tree problems with high difficulty
                 </p>
@@ -555,13 +717,31 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-9-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-9-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-9-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -592,7 +772,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   General Algorithm from interviews
                 </p>
@@ -956,13 +1136,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-0-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-0-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-0-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -993,7 +1191,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   A super simple introduction to help you get started!
                 </p>
@@ -1025,13 +1223,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-1-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-1-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-1-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1062,7 +1278,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Learn how to solve simple algorithm problems recursively with the following exercises. 
                 </p>
@@ -1076,13 +1292,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-2-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-2-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-2-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1113,7 +1347,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.
                 </p>
@@ -1127,13 +1361,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-3-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-3-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-3-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1164,7 +1416,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will test your understanding of objects, which includes linked lists and trees
                 </p>
@@ -1178,13 +1430,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-4-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-4-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-4-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1215,7 +1485,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)
                 </p>
@@ -1229,13 +1499,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-5-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-5-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-5-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1266,7 +1554,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will help you build a strong understanding of how the web works.
                 </p>
@@ -1280,13 +1568,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-6-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-6-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-6-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1317,7 +1623,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   React and GraphQL Lessons
                 </p>
@@ -1331,13 +1637,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-7-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-7-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-7-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1368,7 +1692,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Problems that are commonly asked to test your JavaScript knowledge
                 </p>
@@ -1382,13 +1706,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-8-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-8-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-8-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1419,7 +1761,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Tree problems with high difficulty
                 </p>
@@ -1433,13 +1775,31 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-9-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-9-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-9-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -1470,7 +1830,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   General Algorithm from interviews
                 </p>
@@ -1871,13 +2231,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-0-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-0-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-0-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <span
                 class="badge badge-pill badge-success float-right mt-2 mr-2 p-2 d-flex align-items-center"
@@ -1936,7 +2314,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   A super simple introduction to help you get started!
                 </p>
@@ -1960,13 +2338,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-1-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-1-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-1-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <span
                 class="badge badge-pill badge-success float-right mt-2 mr-2 p-2 d-flex align-items-center"
@@ -2025,7 +2421,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Learn how to solve simple algorithm problems recursively with the following exercises. 
                 </p>
@@ -2049,13 +2445,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-2-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-2-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-2-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <span
                 class="badge badge-pill badge-success float-right mt-2 mr-2 p-2 d-flex align-items-center"
@@ -2114,7 +2528,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.
                 </p>
@@ -2138,13 +2552,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-3-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-3-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-3-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -2175,7 +2607,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will test your understanding of objects, which includes linked lists and trees
                 </p>
@@ -2207,13 +2639,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-4-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-4-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-4-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -2244,7 +2694,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)
                 </p>
@@ -2258,13 +2708,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-5-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-5-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-5-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -2295,7 +2763,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   These exercises will help you build a strong understanding of how the web works.
                 </p>
@@ -2309,13 +2777,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-6-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-6-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-6-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -2346,7 +2832,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   React and GraphQL Lessons
                 </p>
@@ -2360,13 +2846,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-7-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-7-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-7-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -2397,7 +2901,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Problems that are commonly asked to test your JavaScript knowledge
                 </p>
@@ -2411,13 +2915,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-8-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-8-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-8-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -2448,7 +2970,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   Tree problems with high difficulty
                 </p>
@@ -2462,13 +2984,31 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <img
-              alt="js-9-cover.svg"
-              class="lesson-card__image"
-              src="/assets/curriculum/js-9-cover.svg"
-            />
             <div
-              class="w-100 pl-4"
+              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+            >
+              <div
+                style="box-sizing: border-box; display: block; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  role="presentation"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+                />
+              </div>
+              <img
+                alt="js-9-cover.svg"
+                class="align-self-center"
+                decoding="async"
+                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75"
+                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75 2x"
+                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              />
+            </div>
+            <div
+              class="lesson-card__description pl-4"
             >
               <div>
                 <h4
@@ -2499,7 +3039,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </div>
                 </div>
                 <p
-                  class="lesson-card__description mt-2"
+                  class="mt-2"
                 >
                   General Algorithm from interviews
                 </p>

--- a/components/LessonCard.tsx
+++ b/components/LessonCard.tsx
@@ -8,6 +8,7 @@ import {
   ReviewCountProps
 } from '../@types/lessonCard'
 import NavLink from './NavLink'
+import Image from 'next/image'
 import styles from '../scss/lessonCard.module.scss'
 
 const ReviewCount: React.FC<ReviewCountProps> = props => {
@@ -61,13 +62,16 @@ const LessonCard: React.FC<Props> = props => {
   return (
     <div className={`card shadow-sm mt-3 ${containerClass}`}>
       <div className="d-flex p-2">
-        <img
+        <Image
           src={`/assets/curriculum/${props.coverImg}`}
-          className={`${styles['lesson-card__image']}`}
           alt={props.coverImg}
+          objectFit="contain"
+          className="align-self-center"
+          width="116"
+          height="165"
         />
 
-        <div className="w-100 pl-4">
+        <div className={`${styles['lesson-card__description']} pl-4`}>
           {props.currentState === 'completed' && (
             <span className="badge badge-pill badge-success float-right mt-2 mr-2 p-2 d-flex align-items-center">
               <CheckCircle style={{ height: '15px' }} />
@@ -97,9 +101,7 @@ const LessonCard: React.FC<Props> = props => {
                 </span>
               </div>
             </div>
-            <p className={`${styles['lesson-card__description']} mt-2`}>
-              {props.description}
-            </p>
+            <p className="mt-2">{props.description}</p>
           </div>
           <ReviewButton
             isCompleted={props.currentState === 'completed'}

--- a/components/__snapshots__/LessonCard.test.js.snap
+++ b/components/__snapshots__/LessonCard.test.js.snap
@@ -8,12 +8,29 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
     <div
       class="d-flex p-2"
     >
-      <img
-        class="lesson-card__image"
-        src="/assets/curriculum/undefined"
-      />
       <div
-        class="w-100 pl-4"
+        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+      >
+        <div
+          style="box-sizing: border-box; display: block; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            role="presentation"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+          />
+        </div>
+        <img
+          class="align-self-center"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+        />
+      </div>
+      <div
+        class="lesson-card__description pl-4"
       >
         <span
           class="badge badge-pill badge-success float-right mt-2 mr-2 p-2 d-flex align-items-center"
@@ -69,7 +86,7 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
             </div>
           </div>
           <p
-            class="lesson-card__description mt-2"
+            class="mt-2"
           />
         </div>
         <a
@@ -96,12 +113,29 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
     <div
       class="d-flex p-2"
     >
-      <img
-        class="lesson-card__image"
-        src="/assets/curriculum/undefined"
-      />
       <div
-        class="w-100 pl-4"
+        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+      >
+        <div
+          style="box-sizing: border-box; display: block; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            role="presentation"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+          />
+        </div>
+        <img
+          class="align-self-center"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+        />
+      </div>
+      <div
+        class="lesson-card__description pl-4"
       >
         <span
           class="badge badge-pill badge-success float-right mt-2 mr-2 p-2 d-flex align-items-center"
@@ -157,7 +191,7 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
             </div>
           </div>
           <p
-            class="lesson-card__description mt-2"
+            class="mt-2"
           />
         </div>
         <a
@@ -183,12 +217,29 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
     <div
       class="d-flex p-2"
     >
-      <img
-        class="lesson-card__image"
-        src="/assets/curriculum/undefined"
-      />
       <div
-        class="w-100 pl-4"
+        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+      >
+        <div
+          style="box-sizing: border-box; display: block; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            role="presentation"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+          />
+        </div>
+        <img
+          class="align-self-center"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+        />
+      </div>
+      <div
+        class="lesson-card__description pl-4"
       >
         <span
           class="badge badge-pill badge-success float-right mt-2 mr-2 p-2 d-flex align-items-center"
@@ -244,7 +295,7 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
             </div>
           </div>
           <p
-            class="lesson-card__description mt-2"
+            class="mt-2"
           />
         </div>
         <a
@@ -270,12 +321,29 @@ exports[`Lesson Card Should render ellpsis when no data is present 1`] = `
     <div
       class="d-flex p-2"
     >
-      <img
-        class="lesson-card__image"
-        src="/assets/curriculum/undefined"
-      />
       <div
-        class="w-100 pl-4"
+        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+      >
+        <div
+          style="box-sizing: border-box; display: block; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            role="presentation"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+          />
+        </div>
+        <img
+          class="align-self-center"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+        />
+      </div>
+      <div
+        class="lesson-card__description pl-4"
       >
         <div>
           <h4
@@ -303,7 +371,7 @@ exports[`Lesson Card Should render ellpsis when no data is present 1`] = `
             </div>
           </div>
           <p
-            class="lesson-card__description mt-2"
+            class="mt-2"
           />
         </div>
       </div>
@@ -320,12 +388,29 @@ exports[`Lesson Card Should render lessonCard with inProgress currentState prop 
     <div
       class="d-flex p-2"
     >
-      <img
-        class="lesson-card__image"
-        src="/assets/curriculum/undefined"
-      />
       <div
-        class="w-100 pl-4"
+        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+      >
+        <div
+          style="box-sizing: border-box; display: block; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            role="presentation"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+          />
+        </div>
+        <img
+          class="align-self-center"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+        />
+      </div>
+      <div
+        class="lesson-card__description pl-4"
       >
         <div>
           <h4
@@ -353,7 +438,7 @@ exports[`Lesson Card Should render lessonCard with inProgress currentState prop 
             </div>
           </div>
           <p
-            class="lesson-card__description mt-2"
+            class="mt-2"
           />
         </div>
       </div>
@@ -373,12 +458,29 @@ exports[`Lesson Card Should render lessonCard with lessonId prop 1`] = `
     <div
       class="d-flex p-2"
     >
-      <img
-        class="lesson-card__image"
-        src="/assets/curriculum/undefined"
-      />
       <div
-        class="w-100 pl-4"
+        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+      >
+        <div
+          style="box-sizing: border-box; display: block; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            role="presentation"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+          />
+        </div>
+        <img
+          class="align-self-center"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+        />
+      </div>
+      <div
+        class="lesson-card__description pl-4"
       >
         <div>
           <h4
@@ -406,7 +508,7 @@ exports[`Lesson Card Should render lessonCard with lessonId prop 1`] = `
             </div>
           </div>
           <p
-            class="lesson-card__description mt-2"
+            class="mt-2"
           />
         </div>
       </div>
@@ -423,12 +525,29 @@ exports[`Lesson Card Should render lessonCard with no submission count 1`] = `
     <div
       class="d-flex p-2"
     >
-      <img
-        class="lesson-card__image"
-        src="/assets/curriculum/undefined"
-      />
       <div
-        class="w-100 pl-4"
+        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+      >
+        <div
+          style="box-sizing: border-box; display: block; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            role="presentation"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+          />
+        </div>
+        <img
+          class="align-self-center"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+        />
+      </div>
+      <div
+        class="lesson-card__description pl-4"
       >
         <div>
           <h4
@@ -456,7 +575,7 @@ exports[`Lesson Card Should render lessonCard with no submission count 1`] = `
             </div>
           </div>
           <p
-            class="lesson-card__description mt-2"
+            class="mt-2"
           />
         </div>
       </div>
@@ -473,12 +592,29 @@ exports[`Lesson Card Should render loading card when loading 1`] = `
     <div
       class="d-flex p-2"
     >
-      <img
-        class="lesson-card__image"
-        src="/assets/curriculum/undefined"
-      />
       <div
-        class="w-100 pl-4"
+        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
+      >
+        <div
+          style="box-sizing: border-box; display: block; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            role="presentation"
+            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
+          />
+        </div>
+        <img
+          class="align-self-center"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+        />
+      </div>
+      <div
+        class="lesson-card__description pl-4"
       >
         <div>
           <h4
@@ -506,7 +642,7 @@ exports[`Lesson Card Should render loading card when loading 1`] = `
             </div>
           </div>
           <p
-            class="lesson-card__description mt-2"
+            class="mt-2"
           />
         </div>
       </div>

--- a/scss/lessonCard.module.scss
+++ b/scss/lessonCard.module.scss
@@ -17,3 +17,6 @@
 .lesson-card__image {
   object-fit: contain;
 }
+.lesson-card__description {
+  flex: 1;
+}


### PR DESCRIPTION
This PR adds next image to curriculum page. That way there dimensions of image are known beforehand so refreshing/loading looks a bit nicer. A lot of changed snapshots but the pr itself is very simple. |

[Vercel.](https://c0d3-app-e20ntkijj-c0d3.vercel.app/curriculum) Throttle your connection a bit, hit refresh an watch how `Foundations of JavaScript` and other titles stay more or less in place while images are loading. 