### PR TITLE
Add next/image mock

### DIFF
--- a/__mocks__/next/image.tsx
+++ b/__mocks__/next/image.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import type { ImageProps } from 'next/image'
+
+const Image = (props: ImageProps) => <img {...props} />
+
+export default Image

--- a/__tests__/pages/__snapshots__/404.test.js.snap
+++ b/__tests__/pages/__snapshots__/404.test.js.snap
@@ -120,18 +120,13 @@ exports[`404 Error Page should render 1`] = `
         <div
           class="mb-3 col-sm-9"
         >
-          <div
-            style="display: block; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="display: block; box-sizing: border-box; padding-top: 100%;"
-            />
-            <img
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-            />
-          </div>
+          <img
+            height="1200"
+            layout="responsive"
+            objectfit="contain"
+            src="/assets/errors/404.svg"
+            width="1200"
+          />
         </div>
       </div>
     </div>

--- a/__tests__/pages/__snapshots__/500.test.js.snap
+++ b/__tests__/pages/__snapshots__/500.test.js.snap
@@ -118,18 +118,13 @@ exports[`500 Error Page should render 1`] = `
         <div
           class="mb-3 col-sm-9"
         >
-          <div
-            style="display: block; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="display: block; box-sizing: border-box; padding-top: 100%;"
-            />
-            <img
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-            />
-          </div>
+          <img
+            height="1200"
+            layout="responsive"
+            objectfit="contain"
+            src="/assets/errors/500.svg"
+            width="1200"
+          />
         </div>
       </div>
     </div>

--- a/__tests__/pages/__snapshots__/_error.test.js.snap
+++ b/__tests__/pages/__snapshots__/_error.test.js.snap
@@ -118,18 +118,13 @@ exports[`_error page Should capture error when component is loading 1`] = `
         <div
           class="mb-3 col-sm-9"
         >
-          <div
-            style="display: block; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="display: block; box-sizing: border-box; padding-top: 100%;"
-            />
-            <img
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-            />
-          </div>
+          <img
+            height="1200"
+            layout="responsive"
+            objectfit="contain"
+            src="/assets/errors/500.svg"
+            width="1200"
+          />
         </div>
       </div>
     </div>
@@ -262,18 +257,13 @@ exports[`_error page Should return Error 500 component 1`] = `
         <div
           class="mb-3 col-sm-9"
         >
-          <div
-            style="display: block; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="display: block; box-sizing: border-box; padding-top: 100%;"
-            />
-            <img
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-            />
-          </div>
+          <img
+            height="1200"
+            layout="responsive"
+            objectfit="contain"
+            src="/assets/errors/500.svg"
+            width="1200"
+          />
         </div>
       </div>
     </div>

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -96,29 +96,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-0-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-0-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-0-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -165,29 +150,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-1-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-1-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-1-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -234,29 +204,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-2-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-2-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-2-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -303,29 +258,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-3-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-3-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-3-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -372,29 +312,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-4-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-4-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-4-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -441,29 +366,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-5-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-5-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-5-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -510,29 +420,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-6-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-6-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-6-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -579,29 +474,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-7-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-7-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-7-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -648,29 +528,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-8-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-8-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-8-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -717,29 +582,14 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-9-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-9-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-9-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1136,29 +986,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-0-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-0-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-0-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1223,29 +1058,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-1-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-1-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-1-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1292,29 +1112,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-2-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-2-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-2-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1361,29 +1166,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-3-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-3-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-3-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1430,29 +1220,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-4-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-4-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-4-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1499,29 +1274,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-5-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-5-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-5-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1568,29 +1328,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-6-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-6-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-6-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1637,29 +1382,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-7-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-7-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-7-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1706,29 +1436,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-8-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-8-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-8-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -1775,29 +1490,14 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-9-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-9-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-9-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2231,29 +1931,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-0-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-0-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-0-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-0-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2338,29 +2023,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-1-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-1-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-1-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-1-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2445,29 +2115,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-2-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-2-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-2-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-2-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2552,29 +2207,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-3-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-3-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-3-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-3-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2639,29 +2279,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-4-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-4-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-4-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-4-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2708,29 +2333,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-5-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-5-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-5-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-5-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2777,29 +2387,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-6-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-6-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-6-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-6-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2846,29 +2441,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-7-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-7-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-7-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-7-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2915,29 +2495,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-8-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-8-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-8-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-8-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >
@@ -2984,29 +2549,14 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
           <div
             class="d-flex p-2"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="js-9-cover.svg"
-                class="align-self-center"
-                decoding="async"
-                src="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75"
-                srcset="/_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=128&q=75 1x, /_next/image?url=%2Fassets%2Fcurriculum%2Fjs-9-cover.svg&w=256&q=75 2x"
-                style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-              />
-            </div>
+            <img
+              alt="js-9-cover.svg"
+              class="align-self-center"
+              height="165"
+              objectfit="contain"
+              src="/assets/curriculum/js-9-cover.svg"
+              width="116"
+            />
             <div
               class="lesson-card__description pl-4"
             >

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -90,27 +90,12 @@ exports[`Index Page Should render index page 1`] = `
         <div
           class="col-md-6 offset-md-3"
         >
-          <div
-            style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="box-sizing: border-box; display: block; max-width: 100%;"
-            >
-              <img
-                alt=""
-                aria-hidden="true"
-                role="presentation"
-                src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzEzIiBoZWlnaHQ9IjM2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-              />
-            </div>
-            <img
-              alt="Hero image"
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            />
-          </div>
+          <img
+            alt="Hero image"
+            height="360"
+            src="/assets/landing/header-01.svg"
+            width="313"
+          />
         </div>
       </div>
       <div
@@ -188,16 +173,13 @@ exports[`Index Page Should render index page 1`] = `
         <div
           class="col-md-4"
         >
-          <div
-            style="overflow: hidden; box-sizing: border-box; display: inline-block; position: relative; width: 163px; height: 170px;"
-          >
-            <img
-              alt="Modern curriculum"
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            />
-          </div>
+          <img
+            alt="Modern curriculum"
+            height="170"
+            layout="fixed"
+            src="/assets/landing/choose-01.svg"
+            width="163"
+          />
           <h4
             class="mt-3 font-weight-bold"
           >
@@ -212,16 +194,13 @@ exports[`Index Page Should render index page 1`] = `
         <div
           class="col-md-4"
         >
-          <div
-            style="overflow: hidden; box-sizing: border-box; display: inline-block; position: relative; width: 259px; height: 170px;"
-          >
-            <img
-              alt="Support"
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            />
-          </div>
+          <img
+            alt="Support"
+            height="170"
+            layout="fixed"
+            src="/assets/landing/choose-02.svg"
+            width="259"
+          />
           <h4
             class="mt-3 font-weight-bold"
           >
@@ -236,16 +215,13 @@ exports[`Index Page Should render index page 1`] = `
         <div
           class="col-md-4"
         >
-          <div
-            style="overflow: hidden; box-sizing: border-box; display: inline-block; position: relative; width: 93px; height: 170px;"
-          >
-            <img
-              alt="Work Experience"
-              decoding="async"
-              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-              style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-            />
-          </div>
+          <img
+            alt="Work Experience"
+            height="170"
+            layout="fixed"
+            src="/assets/landing/choose-03.svg"
+            width="93"
+          />
           <h4
             class="mt-3 font-weight-bold"
           >
@@ -284,27 +260,13 @@ exports[`Index Page Should render index page 1`] = `
           <div
             class="col-md-5 order-md-2 text-center"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAzIiBoZWlnaHQ9IjI5MyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="Creating an account"
-                decoding="async"
-                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-              />
-            </div>
+            <img
+              alt="Creating an account"
+              height="293"
+              layout="intrinsic"
+              src="/assets/landing/journey-01.svg"
+              width="403"
+            />
           </div>
           <div
             class="col-md-5 offset-md-1 order-md-1 align-self-center"
@@ -328,27 +290,13 @@ exports[`Index Page Should render index page 1`] = `
           <div
             class="col-md-5 offset-md-1 text-center"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDE5IiBoZWlnaHQ9IjQ0OSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="Curriculum"
-                decoding="async"
-                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-              />
-            </div>
+            <img
+              alt="Curriculum"
+              height="449"
+              layout="intrinsic"
+              src="/assets/landing/journey-02.svg"
+              width="419"
+            />
           </div>
           <div
             class="col-md-5 align-self-center"
@@ -382,27 +330,13 @@ exports[`Index Page Should render index page 1`] = `
           <div
             class="col-md-5 order-md-2 text-center"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDE5IiBoZWlnaHQ9IjQzNyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="Pay it forward"
-                decoding="async"
-                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-              />
-            </div>
+            <img
+              alt="Pay it forward"
+              height="437"
+              layout="intrinsic"
+              src="/assets/landing/journey-03.svg"
+              width="419"
+            />
           </div>
           <div
             class="col-md-5 order-md-1 offset-md-1 align-self-center"
@@ -426,27 +360,13 @@ exports[`Index Page Should render index page 1`] = `
           <div
             class="col-md-5 offset-md-1 text-center"
           >
-            <div
-              style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-            >
-              <div
-                style="box-sizing: border-box; display: block; max-width: 100%;"
-              >
-                <img
-                  alt=""
-                  aria-hidden="true"
-                  role="presentation"
-                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzE2IiBoZWlnaHQ9IjQxOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-                  style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-                />
-              </div>
-              <img
-                alt="Work Experience"
-                decoding="async"
-                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
-              />
-            </div>
+            <img
+              alt="Work Experience"
+              height="418"
+              layout="intrinsic"
+              src="/assets/landing/journey-04.svg"
+              width="316"
+            />
           </div>
           <div
             class="col-md-5 align-self-center"

--- a/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
@@ -542,20 +542,13 @@ exports[`Lesson Page Should render correctly with invalid lesson route 1`] = `
         <div
           class="mb-3 col-sm-9"
         >
-          <div
-            style="display: block; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="display: block; box-sizing: border-box; padding-top: 100%;"
-            />
-            <img
-              decoding="async"
-              sizes="100vw"
-              src="/_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=3840&q=75"
-              srcset="/_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=640&q=75 640w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=750&q=75 750w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=828&q=75 828w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1080&q=75 1080w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1200&q=75 1200w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1920&q=75 1920w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=2048&q=75 2048w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=3840&q=75 3840w"
-              style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-            />
-          </div>
+          <img
+            height="1200"
+            layout="responsive"
+            objectfit="contain"
+            src="/assets/errors/404.svg"
+            width="1200"
+          />
         </div>
       </div>
     </div>
@@ -1140,20 +1133,13 @@ exports[`Lesson Page Should return Internal server Error if alerts or lessons ar
         <div
           class="mb-3 col-sm-9"
         >
-          <div
-            style="display: block; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="display: block; box-sizing: border-box; padding-top: 100%;"
-            />
-            <img
-              decoding="async"
-              sizes="100vw"
-              src="/_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=3840&q=75"
-              srcset="/_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=640&q=75 640w, /_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=750&q=75 750w, /_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=828&q=75 828w, /_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=1080&q=75 1080w, /_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=1200&q=75 1200w, /_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=1920&q=75 1920w, /_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=2048&q=75 2048w, /_next/image?url=%2Fassets%2Ferrors%2F500.svg&w=3840&q=75 3840w"
-              style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-            />
-          </div>
+          <img
+            height="1200"
+            layout="responsive"
+            objectfit="contain"
+            src="/assets/errors/500.svg"
+            width="1200"
+          />
         </div>
       </div>
     </div>

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -134,20 +134,13 @@ exports[`Lesson Page Should render Error component if route is invalid 1`] = `
         <div
           class="mb-3 col-sm-9"
         >
-          <div
-            style="display: block; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-          >
-            <div
-              style="display: block; box-sizing: border-box; padding-top: 100%;"
-            />
-            <img
-              decoding="async"
-              sizes="100vw"
-              src="/_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=3840&q=75"
-              srcset="/_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=640&q=75 640w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=750&q=75 750w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=828&q=75 828w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1080&q=75 1080w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1200&q=75 1200w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=1920&q=75 1920w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=2048&q=75 2048w, /_next/image?url=%2Fassets%2Ferrors%2F404.svg&w=3840&q=75 3840w"
-              style="visibility: inherit; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-            />
-          </div>
+          <img
+            height="1200"
+            layout="responsive"
+            objectfit="contain"
+            src="/assets/errors/404.svg"
+            width="1200"
+          />
         </div>
       </div>
     </div>

--- a/components/__snapshots__/LessonCard.test.js.snap
+++ b/components/__snapshots__/LessonCard.test.js.snap
@@ -8,27 +8,13 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
     <div
       class="d-flex p-2"
     >
-      <div
-        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-      >
-        <div
-          style="box-sizing: border-box; display: block; max-width: 100%;"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            role="presentation"
-            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-          />
-        </div>
-        <img
-          class="align-self-center"
-          decoding="async"
-          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-        />
-      </div>
+      <img
+        class="align-self-center"
+        height="165"
+        objectfit="contain"
+        src="/assets/curriculum/undefined"
+        width="116"
+      />
       <div
         class="lesson-card__description pl-4"
       >
@@ -113,27 +99,13 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
     <div
       class="d-flex p-2"
     >
-      <div
-        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-      >
-        <div
-          style="box-sizing: border-box; display: block; max-width: 100%;"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            role="presentation"
-            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-          />
-        </div>
-        <img
-          class="align-self-center"
-          decoding="async"
-          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-        />
-      </div>
+      <img
+        class="align-self-center"
+        height="165"
+        objectfit="contain"
+        src="/assets/curriculum/undefined"
+        width="116"
+      />
       <div
         class="lesson-card__description pl-4"
       >
@@ -217,27 +189,13 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
     <div
       class="d-flex p-2"
     >
-      <div
-        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-      >
-        <div
-          style="box-sizing: border-box; display: block; max-width: 100%;"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            role="presentation"
-            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-          />
-        </div>
-        <img
-          class="align-self-center"
-          decoding="async"
-          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-        />
-      </div>
+      <img
+        class="align-self-center"
+        height="165"
+        objectfit="contain"
+        src="/assets/curriculum/undefined"
+        width="116"
+      />
       <div
         class="lesson-card__description pl-4"
       >
@@ -321,27 +279,13 @@ exports[`Lesson Card Should render ellpsis when no data is present 1`] = `
     <div
       class="d-flex p-2"
     >
-      <div
-        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-      >
-        <div
-          style="box-sizing: border-box; display: block; max-width: 100%;"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            role="presentation"
-            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-          />
-        </div>
-        <img
-          class="align-self-center"
-          decoding="async"
-          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-        />
-      </div>
+      <img
+        class="align-self-center"
+        height="165"
+        objectfit="contain"
+        src="/assets/curriculum/undefined"
+        width="116"
+      />
       <div
         class="lesson-card__description pl-4"
       >
@@ -388,27 +332,13 @@ exports[`Lesson Card Should render lessonCard with inProgress currentState prop 
     <div
       class="d-flex p-2"
     >
-      <div
-        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-      >
-        <div
-          style="box-sizing: border-box; display: block; max-width: 100%;"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            role="presentation"
-            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-          />
-        </div>
-        <img
-          class="align-self-center"
-          decoding="async"
-          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-        />
-      </div>
+      <img
+        class="align-self-center"
+        height="165"
+        objectfit="contain"
+        src="/assets/curriculum/undefined"
+        width="116"
+      />
       <div
         class="lesson-card__description pl-4"
       >
@@ -458,27 +388,13 @@ exports[`Lesson Card Should render lessonCard with lessonId prop 1`] = `
     <div
       class="d-flex p-2"
     >
-      <div
-        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-      >
-        <div
-          style="box-sizing: border-box; display: block; max-width: 100%;"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            role="presentation"
-            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-          />
-        </div>
-        <img
-          class="align-self-center"
-          decoding="async"
-          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-        />
-      </div>
+      <img
+        class="align-self-center"
+        height="165"
+        objectfit="contain"
+        src="/assets/curriculum/undefined"
+        width="116"
+      />
       <div
         class="lesson-card__description pl-4"
       >
@@ -525,27 +441,13 @@ exports[`Lesson Card Should render lessonCard with no submission count 1`] = `
     <div
       class="d-flex p-2"
     >
-      <div
-        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-      >
-        <div
-          style="box-sizing: border-box; display: block; max-width: 100%;"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            role="presentation"
-            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-          />
-        </div>
-        <img
-          class="align-self-center"
-          decoding="async"
-          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-        />
-      </div>
+      <img
+        class="align-self-center"
+        height="165"
+        objectfit="contain"
+        src="/assets/curriculum/undefined"
+        width="116"
+      />
       <div
         class="lesson-card__description pl-4"
       >
@@ -592,27 +494,13 @@ exports[`Lesson Card Should render loading card when loading 1`] = `
     <div
       class="d-flex p-2"
     >
-      <div
-        style="display: inline-block; max-width: 100%; overflow: hidden; position: relative; box-sizing: border-box; margin: 0px;"
-      >
-        <div
-          style="box-sizing: border-box; display: block; max-width: 100%;"
-        >
-          <img
-            alt=""
-            aria-hidden="true"
-            role="presentation"
-            src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTE2IiBoZWlnaHQ9IjE2NSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
-            style="max-width: 100%; display: block; margin: 0px; padding: 0px;"
-          />
-        </div>
-        <img
-          class="align-self-center"
-          decoding="async"
-          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-          style="visibility: hidden; position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: contain;"
-        />
-      </div>
+      <img
+        class="align-self-center"
+        height="165"
+        objectfit="contain"
+        src="/assets/curriculum/undefined"
+        width="116"
+      />
       <div
         class="lesson-card__description pl-4"
       >

--- a/components/mdx/ModalImage.test.js
+++ b/components/mdx/ModalImage.test.js
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Image from './ModalImage'
 import userEvent from '@testing-library/user-event'
+jest.unmock('next/image')
 
 describe('Image component test', () => {
   test('Should render image', async () => {


### PR DESCRIPTION
Closes #717

- Added manual mock for the `next/image` component.
  - This component made some snapshots fail randomly due to do unpredictable behavior.
  - Mock just returns a simple `<img />` passing all the props from the image.
- Updated all the snapshots affected from this.
- The modal image mdx component had to have this module unmocked to test the visibility.