### PR TITLE
Fix session graphql query

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -546,10 +546,7 @@ export type GetSessionQuery = { __typename?: 'Query' } & {
               | 'updatedAt'
             > & {
                 reviewer?: Maybe<
-                  { __typename?: 'User' } & Pick<
-                    User,
-                    'id' | 'username' | 'isAdmin'
-                  >
+                  { __typename?: 'User' } & Pick<User, 'id' | 'username'>
                 >
               }
           >
@@ -2212,7 +2209,6 @@ export const GetSessionDocument = gql`
         reviewer {
           id
           username
-          isAdmin
         }
         createdAt
         updatedAt

--- a/graphql/queries/getSession.ts
+++ b/graphql/queries/getSession.ts
@@ -22,7 +22,6 @@ const GET_SESSION = gql`
         reviewer {
           id
           username
-          isAdmin
         }
         createdAt
         updatedAt

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -39,8 +39,7 @@ const generateMap = (
   session: GetSessionQuery['session']
 ): { [id: string]: UserLesson } => {
   const lessonStatusMap: { [id: string]: UserLesson } = {}
-  if (!session) return lessonStatusMap
-  const { lessonStatus } = session
+  const { lessonStatus } = session!
   for (const status of lessonStatus) {
     const lessonId = _.get(status, 'lessonId', '-1') as string
     lessonStatusMap[lessonId] = status

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -11,9 +11,9 @@ import {
   GetAppDocument,
   Lesson,
   Alert,
-  Session,
   UserLesson,
-  useGetSessionQuery
+  useGetSessionQuery,
+  GetSessionQuery
 } from '../graphql/'
 import DiscordBar from '../components/DiscordBar'
 import _ from 'lodash'
@@ -31,20 +31,26 @@ type Props = {
   alerts: Alert[]
 }
 interface State {
-  session: Session
+  session: GetSessionQuery['session']
   progress: number
   current: number
 }
-const generateMap = (session: Session): { [id: string]: UserLesson } => {
-  const { lessonStatus } = session
+const generateMap = (
+  session: GetSessionQuery['session']
+): { [id: string]: UserLesson } => {
   const lessonStatusMap: { [id: string]: UserLesson } = {}
+  if (!session) return lessonStatusMap
+  const { lessonStatus } = session
   for (const status of lessonStatus) {
     const lessonId = _.get(status, 'lessonId', '-1') as string
     lessonStatusMap[lessonId] = status
   }
   return lessonStatusMap
 }
-const calculateProgress = (session: Session, lessons: Lesson[]): number => {
+const calculateProgress = (
+  session: GetSessionQuery['session'],
+  lessons: Lesson[]
+): number => {
   const lessonStatusMap = generateMap(session)
   const lessonInProgressIdx = _.cond([
     [_.isEqual.bind(null, -1), _.constant(0)],
@@ -60,7 +66,10 @@ const calculateProgress = (session: Session, lessons: Lesson[]): number => {
   const TOTAL_LESSONS = 7
   return Math.floor((lessonInProgressIdx * 100) / TOTAL_LESSONS)
 }
-const calculateCurrent = (session: Session, lessons: Lesson[]): number => {
+const calculateCurrent = (
+  session: GetSessionQuery['session'],
+  lessons: Lesson[]
+): number => {
   const lessonStatusMap = generateMap(session)
   return _.cond([
     [_.isEqual.bind(null, -1), _.constant(0)],


### PR DESCRIPTION
The `getSession` query was requesting the `isAdmin` field for the `reviewer` user on submissions.

This value is not needed at all for the app, it's only used for the user in the session.

It was also giving error messages from the network requests.

![image](https://user-images.githubusercontent.com/16023489/115802902-22505f00-a3b6-11eb-81f4-d0fac5d0afd9.png)
