### PR TITLE
 close #473 - add mobile layout for challenge page 

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -631,7 +631,8 @@ exports[`Storyshots Components/ChallengeMaterial Basic 1`] = `
   className="row challenge-display mt-3"
 >
   <div
-    className="col-4"
+    className="challenge-display_challenges undefined col-md-4"
+    onClick={[Function]}
   >
     <div
       className="card mb-2 challenge-title-card challenge-title-card--active shadow-sm border-0"
@@ -661,7 +662,7 @@ exports[`Storyshots Components/ChallengeMaterial Basic 1`] = `
     </div>
   </div>
   <div
-    className="col-8"
+    className="col-md-8"
   >
     <div
       className="card shadow-sm border-0"
@@ -695,7 +696,8 @@ exports[`Storyshots Components/ChallengeMaterial Final Challenge 1`] = `
   className="row challenge-display mt-3"
 >
   <div
-    className="col-4"
+    className="challenge-display_challenges undefined col-md-4"
+    onClick={[Function]}
   >
     <div
       className="card mb-2 challenge-title-card challenge-title-card--done"
@@ -753,7 +755,7 @@ exports[`Storyshots Components/ChallengeMaterial Final Challenge 1`] = `
     </div>
   </div>
   <div
-    className="col-8"
+    className="col-md-8"
   >
     <div
       className="card text-center shadow-sm"
@@ -829,7 +831,8 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
   className="row challenge-display mt-3"
 >
   <div
-    className="col-4"
+    className="challenge-display_challenges undefined col-md-4"
+    onClick={[Function]}
   >
     <div
       className="card mb-2 challenge-title-card challenge-title-card--done"
@@ -864,7 +867,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
     </div>
   </div>
   <div
-    className="col-8"
+    className="col-md-8"
   >
     <div
       className="card shadow-sm border-0"
@@ -1328,7 +1331,8 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
   className="row challenge-display mt-3"
 >
   <div
-    className="col-4"
+    className="challenge-display_challenges undefined col-md-4"
+    onClick={[Function]}
   >
     <div
       className="card mb-2 challenge-title-card challenge-title-card--active shadow-sm border-0"
@@ -1358,7 +1362,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
     </div>
   </div>
   <div
-    className="col-8"
+    className="col-md-8"
   >
     <div
       className="card shadow-sm border-0"

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -631,7 +631,7 @@ exports[`Storyshots Components/ChallengeMaterial Basic 1`] = `
   className="row challenge-display mt-3"
 >
   <div
-    className="challenge-display_challenges undefined col-md-4"
+    className="challenge-display_challenges false col-md-4"
     onClick={[Function]}
   >
     <div
@@ -696,7 +696,7 @@ exports[`Storyshots Components/ChallengeMaterial Final Challenge 1`] = `
   className="row challenge-display mt-3"
 >
   <div
-    className="challenge-display_challenges undefined col-md-4"
+    className="challenge-display_challenges false col-md-4"
     onClick={[Function]}
   >
     <div
@@ -831,7 +831,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
   className="row challenge-display mt-3"
 >
   <div
-    className="challenge-display_challenges undefined col-md-4"
+    className="challenge-display_challenges false col-md-4"
     onClick={[Function]}
   >
     <div
@@ -1331,7 +1331,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
   className="row challenge-display mt-3"
 >
   <div
-    className="challenge-display_challenges undefined col-md-4"
+    className="challenge-display_challenges false col-md-4"
     onClick={[Function]}
   >
     <div

--- a/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
@@ -205,7 +205,7 @@ exports[`Lesson Page Should correctly render challenges page for students who ha
             class="row challenge-display mt-3"
           >
             <div
-              class="col-4"
+              class="challenge-display_challenges false col-md-4"
             >
               <div
                 class="card mb-2 challenge-title-card challenge-title-card--active shadow-sm border-0"
@@ -353,7 +353,7 @@ exports[`Lesson Page Should correctly render challenges page for students who ha
               </div>
             </div>
             <div
-              class="col-8"
+              class="col-md-8"
             >
               <div
                 class="card shadow-sm border-0"
@@ -783,7 +783,7 @@ exports[`Lesson Page Should render correctly with valid lesson route 1`] = `
             class="row challenge-display mt-3"
           >
             <div
-              class="col-4"
+              class="challenge-display_challenges false col-md-4"
             >
               <div
                 class="card mb-2 challenge-title-card challenge-title-card--done"
@@ -941,7 +941,7 @@ exports[`Lesson Page Should render correctly with valid lesson route 1`] = `
               </div>
             </div>
             <div
-              class="col-8"
+              class="col-md-8"
             >
               <div
                 class="card shadow-sm border-0"

--- a/components/ChallengeMaterial.test.js
+++ b/components/ChallengeMaterial.test.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import dayjs from 'dayjs'
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
 import ChallengeMaterial from './ChallengeMaterial'
 import SET_STAR from '../graphql/queries/setStar'
 import GET_LESSON_MENTORS from '../graphql/queries/getLessonMentors'
 import lessonMentorsData from '../__dummy__/getLessonMentorsData'
 import { MockedProvider } from '@apollo/client/testing'
+import '@testing-library/jest-dom'
 
 const mocks = [
   {
@@ -143,5 +144,33 @@ describe('Curriculum challenge page', () => {
     // click exit button of GiveStarCard
     fireEvent.click(getByRole('img'))
     expect(document.body).toMatchSnapshot()
+  })
+  test('Should hide mobile modal on double tap', async () => {
+    global.window.innerWidth = 500
+    const foo = { ...props, show: true }
+    const { container } = render(<ChallengeMaterial {...foo} />)
+    expect(screen.getByTestId('modal-challenges')).toBeVisible()
+    expect(container).toMatchSnapshot()
+    fireEvent.click(screen.getByText('0. Greater than 5'), {
+      target: { innerText: '0. Greater than 5' }
+    })
+
+    fireEvent.click(screen.getByText('0. Greater than 5'), {
+      target: { innerText: '0. Greater than 5' }
+    })
+    expect(setShow).toBeCalledWith(false)
+  })
+  test('Should hide mobile modal by clicking on the background', async () => {
+    global.window.innerWidth = 500
+    const foo = { ...props, show: true }
+    const { container } = render(<ChallengeMaterial {...foo} />)
+    expect(screen.getByTestId('modal-challenges')).toBeVisible()
+    fireEvent.keyDown(container, {
+      key: 'Escape',
+      code: 'Escape',
+      keyCode: 27,
+      charCode: 27
+    })
+    expect(setShow).toBeCalledWith(false)
   })
 })

--- a/components/ChallengeMaterial.test.js
+++ b/components/ChallengeMaterial.test.js
@@ -84,13 +84,15 @@ const userSubmissions = [
 
 describe('Curriculum challenge page', () => {
   let props
+  const setShow = jest.fn()
   beforeEach(() => {
     props = {
       challenges,
       lessonStatus: lessonStatusNoPass,
       userSubmissions,
       chatUrl: 'https://chat.c0d3.com/c0d3/channels/js0-foundations',
-      lessonId: '5'
+      lessonId: '5',
+      setShow
     }
   })
 

--- a/components/ChallengeMaterial.test.js
+++ b/components/ChallengeMaterial.test.js
@@ -146,16 +146,13 @@ describe('Curriculum challenge page', () => {
     fireEvent.click(getByRole('img'))
     expect(document.body).toMatchSnapshot()
   })
-  test('Should hide mobile modal on double tap', async () => {
+  test('Should hide mobile modal on click', async () => {
     global.window.innerWidth = 500
     const { container } = render(
       <ChallengeMaterial {...{ ...props, show: true }} />
     )
     expect(screen.getByTestId('modal-challenges')).toBeVisible()
     expect(container).toMatchSnapshot()
-    fireEvent.click(screen.getByText('0. Greater than 5'), {
-      target: { innerText: '0. Greater than 5' }
-    })
 
     fireEvent.click(screen.getByText('0. Greater than 5'), {
       target: { innerText: '0. Greater than 5' }

--- a/components/ChallengeMaterial.test.js
+++ b/components/ChallengeMaterial.test.js
@@ -87,6 +87,7 @@ describe('Curriculum challenge page', () => {
   let props
   const setShow = jest.fn()
   beforeEach(() => {
+    jest.clearAllMocks()
     props = {
       challenges,
       lessonStatus: lessonStatusNoPass,
@@ -147,8 +148,9 @@ describe('Curriculum challenge page', () => {
   })
   test('Should hide mobile modal on double tap', async () => {
     global.window.innerWidth = 500
-    const foo = { ...props, show: true }
-    const { container } = render(<ChallengeMaterial {...foo} />)
+    const { container } = render(
+      <ChallengeMaterial {...{ ...props, show: true }} />
+    )
     expect(screen.getByTestId('modal-challenges')).toBeVisible()
     expect(container).toMatchSnapshot()
     fireEvent.click(screen.getByText('0. Greater than 5'), {
@@ -162,8 +164,9 @@ describe('Curriculum challenge page', () => {
   })
   test('Should hide mobile modal by clicking on the background', async () => {
     global.window.innerWidth = 500
-    const foo = { ...props, show: true }
-    const { container } = render(<ChallengeMaterial {...foo} />)
+    const { container } = render(
+      <ChallengeMaterial {...{ ...props, show: true }} />
+    )
     expect(screen.getByTestId('modal-challenges')).toBeVisible()
     fireEvent.keyDown(container, {
       key: 'Escape',

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -397,7 +397,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   )
   return (
     <div className="row challenge-display mt-3">
-      {window.innerWidth > 765 ? (
+      {window.innerWidth > 768 ? (
         challengeList
       ) : (
         <Modal

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -315,7 +315,6 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   if (!challenges.length) {
     return <h1>No Challenges for this lesson</h1>
   }
-  const [status, setStatus] = useState('')
   //create an object to evaluate the student's status with a challenge
   const userSubmissionsObject: UserSubmissionsObject = userSubmissions.reduce(
     (acc: UserSubmissionsObject, submission: UserSubmission) => {
@@ -374,11 +373,8 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   const challengeList = (
     <div
       className={`challenge-display_challenges ${show && 'show'} col-md-4`}
-      onClick={e => {
-        const target = e.target as HTMLElement
-        if (status === target.innerText) {
-          setShow(!show)
-        } else setStatus(target.innerText)
+      onClick={() => {
+        setShow(!show)
       }}
     >
       {challengeTitleCards}

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -15,6 +15,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { GiveStarCard } from '../components/GiveStarCard'
 import _ from 'lodash'
+import Modal from 'react-bootstrap/Modal'
 
 dayjs.extend(relativeTime)
 
@@ -299,6 +300,7 @@ type ChallengeMaterialProps = {
   chatUrl: string
   lessonId: number
   show: boolean
+  setShow: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
@@ -307,7 +309,8 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   lessonStatus,
   chatUrl,
   lessonId,
-  show
+  show,
+  setShow
 }) => {
   if (!challenges.length) {
     return <h1>No Challenges for this lesson</h1>
@@ -367,24 +370,34 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
       )
     }
   )
+  const challengeList = (
+    <div className={`challenge-display_challenges ${show && 'show'} col-md-4`}>
+      {challengeTitleCards}
+      {lessonStatus.isPassed && (
+        <ChallengeTitleCard
+          key={finalChallenge.id}
+          id={finalChallenge.id}
+          challengeNum={finalChallenge.order}
+          title={finalChallenge.title}
+          setCurrentChallenge={setCurrentChallenge}
+          active={finalChallenge.id === currentChallenge.id}
+          submissionStatus={finalChallenge.status}
+        />
+      )}
+    </div>
+  )
   return (
     <div className="row challenge-display mt-3">
-      <div
-        className={`challenge-display_challenges ${show && 'show'} col-md-4`}
+      {window.innerWidth > 765 ? challengeList :  <Modal
+        show={show}
+        onHide={() => setShow(!show)}
+        size="lg"
+        centered
+        className="challenge-modal"
       >
-        {challengeTitleCards}
-        {lessonStatus.isPassed && (
-          <ChallengeTitleCard
-            key={finalChallenge.id}
-            id={finalChallenge.id}
-            challengeNum={finalChallenge.order}
-            title={finalChallenge.title}
-            setCurrentChallenge={setCurrentChallenge}
-            active={finalChallenge.id === currentChallenge.id}
-            submissionStatus={finalChallenge.status}
-          />
-        )}
-      </div>
+        <Modal.Body>{challengeList}</Modal.Body>
+      </Modal>}
+     
       <div className="col-md-8">
         {currentChallenge.id !== 'finalChallenge' && (
           <ChallengeQuestionCard currentChallenge={currentChallenge} />

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -298,6 +298,7 @@ type ChallengeMaterialProps = {
   lessonStatus: LessonStatus
   chatUrl: string
   lessonId: number
+  show: boolean
 }
 
 const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
@@ -305,7 +306,8 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   userSubmissions,
   lessonStatus,
   chatUrl,
-  lessonId
+  lessonId,
+  show
 }) => {
   if (!challenges.length) {
     return <h1>No Challenges for this lesson</h1>
@@ -367,7 +369,9 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   )
   return (
     <div className="row challenge-display mt-3">
-      <div className="col-4">
+      <div
+        className={`challenge-display_challenges ${show && 'show'} col-md-4`}
+      >
         {challengeTitleCards}
         {lessonStatus.isPassed && (
           <ChallengeTitleCard
@@ -381,7 +385,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
           />
         )}
       </div>
-      <div className="col-8">
+      <div className="col-md-8">
         {currentChallenge.id !== 'finalChallenge' && (
           <ChallengeQuestionCard currentChallenge={currentChallenge} />
         )}

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -315,6 +315,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   if (!challenges.length) {
     return <h1>No Challenges for this lesson</h1>
   }
+  const [status, setStatus] = useState('')
   //create an object to evaluate the student's status with a challenge
   const userSubmissionsObject: UserSubmissionsObject = userSubmissions.reduce(
     (acc: UserSubmissionsObject, submission: UserSubmission) => {
@@ -371,7 +372,18 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
     }
   )
   const challengeList = (
-    <div className={`challenge-display_challenges ${show && 'show'} col-md-4`}>
+    <div
+      className={`challenge-display_challenges ${show && 'show'} col-md-4`}
+      onClick={e => {
+        const target = e.target as HTMLElement
+        if (!show) {
+          setShow(true)
+          setStatus(target.innerText)
+        } else if (status === target.innerText) {
+          setShow(!show)
+        } else setStatus(target.innerText)
+      }}
+    >
       {challengeTitleCards}
       {lessonStatus.isPassed && (
         <ChallengeTitleCard
@@ -388,16 +400,19 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   )
   return (
     <div className="row challenge-display mt-3">
-      {window.innerWidth > 765 ? challengeList :  <Modal
-        show={show}
-        onHide={() => setShow(!show)}
-        size="lg"
-        centered
-        className="challenge-modal"
-      >
-        <Modal.Body>{challengeList}</Modal.Body>
-      </Modal>}
-     
+      {window.innerWidth > 765 ? (
+        challengeList
+      ) : (
+        <Modal
+          show={show}
+          onHide={() => setShow(!show)}
+          centered
+          className="challenge-modal"
+        >
+          <Modal.Body>{challengeList}</Modal.Body>
+        </Modal>
+      )}
+
       <div className="col-md-8">
         {currentChallenge.id !== 'finalChallenge' && (
           <ChallengeQuestionCard currentChallenge={currentChallenge} />

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -376,10 +376,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
       className={`challenge-display_challenges ${show && 'show'} col-md-4`}
       onClick={e => {
         const target = e.target as HTMLElement
-        if (!show) {
-          setShow(true)
-          setStatus(target.innerText)
-        } else if (status === target.innerText) {
+        if (status === target.innerText) {
           setShow(!show)
         } else setStatus(target.innerText)
       }}
@@ -405,9 +402,12 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
       ) : (
         <Modal
           show={show}
-          onHide={() => setShow(!show)}
+          onHide={() => {
+            setShow(!show)
+          }}
           centered
           className="challenge-modal"
+          data-testid="modal-challenges"
         >
           <Modal.Body>{challengeList}</Modal.Body>
         </Modal>

--- a/components/LessonTitleCard.test.js
+++ b/components/LessonTitleCard.test.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import LessonTitleCard from './LessonTitleCard'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+describe('LessonTitleCard component', () => {
+  const setShow = jest.fn()
+  const props = {
+    lessonCoverUrl: 'coverUrl',
+    lessonUrl: 'lessonUrl',
+    lessonTitle: 'Test Lesson',
+    lessonId: '0',
+    isPassed: true,
+    setShow,
+    show: false
+  }
+  test('Should show challenges on click on mobile devices', async () => {
+    global.window.innerWidth = 500
+    const { container } = render(<LessonTitleCard {...props} />)
+    await waitFor(() => fireEvent.click(screen.getByText('CHALLENGES')))
+    expect(setShow).toBeCalledWith(true)
+    expect(container).toMatchSnapshot()
+  })
+  test('Should render default layout for wider screens', async () => {
+    global.window.innerWidth = 1080
+    const { container } = render(<LessonTitleCard {...props} />)
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/components/LessonTitleCard.test.js
+++ b/components/LessonTitleCard.test.js
@@ -15,7 +15,7 @@ describe('LessonTitleCard component', () => {
   test('Should show challenges on click on mobile devices', async () => {
     global.window.innerWidth = 500
     const { container } = render(<LessonTitleCard {...props} />)
-    await waitFor(() => fireEvent.click(screen.getByText('CHALLENGES')))
+    await waitFor(() => fireEvent.click(screen.getByText('SHOW CHALLENGES')))
     expect(setShow).toBeCalledWith(true)
     expect(container).toMatchSnapshot()
   })

--- a/components/LessonTitleCard.tsx
+++ b/components/LessonTitleCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import NavLink from './NavLink'
 import styles from '../scss/lessonTitleCard.module.scss'
+import Button from 'react-bootstrap/Button'
 
 type Props = {
   lessonCoverUrl: string
@@ -8,6 +9,8 @@ type Props = {
   lessonTitle: string
   lessonId: string
   isPassed: boolean
+  setShow: React.Dispatch<React.SetStateAction<boolean>>
+  show: boolean
 }
 
 const LessonTitleCard: React.FC<Props> = props => {
@@ -37,12 +40,11 @@ const LessonTitleCard: React.FC<Props> = props => {
           >
             LESSON
           </NavLink>
-          <NavLink
-            path={`/curriculum/${props.lessonId}`}
-            className="btn border-right rounded-0 px-4 py-3"
-          >
-            CHALLENGES
-          </NavLink>
+          {window.innerWidth < 750 && (
+            <Button onClick={() => props.setShow(!props.show)}>
+              CHALLENGES
+            </Button>
+          )}
           {props.isPassed && (
             <NavLink
               path={`/review/${props.lessonId}`}

--- a/components/LessonTitleCard.tsx
+++ b/components/LessonTitleCard.tsx
@@ -40,10 +40,18 @@ const LessonTitleCard: React.FC<Props> = props => {
           >
             LESSON
           </NavLink>
-          {window.innerWidth < 768 && (
+          {/* 768 px is md bootstrap breakpoint */}
+          {window.innerWidth < 768 ? (
             <Button onClick={() => props.setShow(!props.show)}>
-              SHOW CHALLENGES
+              CHALLENGES
             </Button>
+          ) : (
+            <NavLink
+              path={`/curriculum/${props.lessonId}`}
+              className="btn border-right rounded-0 px-4 py-3"
+            >
+              CHALLENGES
+            </NavLink>
           )}
           {props.isPassed && (
             <NavLink

--- a/components/LessonTitleCard.tsx
+++ b/components/LessonTitleCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import NavLink from './NavLink'
 import styles from '../scss/lessonTitleCard.module.scss'
-import Button from 'react-bootstrap/Button'
+import { Button } from './theme/Button'
 
 type Props = {
   lessonCoverUrl: string
@@ -40,9 +40,9 @@ const LessonTitleCard: React.FC<Props> = props => {
           >
             LESSON
           </NavLink>
-          {window.innerWidth < 750 && (
+          {window.innerWidth < 768 && (
             <Button onClick={() => props.setShow(!props.show)}>
-              CHALLENGES
+              SHOW CHALLENGES
             </Button>
           )}
           {props.isPassed && (

--- a/components/LessonTitleCard.tsx
+++ b/components/LessonTitleCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import NavLink from './NavLink'
 import styles from '../scss/lessonTitleCard.module.scss'
-import { Button } from './theme/Button'
 
 type Props = {
   lessonCoverUrl: string
@@ -9,8 +8,8 @@ type Props = {
   lessonTitle: string
   lessonId: string
   isPassed: boolean
-  setShow: React.Dispatch<React.SetStateAction<boolean>>
-  show: boolean
+  setShow?: React.Dispatch<React.SetStateAction<boolean>>
+  show?: boolean
 }
 
 const LessonTitleCard: React.FC<Props> = props => {
@@ -41,10 +40,13 @@ const LessonTitleCard: React.FC<Props> = props => {
             LESSON
           </NavLink>
           {/* 768 px is md bootstrap breakpoint */}
-          {window.innerWidth < 768 ? (
-            <Button onClick={() => props.setShow(!props.show)}>
-              CHALLENGES
-            </Button>
+          {window.innerWidth <= 768 ? (
+            <div
+              onClick={() => props.setShow && props.setShow(!props.show)}
+              className="btn border-right rounded-0 px-4 py-3"
+            >
+              SHOW CHALLENGES
+            </div>
           ) : (
             <NavLink
               path={`/curriculum/${props.lessonId}`}

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -14,7 +14,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
     class="row challenge-display mt-3"
   >
     <div
-      class="col-4"
+      class="challenge-display_challenges undefined col-md-4"
     >
       <div
         class="card mb-2 challenge-title-card challenge-title-card--done"
@@ -69,7 +69,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
       </div>
     </div>
     <div
-      class="col-8"
+      class="col-md-8"
     >
       <div
         class="card text-center shadow-sm"
@@ -146,7 +146,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
       class="row challenge-display mt-3"
     >
       <div
-        class="col-4"
+        class="challenge-display_challenges undefined col-md-4"
       >
         <div
           class="card mb-2 challenge-title-card challenge-title-card--done"
@@ -201,7 +201,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
         </div>
       </div>
       <div
-        class="col-8"
+        class="col-md-8"
       >
         <div
           class="card text-center shadow-sm"
@@ -685,7 +685,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
       class="row challenge-display mt-3"
     >
       <div
-        class="col-4"
+        class="challenge-display_challenges undefined col-md-4"
       >
         <div
           class="card mb-2 challenge-title-card challenge-title-card--done"
@@ -740,7 +740,7 @@ exports[`Curriculum challenge page Should render challenge material page differe
         </div>
       </div>
       <div
-        class="col-8"
+        class="col-md-8"
       >
         <div
           class="card text-center shadow-sm"
@@ -812,7 +812,7 @@ exports[`Curriculum challenge page Should render clicked challenge within challe
     class="row challenge-display mt-3"
   >
     <div
-      class="col-4"
+      class="challenge-display_challenges undefined col-md-4"
     >
       <div
         class="card mb-2 challenge-title-card shadow-sm border-0"
@@ -850,7 +850,7 @@ exports[`Curriculum challenge page Should render clicked challenge within challe
       </div>
     </div>
     <div
-      class="col-8"
+      class="col-md-8"
     >
       <div
         class="card shadow-sm border-0"
@@ -1399,7 +1399,7 @@ exports[`Curriculum challenge page Should render first challenge by default when
     class="row challenge-display mt-3"
   >
     <div
-      class="col-4"
+      class="challenge-display_challenges undefined col-md-4"
     >
       <div
         class="card mb-2 challenge-title-card challenge-title-card--active shadow-sm border-0"
@@ -1427,7 +1427,7 @@ exports[`Curriculum challenge page Should render first challenge by default when
       </div>
     </div>
     <div
-      class="col-8"
+      class="col-md-8"
     >
       <div
         class="card shadow-sm border-0"
@@ -1463,7 +1463,7 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
     class="row challenge-display mt-3"
   >
     <div
-      class="col-4"
+      class="challenge-display_challenges undefined col-md-4"
     >
       <div
         class="card mb-2 challenge-title-card challenge-title-card--active shadow-sm border-0"
@@ -1501,7 +1501,7 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
       </div>
     </div>
     <div
-      class="col-8"
+      class="col-md-8"
     >
       <div
         class="card shadow-sm border-0"

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Curriculum challenge page Should hide mobile modal on double tap 1`] = `
+exports[`Curriculum challenge page Should hide mobile modal on click 1`] = `
 <div
   aria-hidden="true"
 >

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -1,5 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Curriculum challenge page Should hide mobile modal on double tap 1`] = `
+<div
+  aria-hidden="true"
+>
+  <div
+    class="row challenge-display mt-3"
+  >
+    <div
+      class="col-md-8"
+    >
+      <div
+        class="card text-center shadow-sm"
+      >
+        <div
+          class="card-body"
+        >
+          <img
+            class="mt-3"
+            src="/assets/curriculum/icons/icon-challenge-complete.jpg"
+          />
+          <h4
+            class="card-title mt-2"
+          >
+            Congratulations!
+          </h4>
+          <p
+            class="success-message"
+          >
+            You have successfully completed all challenges
+          </p>
+          <p
+            class="review-message"
+          >
+            You can help your peers by
+            <a
+              class="font-weight-bold mx-1"
+              href="https://chat.c0d3.com/c0d3/channels/js0-foundations"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              answering questions
+            </a>
+            they have in the lesson and
+            <a
+              class="font-weight-bold mx-1"
+              href="https://www.c0d3.com/review/5"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              reviewing challenge submissions
+            </a>
+          </p>
+        </div>
+        <div
+          class="card-footer d-flex bg-primary"
+        >
+          <p
+            class="text-white mr-3 my-2"
+          >
+            You can show your appreciation to the user that helped you the most by giving them a star
+          </p>
+          <button
+            class="btn btn-light text-primary font-weight-bold ml-auto"
+          >
+            Give Star
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Curriculum challenge page Should render appropriately when no challenges are passed to component 1`] = `
 <div>
   <h1>

--- a/components/__snapshots__/LessonTitleCard.test.js.snap
+++ b/components/__snapshots__/LessonTitleCard.test.js.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LessonTitleCard component Should render default layout for wider screens 1`] = `
+<div>
+  <div
+    class="card shadow-sm mt-3 col-12 px-0 pt-3 border-0"
+  >
+    <div
+      class="card-body p-0"
+    >
+      <div
+        class="d-flex mb-3 px-3"
+      >
+        <img
+          alt="lesson-cover"
+          class="lessonTitleCard__lesson-cover mr-3"
+          src="/assets/curriculum/coverUrl"
+        />
+        <div>
+          <p
+            class="m-0"
+          >
+            <a
+              class=""
+              href="/curriculum"
+            >
+              Go Back
+            </a>
+          </p>
+          <h1
+            class="lessonTitleCard__lesson-title"
+          >
+            Test Lesson
+          </h1>
+        </div>
+      </div>
+      <div
+        class="card-footer bg-white p-0"
+      >
+        <a
+          class="btn border-right rounded-0 px-4 py-3"
+          href="lessonUrl"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          LESSON
+        </a>
+        <a
+          class="btn border-right rounded-0 px-4 py-3"
+          href="/curriculum/0"
+        >
+          CHALLENGES
+        </a>
+        <a
+          class="btn border-right rounded-0 px-4 py-3"
+          href="/review/0"
+        >
+          REVIEW
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LessonTitleCard component Should show challenges on click on mobile devices 1`] = `
+<div>
+  <div
+    class="card shadow-sm mt-3 col-12 px-0 pt-3 border-0"
+  >
+    <div
+      class="card-body p-0"
+    >
+      <div
+        class="d-flex mb-3 px-3"
+      >
+        <img
+          alt="lesson-cover"
+          class="lessonTitleCard__lesson-cover mr-3"
+          src="/assets/curriculum/coverUrl"
+        />
+        <div>
+          <p
+            class="m-0"
+          >
+            <a
+              class=""
+              href="/curriculum"
+            >
+              Go Back
+            </a>
+          </p>
+          <h1
+            class="lessonTitleCard__lesson-title"
+          >
+            Test Lesson
+          </h1>
+        </div>
+      </div>
+      <div
+        class="card-footer bg-white p-0"
+      >
+        <a
+          class="btn border-right rounded-0 px-4 py-3"
+          href="lessonUrl"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          LESSON
+        </a>
+        <button
+          class="btn"
+          style="color: rgb(41, 41, 41);"
+        >
+          CHALLENGES
+        </button>
+        <a
+          class="btn border-right rounded-0 px-4 py-3"
+          href="/review/0"
+        >
+          REVIEW
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/__snapshots__/LessonTitleCard.test.js.snap
+++ b/components/__snapshots__/LessonTitleCard.test.js.snap
@@ -108,12 +108,11 @@ exports[`LessonTitleCard component Should show challenges on click on mobile dev
         >
           LESSON
         </a>
-        <button
-          class="btn"
-          style="color: rgb(41, 41, 41);"
+        <div
+          class="btn border-right rounded-0 px-4 py-3"
         >
-          CHALLENGES
-        </button>
+          SHOW CHALLENGES
+        </div>
         <a
           class="btn border-right rounded-0 px-4 py-3"
           href="/review/0"

--- a/pages/curriculum/[lesson].tsx
+++ b/pages/curriculum/[lesson].tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useRouter } from 'next/router'
 import Layout from '../../components/Layout'
 import Error, { StatusCode } from '../../components/Error'
@@ -16,7 +16,7 @@ import _ from 'lodash'
 
 const Challenges: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
   const { lessons, session, alerts } = queryData
-  const [show, setShow] = React.useState(true)
+  const [show, setShow] = useState(false)
   const router = useRouter()
   const currentlessonId = router.query.lesson as string
   if (!lessons || !alerts) {

--- a/pages/curriculum/[lesson].tsx
+++ b/pages/curriculum/[lesson].tsx
@@ -60,6 +60,7 @@ const Challenges: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
                 chatUrl={currentLesson.chatUrl}
                 lessonId={parseInt(currentLesson.id, 10)}
                 show={show}
+                setShow={setShow}
               />
             </div>
           )}

--- a/pages/curriculum/[lesson].tsx
+++ b/pages/curriculum/[lesson].tsx
@@ -16,6 +16,7 @@ import _ from 'lodash'
 
 const Challenges: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
   const { lessons, session, alerts } = queryData
+  const [show, setShow] = React.useState(true)
   const router = useRouter()
   const currentlessonId = router.query.lesson as string
   if (!lessons || !alerts) {
@@ -47,6 +48,8 @@ const Challenges: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
                 lessonTitle={currentLesson.title}
                 lessonId={currentlessonId}
                 isPassed={isPassed}
+                setShow={setShow}
+                show={show}
               />
               {/* Casting alerts as any until type is migrated */}
               {alerts && <AlertsDisplay alerts={alerts as any} />}
@@ -56,6 +59,7 @@ const Challenges: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
                 lessonStatus={currentLessonStatus}
                 chatUrl={currentLesson.chatUrl}
                 lessonId={parseInt(currentLesson.id, 10)}
+                show={show}
               />
             </div>
           )}

--- a/scss/challengeMaterial.scss
+++ b/scss/challengeMaterial.scss
@@ -1,7 +1,16 @@
 .challenges-container {
   width: 100%;
 }
-
+.challenge-display_challenges {
+  @media (max-width: 750px) {
+    display: none;
+    position: absolute;
+    z-index: 1;
+    &.show {
+      display: block;
+    }
+  }
+}
 .challenge-title-card {
   :hover {
     cursor: hand;

--- a/scss/challengeMaterial.scss
+++ b/scss/challengeMaterial.scss
@@ -13,7 +13,7 @@
   }
   &--done {
     color: #6d7278;
-    background-color: rgba(255, 255, 255, 0.5);
+    background-color: rgba(255, 255, 255);
   }
   &--active {
     border-left: 3px solid map-get($theme-colors, 'primary') !important;

--- a/scss/challengeMaterial.scss
+++ b/scss/challengeMaterial.scss
@@ -1,16 +1,11 @@
 .challenges-container {
   width: 100%;
 }
-.challenge-display_challenges {
-  @media (max-width: 750px) {
-    display: none;
-    position: absolute;
-    z-index: 1;
-    &.show {
-      display: block;
-    }
-  }
+.challenge-modal .modal-content {
+  background-color: rgba(0, 0, 0, 0);
+  border: none;
 }
+
 .challenge-title-card {
   :hover {
     cursor: hand;

--- a/stories/components/ChallengeMaterial.stories.tsx
+++ b/stories/components/ChallengeMaterial.stories.tsx
@@ -55,6 +55,8 @@ export const Basic: React.FC = () => (
     lessonStatus={lessonStatus}
     chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
     lessonId={5}
+    show={false}
+    setShow={() => {}}
   />
 )
 
@@ -90,6 +92,8 @@ export const WithDiff: React.FC = () => (
     lessonStatus={lessonStatus}
     chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
     lessonId={5}
+    show={false}
+    setShow={() => {}}
   />
 )
 
@@ -129,6 +133,8 @@ export const WithComments: React.FC = () => (
     lessonStatus={lessonStatus}
     chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
     lessonId={5}
+    show={false}
+    setShow={() => {}}
   />
 )
 
@@ -139,6 +145,8 @@ export const NoChallenges: React.FC = () => (
     lessonStatus={lessonStatus}
     chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
     lessonId={5}
+    show={false}
+    setShow={() => {}}
   />
 )
 
@@ -179,6 +187,8 @@ export const FinalChallenge: React.FC = () => (
       lessonStatus={{ ...lessonStatus, isPassed: 'aef' }}
       chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
       lessonId={5}
+      show={false}
+      setShow={() => {}}
     />
   </MockedProvider>
 )


### PR DESCRIPTION
This PR fixes challenge page for mobile devices. Currently it doesn't look very [good](https://www.c0d3.com/curriculum/5). 

Smaller screens (less than `768px` wide, md bootstrap breakpoint) will see only challenge description while challenge list is hidden. Clicking on`SHOW CHALLENGES` results in modal overlay with challenge list. Clicking on challenge name/background hides it. 

Non-mobile page is pretty much the same except for challenge list background color. Previously it was half transparent, I changed it to fully opaque (I doubt anyone will notice the difference). It was messing with overlay. 

[Vercel](https://c0d3-app-cvjn3p0cr-c0d3.vercel.app/curriculum/5). Enable responsive design mode. Click on `SHOW CHALLENGES`, try selecting various challenges. 