### PR TITLE
Add submission status DB constraint and GraphQL enum

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5869,7 +5869,28 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           </h6>
           <div>
             <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
               className="challenge_status bg-gray"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
             />
             <span
               className="challenge_status bg-gray"
@@ -5878,31 +5899,10 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
               className="challenge_status bg-gray"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
           </div>
         </div>
@@ -6193,7 +6193,28 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           </h6>
           <div>
             <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
               className="challenge_status bg-gray"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
             />
             <span
               className="challenge_status bg-gray"
@@ -6202,31 +6223,10 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
               className="challenge_status bg-gray"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
           </div>
         </div>
@@ -6280,28 +6280,28 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           </h6>
           <div>
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
           </div>
         </div>
@@ -6439,7 +6439,28 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           </h6>
           <div>
             <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
               className="challenge_status bg-gray"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
+            />
+            <span
+              className="challenge_status bg-warning"
             />
             <span
               className="challenge_status bg-gray"
@@ -6448,31 +6469,10 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
               className="challenge_status bg-gray"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
-            />
-            <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
           </div>
         </div>
@@ -6502,19 +6502,19 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           </h6>
           <div>
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
             <span
-              className="challenge_status bg-gray"
+              className="challenge_status bg-warning"
             />
           </div>
         </div>

--- a/__tests__/pages/curriculum/[lesson].test.js
+++ b/__tests__/pages/curriculum/[lesson].test.js
@@ -7,13 +7,14 @@ import dummyLessonData from '../../../__dummy__/lessonData'
 import dummySessionData from '../../../__dummy__/sessionData'
 import dummyAlertData from '../../../__dummy__/alertData'
 import { useRouter } from 'next/router'
+import { SubmissionStatus } from '../../../graphql'
 
 const session = {
   ...dummySessionData,
   submissions: [
     {
       id: '1',
-      status: 'passed',
+      status: SubmissionStatus.Passed,
       mrUrl: '',
       diff: '',
       viewCount: 0,
@@ -30,7 +31,7 @@ const session = {
     },
     {
       id: '1',
-      status: 'passed',
+      status: SubmissionStatus.Passed,
       mrUrl: '',
       diff: '',
       viewCount: 0,

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -248,34 +248,34 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -305,40 +305,40 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -368,37 +368,37 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -428,34 +428,34 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -485,25 +485,25 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -533,31 +533,31 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -587,28 +587,28 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -638,37 +638,37 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -698,40 +698,40 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -761,19 +761,19 @@ exports[`user profile test Should render anonymous users 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1047,34 +1047,34 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1107,37 +1107,37 @@ exports[`user profile test Should render if no stars received 1`] = `
                       class="challenge_status bg-success"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1167,37 +1167,37 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1227,34 +1227,34 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1284,25 +1284,25 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1332,31 +1332,31 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1386,28 +1386,28 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1437,37 +1437,37 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1497,40 +1497,40 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1560,19 +1560,19 @@ exports[`user profile test Should render if no stars received 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1848,34 +1848,34 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1905,40 +1905,40 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -1968,37 +1968,37 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2028,34 +2028,34 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2085,25 +2085,25 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2133,31 +2133,31 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2187,28 +2187,28 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2238,37 +2238,37 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2298,40 +2298,40 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2361,19 +2361,19 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2401,13 +2401,13 @@ exports[`user profile test Should render nulled challenges 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -2953,34 +2953,34 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3013,37 +3013,37 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                       class="challenge_status bg-success"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3073,37 +3073,37 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3133,34 +3133,34 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3190,25 +3190,25 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3238,31 +3238,31 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3292,28 +3292,28 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3343,37 +3343,37 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3403,40 +3403,40 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3466,19 +3466,19 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -3952,34 +3952,34 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4039,34 +4039,34 @@ exports[`user profile test Should render profile 1`] = `
                       class="challenge_status bg-success"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4120,37 +4120,37 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4180,34 +4180,34 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4237,25 +4237,25 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4285,31 +4285,31 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4339,28 +4339,28 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4390,37 +4390,37 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4450,40 +4450,40 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>
@@ -4513,19 +4513,19 @@ exports[`user profile test Should render profile 1`] = `
                   </h6>
                   <div>
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                     <span
-                      class="challenge_status bg-gray"
+                      class="challenge_status bg-warning"
                     />
                   </div>
                 </div>

--- a/__tests__/pages/profile/username.test.js
+++ b/__tests__/pages/profile/username.test.js
@@ -9,6 +9,7 @@ import dummyLessonData from '../../../__dummy__/lessonData'
 import dummySessionData from '../../../__dummy__/sessionData'
 import { useRouter } from 'next/router'
 import expectLoading from '../../utils/expectLoading'
+import { SubmissionStatus } from '../../../graphql'
 
 describe('user profile test', () => {
   const { query } = useRouter()
@@ -22,7 +23,7 @@ describe('user profile test', () => {
       submissions: [
         {
           id: '1',
-          status: 'passed',
+          status: SubmissionStatus.Passed,
           mrUrl: '',
           diff: '',
           viewCount: 0,
@@ -39,7 +40,7 @@ describe('user profile test', () => {
         },
         {
           id: '2',
-          status: 'passed',
+          status: SubmissionStatus.Passed,
           mrUrl: '',
           diff: '',
           viewCount: 0,
@@ -171,7 +172,7 @@ describe('user profile test', () => {
       submissions: [
         {
           id: '1',
-          status: 'passed',
+          status: SubmissionStatus.Passed,
           mrUrl: '',
           diff: '',
           viewCount: 0,
@@ -377,7 +378,7 @@ describe('user profile test', () => {
       submissions: [
         {
           id: 1,
-          status: 'passed',
+          status: SubmissionStatus.Passed,
           mrUrl: '',
           diff: '',
           viewCount: 0,

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -142,8 +142,10 @@ exports[`Lesson Page Should render Error component if route is invalid 1`] = `
             />
             <img
               decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              sizes="100vw"
+              src="/_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=3840&q=75"
+              srcset="/_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=640&q=75 640w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=750&q=75 750w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=828&q=75 828w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1080&q=75 1080w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1200&q=75 1200w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1920&q=75 1920w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=2048&q=75 2048w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=3840&q=75 3840w"
+              style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
             />
           </div>
         </div>

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -142,10 +142,8 @@ exports[`Lesson Page Should render Error component if route is invalid 1`] = `
             />
             <img
               decoding="async"
-              sizes="100vw"
-              src="/_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=3840&q=75"
-              srcset="/_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=640&q=75 640w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=750&q=75 750w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=828&q=75 828w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1080&q=75 1080w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1200&q=75 1200w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1920&q=75 1920w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=2048&q=75 2048w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=3840&q=75 3840w"
-              style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
+              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
             />
           </div>
         </div>

--- a/codegen.yml
+++ b/codegen.yml
@@ -13,4 +13,4 @@ generates:
       withHOC: true
 hooks:
   afterAllFileWrite:
-    - prettier --write
+    - eslint --fix

--- a/codegen.yml
+++ b/codegen.yml
@@ -10,3 +10,7 @@ generates:
       - "typescript-react-apollo"
     config:
       withHooks: true
+      withHOC: true
+hooks:
+  afterAllFileWrite:
+    - prettier --write

--- a/components/ChallengeMaterial.test.js
+++ b/components/ChallengeMaterial.test.js
@@ -7,6 +7,7 @@ import GET_LESSON_MENTORS from '../graphql/queries/getLessonMentors'
 import lessonMentorsData from '../__dummy__/getLessonMentorsData'
 import { MockedProvider } from '@apollo/client/testing'
 import '@testing-library/jest-dom'
+import { SubmissionStatus } from '../graphql'
 
 const mocks = [
   {
@@ -54,7 +55,7 @@ const challenges = [
 const userSubmissions = [
   {
     id: '3500',
-    status: 'open',
+    status: SubmissionStatus.Open,
     mrUrl: 'github.com/testmrurl',
     diff:
       'diff --git a/curriculum/js0/2.js b/curriculum/js0/2.js\nindex 647ca32..ac44196 100644\n--- a/curriculum/js0/2.js\n+++ b/curriculum/js0/2.js\n@@ -7,7 +7,7 @@\n  */\n \n const solution = (a, b, c) => {\n-  return 0;\n+  return a + b + c;\n };\n \n module.exports = {\n',
@@ -67,7 +68,7 @@ const userSubmissions = [
   },
   {
     id: '3501',
-    status: 'needMoreWork',
+    status: SubmissionStatus.NeedMoreWork,
     mrUrl: 'github.com/testmrurl2',
     diff:
       'diff --git a/curriculum/js0/2.js b/curriculum/js0/2.js\nindex 647ca32..ac44196 100644\n--- a/curriculum/js0/2.js\n+++ b/curriculum/js0/2.js\n@@ -7,7 +7,7 @@\n  */\n \n const solution = (a, b, c) => {\n-  return 0;\n+  return a + b + c;\n };\n \n module.exports = {\n',
@@ -128,7 +129,9 @@ describe('Curriculum challenge page', () => {
   test('Should render challenge material page differently when user has passed all their challenges', async () => {
     const { lessonStatus, userSubmissions } = props
     lessonStatus.isPassed = 'cmon bruh ive passed already'
-    userSubmissions.forEach(submission => (submission.status = 'passed'))
+    userSubmissions.forEach(
+      submission => (submission.status = SubmissionStatus.Passed)
+    )
     const { container, getByRole, queryByText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
         <ChallengeMaterial {...props} />

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -16,6 +16,7 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import { GiveStarCard } from '../components/GiveStarCard'
 import _ from 'lodash'
 import Modal from 'react-bootstrap/Modal'
+import { SubmissionStatus } from '../graphql'
 
 dayjs.extend(relativeTime)
 
@@ -42,19 +43,19 @@ export const ReviewStatus: React.FC<ReviewStatusProps> = ({
     </NavLink>
   )
   switch (status) {
-    case 'passed':
+    case SubmissionStatus.Passed:
       reviewStatusComment = (
         <>Your solution was reviewed and accepted by {profileLink}</>
       )
       statusClassName = 'border border-success text-success'
       break
-    case 'needMoreWork':
+    case SubmissionStatus.NeedMoreWork:
       reviewStatusComment = (
         <>Your solution was reviewed and rejected by {profileLink}</>
       )
       statusClassName = 'border border-danger text-danger'
       break
-    case 'open':
+    case SubmissionStatus.Open:
       reviewStatusComment = (
         <>Your submission is currently waiting to be reviewed</>
       )
@@ -79,13 +80,13 @@ const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
   }
   let statusIconUrl
   switch (status) {
-    case 'passed':
+    case SubmissionStatus.Passed:
       statusIconUrl = '/assets/curriculum/icons/checkmark.svg'
       break
-    case 'needMoreWork':
+    case SubmissionStatus.NeedMoreWork:
       statusIconUrl = '/assets/curriculum/icons/rejected.svg'
       break
-    case 'open':
+    case SubmissionStatus.Open:
       statusIconUrl = '/assets/curriculum/icons/pending.svg'
   }
   return <img width="25px" height="25px" src={statusIconUrl} />
@@ -113,7 +114,7 @@ export const ChallengeTitleCard: React.FC<ChallengeTitleCardProps> = ({
   if (active) {
     cardStyles.push('challenge-title-card--active')
   }
-  if (submissionStatus === 'passed') {
+  if (submissionStatus === SubmissionStatus.Passed) {
     cardStyles.push('challenge-title-card--done')
   } else {
     cardStyles.push('shadow-sm', 'border-0')
@@ -347,13 +348,13 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
     order: challenges.length + 1,
     description:
       'Congratulations, you have completed all Challenges for this Lesson',
-    status: 'passed'
+    status: SubmissionStatus.Passed
   }
   //find first challenge that is not passed on initial render after clicks will render clicked challenge
   const currentChallenge =
     challengesWithSubmissionData.find((challenge: ChallengeSubmissionData) => {
       if (currentChallengeID) return challenge.id === currentChallengeID
-      return challenge.status !== 'passed'
+      return challenge.status !== SubmissionStatus.Passed
     }) || finalChallenge
   const challengeTitleCards: React.ReactElement[] = challengesWithSubmissionData.map(
     challenge => {

--- a/components/LessonCard.test.js
+++ b/components/LessonCard.test.js
@@ -3,6 +3,7 @@ import { useQuery } from '@apollo/client'
 import * as React from 'react'
 import LessonCard from './LessonCard'
 import { render } from '@testing-library/react'
+import { SubmissionStatus } from '../graphql'
 
 describe('Lesson Card Complete State', () => {
   test('Should render lessonCard with null if no data', async () => {
@@ -26,13 +27,13 @@ describe('Lesson Card Complete State', () => {
       data: {
         submissions: [
           {
-            status: 'open'
+            status: SubmissionStatus.Open
           },
           {
-            status: 'open'
+            status: SubmissionStatus.Open
           },
           {
-            status: 'needMoreWork'
+            status: SubmissionStatus.NeedMoreWork
           }
         ]
       }
@@ -63,14 +64,7 @@ describe('Lesson Card', () => {
   test('Should render lessonCard with no submission count', async () => {
     useQuery.mockReturnValue({
       data: {
-        submissions: [
-          {
-            status: 'underReview'
-          },
-          {
-            status: 'underReview'
-          }
-        ]
+        submissions: []
       }
     })
 

--- a/components/LessonCard.tsx
+++ b/components/LessonCard.tsx
@@ -10,6 +10,7 @@ import {
 import NavLink from './NavLink'
 import Image from 'next/image'
 import styles from '../scss/lessonCard.module.scss'
+import { SubmissionStatus } from '../graphql'
 
 const ReviewCount: React.FC<ReviewCountProps> = props => {
   const { loading, data } = useQuery(GET_SUBMISSIONS, {
@@ -27,7 +28,7 @@ const ReviewCount: React.FC<ReviewCountProps> = props => {
   }
   const pendingSubmissionsCount = data.submissions.reduce(
     (acc: number, val: any) => {
-      if (val.status === 'open') {
+      if (val.status === SubmissionStatus.Open) {
         acc = acc + 1
         return acc
       }

--- a/components/ProfileSubmissions.tsx
+++ b/components/ProfileSubmissions.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Star as StarType } from '../graphql/index'
 import { Star } from 'react-feather'
 import styles from '../scss/profileSubmissions.module.scss'
+import { SubmissionStatus as SubmissionStatusEnum } from '../graphql'
 
 type ChallengeStatusProps = {
   challengesData: Challenge[]
@@ -29,13 +30,13 @@ export const SubmissionStatus: React.FC<ChallengeStatusProps> = ({
   const submissionsStatus = challengesData.map(
     (eachChallenge: Challenge, challengeId: number) => {
       let challengeStatus = 'bg-gray'
-      if (eachChallenge.challengeStatus === 'passed') {
+      if (eachChallenge.challengeStatus === SubmissionStatusEnum.Passed) {
         challengeStatus = 'bg-success'
       }
-      if (eachChallenge.challengeStatus === 'needMoreWork') {
+      if (eachChallenge.challengeStatus === SubmissionStatusEnum.NeedMoreWork) {
         challengeStatus = 'bg-danger'
       }
-      if (eachChallenge.challengeStatus === 'pending') {
+      if (eachChallenge.challengeStatus === SubmissionStatusEnum.Open) {
         challengeStatus = 'bg-warning'
       }
       return (
@@ -52,7 +53,8 @@ export const SubmissionStatus: React.FC<ChallengeStatusProps> = ({
 const ProfileSubmissions: React.FC<LessonChallengeProps> = ({ lessons }) => {
   const displaySubmissions = lessons.map((lesson, lessonId) => {
     const filterPassedChallenges = lesson.challenges.filter(
-      eachChallenge => eachChallenge.challengeStatus === 'passed'
+      eachChallenge =>
+        eachChallenge.challengeStatus === SubmissionStatusEnum.Passed
     )
 
     let starBadge = <></>

--- a/components/ReviewCard.test.js
+++ b/components/ReviewCard.test.js
@@ -5,6 +5,7 @@ import ACCEPT_SUBMISSION from '../graphql/queries/acceptSubmission'
 import ReviewCard, { DiffView } from './ReviewCard'
 import { MockedProvider } from '@apollo/client/testing'
 import _ from 'lodash'
+import { SubmissionStatus } from '../graphql'
 // correct javascript submission
 const JsDiff =
   'diff --git a/js7/1.js b/js7/1.js\nindex 9c96b34..853bddf 100644\n--- a/js7/1.js\n+++ b/js7/1.js\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
@@ -54,7 +55,7 @@ const mocks = [
         acceptSubmission: {
           id: '1',
           comment: 'good job',
-          status: 'passed'
+          status: SubmissionStatus.Passed
         }
       }
     }

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -234,7 +234,7 @@ export type Star = {
 export type Submission = {
   __typename?: 'Submission'
   id?: Maybe<Scalars['String']>
-  status?: Maybe<Scalars['String']>
+  status: SubmissionStatus
   mrUrl?: Maybe<Scalars['String']>
   diff?: Maybe<Scalars['String']>
   viewCount?: Maybe<Scalars['Int']>
@@ -249,6 +249,12 @@ export type Submission = {
   reviewerId?: Maybe<Scalars['String']>
   createdAt?: Maybe<Scalars['String']>
   updatedAt?: Maybe<Scalars['String']>
+}
+
+export enum SubmissionStatus {
+  NeedMoreWork = 'needMoreWork',
+  Open = 'open',
+  Passed = 'passed'
 }
 
 export type SuccessResponse = {
@@ -984,6 +990,7 @@ export type ResolversTypes = {
   Session: ResolverTypeWrapper<Session>
   Star: ResolverTypeWrapper<Star>
   Submission: ResolverTypeWrapper<Submission>
+  SubmissionStatus: SubmissionStatus
   SuccessResponse: ResolverTypeWrapper<SuccessResponse>
   TokenResponse: ResolverTypeWrapper<TokenResponse>
   User: ResolverTypeWrapper<User>
@@ -1278,7 +1285,7 @@ export type SubmissionResolvers<
   ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']
 > = {
   id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  status?: Resolver<ResolversTypes['SubmissionStatus'], ParentType, ContextType>
   mrUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   diff?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   viewCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -93,7 +93,7 @@ export default gql`
 
   type Submission {
     id: String
-    status: String
+    status: SubmissionStatus!
     mrUrl: String
     diff: String
     viewCount: Int
@@ -108,6 +108,12 @@ export default gql`
     reviewerId: String
     createdAt: String
     updatedAt: String
+  }
+
+  enum SubmissionStatus {
+    needMoreWork
+    open
+    passed
   }
 
   type User {

--- a/helpers/controllers/submissionController.test.js
+++ b/helpers/controllers/submissionController.test.js
@@ -8,6 +8,8 @@ import resolvers from '../../graphql/resolvers'
 import { publicChannelMessage, getUserByEmail } from '../mattermost'
 import { submissions } from './submissionController'
 import { hasPassedLesson } from '../hasPassedLesson'
+import { prisma } from '../../prisma'
+import { SubmissionStatus } from '../../graphql'
 const { Mutation } = resolvers
 const { Lesson, Submission, User, Challenge } = db
 
@@ -147,7 +149,7 @@ describe('Submissions Mutations', () => {
     expect(controller.updateSubmission).toHaveBeenCalledWith({
       ...submission,
       reviewerId: 2,
-      status: 'passed'
+      status: SubmissionStatus.Passed
     })
   })
 
@@ -211,7 +213,7 @@ describe('Submissions Mutations', () => {
 
 describe('Submissions Queries', () => {
   test('should return no submissions if there are none open', async () => {
-    Submission.findAll = jest.fn().mockReturnValue([])
+    prisma.submission.findMany = jest.fn().mockReturnValue([])
     hasPassedLesson.mockReturnValue(true)
     const result = await submissions(
       null,
@@ -231,7 +233,9 @@ describe('Submissions Queries', () => {
       createdAt: '1586386486986',
       challengeId: '200'
     }
-    Submission.findAll = jest.fn().mockResolvedValue([submissionResults])
+    prisma.submission.findMany = jest
+      .fn()
+      .mockResolvedValue([submissionResults])
     hasPassedLesson.mockReturnValue(true)
     const result = await submissions(
       null,

--- a/helpers/controllers/userInfoController.test.js
+++ b/helpers/controllers/userInfoController.test.js
@@ -1,3 +1,4 @@
+import { SubmissionStatus } from '../../graphql'
 import { prisma } from '../../prisma'
 import { userInfo } from './userInfoController'
 
@@ -7,7 +8,7 @@ const user = {
   email: 'testing2020@gmail.com'
 }
 
-const userLesson = { id: '1', status: 'passed', lessonId: 1 }
+const userLesson = { id: '1', status: SubmissionStatus.Passed, lessonId: 1 }
 
 const submission = {
   id: '1',

--- a/helpers/hasPassedLesson.ts
+++ b/helpers/hasPassedLesson.ts
@@ -5,6 +5,7 @@ export const hasPassedLesson = async (
   lessonId: string
 ): Promise<Boolean> => {
   // query userlesson that belongs to lesson and user
+  // TODO fix lessonId graphql typedef to Int
   const userLesson = await prisma.userLesson.findFirst({
     where: {
       lessonId: Number(lessonId),

--- a/helpers/updateSubmission.test.js
+++ b/helpers/updateSubmission.test.js
@@ -5,10 +5,9 @@ import { updateSubmission, sendChatNotification } from './updateSubmission'
 import {
   publicChannelMessage,
   getUserByEmail,
-  getChatUserById,
   sendDirectMessage
 } from './mattermost'
-import { SubmissionStatus } from './controllers/submissionController'
+import { SubmissionStatus } from '../graphql'
 
 const { Challenge, Submission, User, UserLesson, Lesson } = db
 
@@ -36,9 +35,9 @@ describe('updateSubmission', () => {
     }
 
     const submissions = [
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
       { status: 'not passed' } // don't update userlesson
     ]
 
@@ -77,10 +76,10 @@ describe('updateSubmission', () => {
     }
 
     const submissions = [
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' } // update userlesson
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed } // update userlesson
     ]
 
     const setStub = jest.fn()
@@ -124,10 +123,10 @@ describe('updateSubmission', () => {
     }
 
     const submissions = [
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' } // update userlesson
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed } // update userlesson
     ]
 
     const setStub = jest.fn()
@@ -191,10 +190,10 @@ describe('updateSubmission', () => {
     }
 
     const submissions = [
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' } // update userlesson
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed } // update userlesson
     ]
 
     const userLesson = {
@@ -248,10 +247,10 @@ describe('updateSubmission', () => {
     }
 
     const submissions = [
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' },
-      { status: 'passed' } // update userlesson
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed },
+      { status: SubmissionStatus.Passed } // update userlesson
     ]
 
     const userLesson = {
@@ -298,7 +297,7 @@ describe('sendChatNotification', () => {
   })
 
   test('Should send submission accepted notification', async () => {
-    const submission = { status: SubmissionStatus.PASSED, challengeId: '1' }
+    const submission = { status: SubmissionStatus.Passed, challengeId: '1' }
     const reviewer = { username: 'reviewer', email: 'reviewer@fake.com' }
     const challenge = { title: 'Fake Challenge' }
     User.findByPk = jest.fn().mockReturnValue(reviewer)
@@ -312,7 +311,10 @@ describe('sendChatNotification', () => {
   })
 
   test('Should send submission reject notification', async () => {
-    const submission = { status: SubmissionStatus.REJECTED, challengeId: '1' }
+    const submission = {
+      status: SubmissionStatus.NeedMoreWork,
+      challengeId: '1'
+    }
     const reviewer = { username: 'reviewer', email: 'reviewer@fake.com' }
     const challenge = { title: 'Fake Challenge' }
     User.findByPk = jest.fn().mockReturnValue(reviewer)
@@ -327,7 +329,7 @@ describe('sendChatNotification', () => {
 
   test('Should include comment in the message', async () => {
     const submission = {
-      status: SubmissionStatus.PASSED,
+      status: SubmissionStatus.Passed,
       challengeId: '1',
       comment: 'nice work'
     }

--- a/helpers/updateSubmission.ts
+++ b/helpers/updateSubmission.ts
@@ -5,7 +5,7 @@ import {
   publicChannelMessage,
   sendDirectMessage
 } from './mattermost'
-import { SubmissionStatus } from './controllers/submissionController'
+import { SubmissionStatus } from '../graphql'
 
 const { Submission, Challenge, User, UserLesson, Lesson } = db
 
@@ -67,7 +67,7 @@ export const updateSubmission = async (
     // count how many submissions user passed in total
     const passedLessonSubmissions = lessonSubmissions.reduce(
       (sum: number, s: any) =>
-        sum + (s.status === SubmissionStatus.PASSED ? 1 : 0),
+        sum + (s.status === SubmissionStatus.Passed ? 1 : 0),
       0
     )
 
@@ -134,7 +134,7 @@ export const sendChatNotification = async (
   const { username: reviewerChatUsername } = await getUserByEmail(reviewerEmail)
   const { title } = await Challenge.findByPk(challengeId)
   let message = `Your submission for the challenge **_${title}_** has been **${
-    status === SubmissionStatus.PASSED ? 'ACCEPTED' : 'REJECTED'
+    status === SubmissionStatus.Passed ? 'ACCEPTED' : 'REJECTED'
   }** by @${reviewerChatUsername}.`
   if (comment) {
     message += `\n\nThe reviewer left the following comment:\n\n___\n\n${comment}`

--- a/pages/profile/[username].tsx
+++ b/pages/profile/[username].tsx
@@ -2,7 +2,12 @@ import * as React from 'react'
 import _ from 'lodash'
 import Layout from '../../components/Layout'
 import { useRouter } from 'next/router'
-import { UserLesson, Submission, Star } from '../../graphql/index'
+import {
+  UserLesson,
+  Submission,
+  Star,
+  SubmissionStatus
+} from '../../graphql/index'
 import { useUserInfoQuery } from '../../graphql/index'
 import ProfileLessons from '../../components/ProfileLessons'
 import ProfileImageInfo from '../../components/ProfileImageInfo'
@@ -59,7 +64,7 @@ const UserProfile: React.FC = () => {
       ({ status, lessonId }) => {
         // TODO: Fix lesson.id and lessonId types
         return (
-          status === 'passed' &&
+          status === SubmissionStatus.Passed &&
           parseInt(lessonId || '') === parseInt(lesson.id + '')
         )
       }
@@ -88,7 +93,7 @@ const UserProfile: React.FC = () => {
         challengeNumber: challenge.order || 0,
         challengeStatus: challengeSubmission
           ? challengeSubmission.status
-          : 'open'
+          : SubmissionStatus.Open
       }
     })
     const lessonStatus: UserLesson[] = _.get(data, 'userInfo.lessonStatus', [])

--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -16,6 +16,7 @@ import withQueryLoader, {
   QueryDataProps
 } from '../../containers/withQueryLoader'
 import _ from 'lodash'
+import { SubmissionStatus } from '../../graphql'
 
 type SubmissionDisplayProps = {
   submissions: SubmissionData[]
@@ -62,7 +63,8 @@ const Review: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
   const lessonSubmissions: SubmissionData[] = data
     ? data.submissions.filter(
         (submission: SubmissionData) =>
-          submission.status !== 'passed' && submission.status !== 'needMoreWork'
+          submission.status !== SubmissionStatus.Passed &&
+          submission.status !== SubmissionStatus.NeedMoreWork
       )
     : []
   return (

--- a/prisma/migrations/20210421224640_submission_status_check/migration.sql
+++ b/prisma/migrations/20210421224640_submission_status_check/migration.sql
@@ -1,0 +1,11 @@
+-- Delete legacy data
+DELETE FROM "submissions"
+WHERE "status" = 'underReview';
+
+-- AlterTable
+ALTER TABLE "submissions"
+ADD CONSTRAINT "submissions_status_check"
+CHECK ("status" IN ('needMoreWork', 'open', 'passed'));
+
+ALTER TABLE "submissions" ALTER COLUMN "status" SET NOT NULL;
+ALTER TABLE "submissions" ALTER COLUMN "status" SET DEFAULT 'open';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,7 +82,7 @@ model Submission {
   mrUrl       String?    @db.VarChar(255)
   diff        String?
   comment     String?
-  status      String?    @db.VarChar(255)
+  status      String     @default("open") @db.VarChar(255)
   viewCount   Int?       @default(0)
   createdAt   DateTime   @default(now()) @db.Timestamptz(6)
   updatedAt   DateTime   @updatedAt @db.Timestamptz(6)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -22,7 +22,7 @@ async function main() {
   await seedUserLessons(admin, lessons)
   await seedUserLessons(leet, lessons)
   await seedSubmissions(leet, admin, lessons, SubmissionStatus.Passed)
-  await seedSubmissions(noob, null, lessons.slice(0), SubmissionStatus.Open)
+  await seedSubmissions(noob, null, lessons.slice(0, 1), SubmissionStatus.Open)
   await seedStars(leet, admin, lessons)
 }
 

--- a/prisma/seedData.ts
+++ b/prisma/seedData.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client'
+import { SubmissionStatus } from '../graphql'
 
 export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
   {
@@ -743,14 +744,15 @@ export const submissionData = (
   userId: number,
   lessonId: number,
   challengeId: number,
-  reviewerId: number
+  reviewerId: number | undefined | null,
+  status: SubmissionStatus = SubmissionStatus.Open
 ) =>
   Prisma.validator<Prisma.SubmissionCreateManyInput>()({
     userId,
     lessonId,
     challengeId,
     reviewerId,
-    status: 'passed',
+    status,
     diff:
       'diff --git a/js0/1.js b/js0/1.js\nindex d7dcc70..0eff076 100644\n--- a/js0/1.js\n+++ b/js0/1.js\n@@ -6,9 +6,7 @@\n  * @returns {number}\n  */\n \n-const solution = (num1, num2) => {\n-  return 0\n-}\n+const solution = (num1, num2) => num1 + num2\n \n module.exports = {\n   solution\n'
   })

--- a/stories/components/ChallengeMaterial.stories.tsx
+++ b/stories/components/ChallengeMaterial.stories.tsx
@@ -4,6 +4,7 @@ import SET_STAR from '../../graphql/queries/setStar'
 import GET_LESSON_MENTORS from '../../graphql/queries/getLessonMentors'
 import lessonMentorsData from '../../__dummy__/getLessonMentorsData'
 import { MockedProvider } from '@apollo/client/testing'
+import { SubmissionStatus } from '../../graphql'
 export default {
   component: ChallengeMaterial,
   title: 'Components/ChallengeMaterial'
@@ -102,7 +103,7 @@ export const WithComments: React.FC = () => (
     challenges={challenges}
     userSubmissions={[
       {
-        status: 'passed',
+        status: SubmissionStatus.Passed,
         id: '1',
         mrUrl: '',
         diff: `diff --git a/curriculum/js0/2.js b/curriculum/js0/2.js\nindex 647ca32..ac44196 100644\n--- a/curriculum/js0/2.js\n+++ b/curriculum/js0/2.js\n@@ -7,7 +7,7 @@\n  */\n \n const solution = (a, b, c) => {\n-  return 0;\n+  return a + b + c;\n };\n \n module.exports = {\n`,
@@ -156,7 +157,7 @@ export const FinalChallenge: React.FC = () => (
       challenges={challenges}
       userSubmissions={[
         {
-          status: 'passed',
+          status: SubmissionStatus.Passed,
           id: '1',
           mrUrl: '',
           diff: `diff --git a/curriculum/js0/2.js b/curriculum/js0/2.js\nindex 647ca32..ac44196 100644\n--- a/curriculum/js0/2.js\n+++ b/curriculum/js0/2.js\n@@ -7,7 +7,7 @@\n  */\n \n const solution = (a, b, c) => {\n-  return 0;\n+  return a + b + c;\n };\n \n module.exports = {\n`,
@@ -172,7 +173,7 @@ export const FinalChallenge: React.FC = () => (
           updatedAt: Date.now().toString()
         },
         {
-          status: 'passed',
+          status: SubmissionStatus.Passed,
           id: '1',
           mrUrl: '',
           diff: `diff --git a/curriculum/js0/2.js b/curriculum/js0/2.js\nindex 647ca32..ac44196 100644\n--- a/curriculum/js0/2.js\n+++ b/curriculum/js0/2.js\n@@ -7,7 +7,7 @@\n  */\n \n const solution = (a, b, c) => {\n-  return 0;\n+  return a + b + c;\n };\n \n module.exports = {\n`,

--- a/stories/components/LessonCard.stories.tsx
+++ b/stories/components/LessonCard.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import LessonCard from '../../components/LessonCard'
 import { MockedProvider } from '@apollo/client/testing'
 import GET_SUBMISSIONS from '../../graphql/queries/getSubmissions'
+import { SubmissionStatus } from '../../graphql'
 
 export default {
   component: LessonCard,
@@ -25,7 +26,7 @@ const mocks = [
         submissions: [
           {
             id: '',
-            status: 'open',
+            status: SubmissionStatus.Open,
             diff: '',
             comment: '',
             challengeId: '0',
@@ -40,7 +41,7 @@ const mocks = [
           },
           {
             id: '',
-            status: 'open',
+            status: SubmissionStatus.Open,
             diff: '',
             comment: '',
             challengeId: '1',

--- a/stories/components/ReviewCard.stories.tsx
+++ b/stories/components/ReviewCard.stories.tsx
@@ -8,6 +8,7 @@ export default {
 import { MockedProvider } from '@apollo/client/testing'
 import ACCEPT_SUBMISSION from '../../graphql/queries/acceptSubmission'
 import REJECT_SUBMISSION from '../../graphql/queries/rejectSubmission'
+import { SubmissionStatus } from '../../graphql'
 const mocks = [
   {
     request: {
@@ -18,8 +19,7 @@ const mocks = [
       data: {
         acceptSubmission: {
           id: '1',
-          comment: 'good job',
-          status: 'passed'
+          comment: 'good job'
         }
       }
     }
@@ -29,16 +29,14 @@ const mocks = [
       query: REJECT_SUBMISSION,
       variables: {
         id: '1',
-        comment: 'error on line 3',
-        status: 'active'
+        comment: 'error on line 3'
       }
     },
     result: {
       data: {
         rejectSubmission: {
           id: '1',
-          comment: 'error on line 3',
-          status: 'active'
+          comment: 'error on line 3'
         }
       }
     }
@@ -48,7 +46,7 @@ const JsDiff =
   'diff --git a/js7/1.js b/js7/1.js\nindex 9c96b34..853bddf 100644\n--- a/js7/1.js\n+++ b/js7/1.js\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
 const submissionData = {
   id: '1',
-  status: 'active',
+  status: SubmissionStatus.Open,
   mrUrl: '',
   diff: JsDiff,
   viewCount: 0,

--- a/stories/pages/Lesson.stories.tsx
+++ b/stories/pages/Lesson.stories.tsx
@@ -6,6 +6,7 @@ import { withTestRouter } from '../../__tests__/utils/withTestRouter'
 import dummyLessonData from '../../__dummy__/lessonData'
 import dummySessionData from '../../__dummy__/sessionData'
 import dummyAlertData from '../../__dummy__/alertData'
+import { SubmissionStatus } from '../../graphql'
 
 export default {
   component: Lesson,
@@ -66,7 +67,7 @@ export const CompletedChallenges: React.FC = () => {
     submissions: [
       {
         id: '1',
-        status: 'passed',
+        status: SubmissionStatus.Passed,
         mrUrl: '',
         diff: '',
         viewCount: 0,
@@ -83,7 +84,7 @@ export const CompletedChallenges: React.FC = () => {
       },
       {
         id: '1',
-        status: 'passed',
+        status: SubmissionStatus.Passed,
         mrUrl: '',
         diff: '',
         viewCount: 0,

--- a/stories/profile/ProfileSubmissions.stories.tsx
+++ b/stories/profile/ProfileSubmissions.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import ProfileSubmissions from '../../components/ProfileSubmissions'
 import { LessonChallenge } from '../../components/ProfileSubmissions'
+import { SubmissionStatus } from '../../graphql'
 import dummyLesson from '../../__dummy__/lessonData'
 
 export default {
@@ -23,74 +24,74 @@ const mentor = {
 }
 
 const completedChallenges = [
-  { challengeNumber: 1, challengeStatus: 'passed' },
-  { challengeNumber: 2, challengeStatus: 'passed' },
-  { challengeNumber: 3, challengeStatus: 'passed' },
-  { challengeNumber: 4, challengeStatus: 'passed' },
-  { challengeNumber: 5, challengeStatus: 'passed' },
-  { challengeNumber: 6, challengeStatus: 'passed' },
-  { challengeNumber: 7, challengeStatus: 'passed' },
-  { challengeNumber: 8, challengeStatus: 'passed' },
-  { challengeNumber: 9, challengeStatus: 'passed' },
-  { challengeNumber: 10, challengeStatus: 'passed' }
+  { challengeNumber: 1, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 2, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 3, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 4, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 5, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 6, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 7, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 8, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 9, challengeStatus: SubmissionStatus.Passed },
+  { challengeNumber: 10, challengeStatus: SubmissionStatus.Passed }
 ]
 
 const defaultChallenges = [
-  { challengeNumber: 1, challengeStatus: 'open' },
-  { challengeNumber: 2, challengeStatus: 'open' },
-  { challengeNumber: 3, challengeStatus: 'open' },
-  { challengeNumber: 4, challengeStatus: 'open' },
+  { challengeNumber: 1, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 2, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 3, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 4, challengeStatus: SubmissionStatus.Open },
   { challengeNumber: 5 },
-  { challengeNumber: 6, challengeStatus: 'open' },
-  { challengeNumber: 7, challengeStatus: 'open' },
-  { challengeNumber: 8, challengeStatus: 'open' },
+  { challengeNumber: 6, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 7, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 8, challengeStatus: SubmissionStatus.Open },
   { challengeNumber: 9 },
   { challengeNumber: 10 },
-  { challengeNumber: 11, challengeStatus: 'open' },
-  { challengeNumber: 12, challengeStatus: 'open' }
+  { challengeNumber: 11, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 12, challengeStatus: SubmissionStatus.Open }
 ]
 
 const pendingChallenges = [
-  { challengeNumber: 1, challengeStatus: 'pending' },
-  { challengeNumber: 2, challengeStatus: 'pending' },
-  { challengeNumber: 3, challengeStatus: 'pending' },
-  { challengeNumber: 4, challengeStatus: 'pending' },
-  { challengeNumber: 5, challengeStatus: 'pending' },
-  { challengeNumber: 6, challengeStatus: 'pending' },
-  { challengeNumber: 7, challengeStatus: 'pending' },
-  { challengeNumber: 8, challengeStatus: 'pending' },
-  { challengeNumber: 9, challengeStatus: 'pending' },
-  { challengeNumber: 10, challengeStatus: 'pending' },
-  { challengeNumber: 11, challengeStatus: 'pending' }
+  { challengeNumber: 1, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 2, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 3, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 4, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 5, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 6, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 7, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 8, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 9, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 10, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 11, challengeStatus: SubmissionStatus.Open }
 ]
 
 const rejectedChallenges = [
-  { challengeNumber: 1, challengeStatus: 'needMoreWork' },
-  { challengeNumber: 2, challengeStatus: 'needMoreWork' },
-  { challengeNumber: 3, challengeStatus: 'needMoreWork' },
-  { challengeNumber: 4, challengeStatus: 'needMoreWork' },
-  { challengeNumber: 5, challengeStatus: 'needMoreWork' },
-  { challengeNumber: 6, challengeStatus: 'needMoreWork' },
-  { challengeNumber: 7, challengeStatus: 'needMoreWork' }
+  { challengeNumber: 1, challengeStatus: SubmissionStatus.NeedMoreWork },
+  { challengeNumber: 2, challengeStatus: SubmissionStatus.NeedMoreWork },
+  { challengeNumber: 3, challengeStatus: SubmissionStatus.NeedMoreWork },
+  { challengeNumber: 4, challengeStatus: SubmissionStatus.NeedMoreWork },
+  { challengeNumber: 5, challengeStatus: SubmissionStatus.NeedMoreWork },
+  { challengeNumber: 6, challengeStatus: SubmissionStatus.NeedMoreWork },
+  { challengeNumber: 7, challengeStatus: SubmissionStatus.NeedMoreWork }
 ]
 
 const challengesLesson6 = [
-  { challengeNumber: 1, challengeStatus: 'open' },
-  { challengeNumber: 2, challengeStatus: 'open' },
-  { challengeNumber: 3, challengeStatus: 'open' },
-  { challengeNumber: 4, challengeStatus: 'open' },
-  { challengeNumber: 5, challengeStatus: 'open' },
-  { challengeNumber: 6, challengeStatus: 'open' },
-  { challengeNumber: 7, challengeStatus: 'open' },
-  { challengeNumber: 8, challengeStatus: 'open' }
+  { challengeNumber: 1, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 2, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 3, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 4, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 5, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 6, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 7, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 8, challengeStatus: SubmissionStatus.Open }
 ]
 
 const challengesLesson9 = [
-  { challengeNumber: 1, challengeStatus: 'open' },
-  { challengeNumber: 2, challengeStatus: 'open' },
-  { challengeNumber: 3, challengeStatus: 'open' },
-  { challengeNumber: 4, challengeStatus: 'open' },
-  { challengeNumber: 5, challengeStatus: 'open' }
+  { challengeNumber: 1, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 2, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 3, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 4, challengeStatus: SubmissionStatus.Open },
+  { challengeNumber: 5, challengeStatus: SubmissionStatus.Open }
 ]
 
 const starsReceived = [


### PR DESCRIPTION
Part of #545

- Added a migration to create a constraint for the `status` column in the `submissions` table
  - Now `status` is not null and can only be `passed`, `needMoreWork` or `open`, defaulting to the last one.
  - The migration will also delete some legacy entries from the db which have a `underReview` status which is not used in the app. There's 13 rows that match this condition and will be deleted. [These are the entries.](https://user-images.githubusercontent.com/16023489/115643766-cc1ae780-a2f3-11eb-9651-dea082b0914f.png)


- Added a `SubmissionStatus` GraphQL enum type in our typedef file.
  - Changed the type of the `status` field in the `Submission` type to this enum.
  - The auto-generated `graphql/index.tsx` also contains this enum type that can be used for development.
  - Also updated the `submissions` resolver to use Prisma.
- Replaced the hardcoded submission status strings with the new enum on the query resolvers and React components.
  - The `ProfileSubmissions` component had a unused `pending` status code switch case, I replaced it with the `open` status.
  - Also updated all tests, snapshots and stories.
- Fixed the `codegen.yml` file to generate the HOCs that we still use, and to also run `eslint` after generating.
- Added more seed data to include some open submissions for the first lesson from the `noob` user.