### PR TITLE
Challenges table migration, replace sequelize on challenge controller

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -181,10 +181,10 @@ export type MutationCreateChallengeArgs = {
 
 export type MutationUpdateChallengeArgs = {
   lessonId: Scalars['Int']
+  order: Scalars['Int']
+  description: Scalars['String']
+  title: Scalars['String']
   id: Scalars['Int']
-  order?: Maybe<Scalars['Int']>
-  description?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
 }
 
 export type Query = {
@@ -680,9 +680,9 @@ export type SignupMutation = { __typename?: 'Mutation' } & {
 
 export type UpdateChallengeMutationVariables = Exact<{
   lessonId: Scalars['Int']
-  order?: Maybe<Scalars['Int']>
-  description?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
+  order: Scalars['Int']
+  description: Scalars['String']
+  title: Scalars['String']
   id: Scalars['Int']
 }>
 
@@ -1205,7 +1205,10 @@ export type MutationResolvers<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
     ParentType,
     ContextType,
-    RequireFields<MutationUpdateChallengeArgs, 'lessonId' | 'id'>
+    RequireFields<
+      MutationUpdateChallengeArgs,
+      'lessonId' | 'order' | 'description' | 'title' | 'id'
+    >
   >
 }
 
@@ -2993,9 +2996,9 @@ export type SignupMutationOptions = Apollo.BaseMutationOptions<
 export const UpdateChallengeDocument = gql`
   mutation updateChallenge(
     $lessonId: Int!
-    $order: Int
-    $description: String
-    $title: String
+    $order: Int!
+    $description: String!
+    $title: String!
     $id: Int!
   ) {
     updateChallenge(

--- a/graphql/queries/updateChallenge.ts
+++ b/graphql/queries/updateChallenge.ts
@@ -3,9 +3,9 @@ import { gql } from '@apollo/client'
 const UPDATE_CHALLENGE = gql`
   mutation updateChallenge(
     $lessonId: Int!
-    $order: Int
-    $description: String
-    $title: String
+    $order: Int!
+    $description: String!
+    $title: String!
     $id: Int!
   ) {
     updateChallenge(

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -73,10 +73,10 @@ export default gql`
     ): [Lesson]
     updateChallenge(
       lessonId: Int!
+      order: Int!
+      description: String!
+      title: String!
       id: Int!
-      order: Int
-      description: String
-      title: String
     ): [Lesson]
   }
 

--- a/prisma/migrations/20210423013330_challenge_fixes/migration.sql
+++ b/prisma/migrations/20210423013330_challenge_fixes/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `status` on the `challenges` table. All the data in the column will be lost.
+  - Made the column `description` on table `challenges` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `title` on table `challenges` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `order` on table `challenges` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `lessonId` on table `challenges` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- Delete legacy data
+DELETE FROM "challenges"
+WHERE 
+  "challenges"."description" IS NULL
+  OR "challenges"."title" IS NULL
+  OR "challenges"."order" IS NULL
+  OR "challenges"."lessonId" IS NULL;
+
+-- AlterTable
+ALTER TABLE "challenges" 
+DROP COLUMN "status",
+ALTER COLUMN "description" SET NOT NULL,
+ALTER COLUMN "title" SET NOT NULL,
+ALTER COLUMN "order" SET NOT NULL,
+ALTER COLUMN "lessonId" SET NOT NULL,
+DROP CONSTRAINT IF EXISTS "challenges_lessonId_fkey";
+
+-- Recreate foreign key with ON DELETE CASCADE
+ALTER TABLE "challenges" ADD CONSTRAINT "challenges_lessonId_fk" 
+FOREIGN KEY ("lessonId") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,14 +30,13 @@ model Alert {
 
 model Challenge {
   id          Int          @id @default(autoincrement())
-  status      String?      @db.VarChar(255)
-  description String?
-  title       String?      @db.VarChar(255)
-  order       Int?
+  description String
+  title       String       @db.VarChar(255)
+  order       Int
   createdAt   DateTime     @default(now()) @db.Timestamptz(6)
   updatedAt   DateTime     @updatedAt @db.Timestamptz(6)
-  lessonId    Int?
-  lesson      Lesson?      @relation(fields: [lessonId], references: [id])
+  lessonId    Int
+  lesson      Lesson       @relation(fields: [lessonId], references: [id])
   submissions Submission[]
 
   @@map("challenges")


### PR DESCRIPTION
Part of #545 

- Challenges table migrations
  - Deletes legacy data with `title`, `order`, `description` or `lessonId` columns with null values.
  - Removed the `status` column since it's unused and only contains null values.
  - Made `title`, `order`, `description` and `lessonId` columns NOT NULL.
  - Added foreign key on `lessonId` because the production DB doesn't have one. [Prod db table DDL](https://user-images.githubusercontent.com/16023489/115811341-e45b3700-a3c5-11eb-9f38-f5b389f614af.png). This foreign key will cascade on delete and on update so there's no more orphan challenges.

- Changed `updateChallenge` mutation to have all variables required.

- Replaced Sequelize with Prisma on `challengesController`.
  - Also replaced the types with the auto generated ones.