### PR TITLE
update #719 - add custom titles

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,5 @@
 #docker volumes
 docker/volumes/
+#TO-DO fix eslint and mdx integration (imports and ">", "<" signs)
+pages/docs/
+pages/curriculum/lessons/

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -15747,7 +15747,7 @@ Array [
           >
             <a
               className="btn border-right rounded-0 px-4 py-3"
-              href="/"
+              href="/curriculum/lessons/js0/primitive_data_and_operators"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/components/Error.tsx
+++ b/components/Error.tsx
@@ -18,7 +18,7 @@ const errorTitle: Readonly<{ [key in StatusCode]: string }> = {
 
 const Error: React.FC<ErrorProps> = ({ code, message }) => {
   return (
-    <Layout>
+    <Layout title={errorTitle[code]}>
       <div className="container">
         <div className="row">
           <div className="d-flex col-sm-3 align-items-center justify-content-center">

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import AppNav from './AppNav'
 import Footer from './Footer'
-
-const Layout: React.FC = ({ children }) => (
+import Head from 'next/head'
+const Layout: React.FC<{ title?: string }> = ({ children, title }) => (
   <>
+    <Head>
+      <title key="title">{title ? `${title} — C0D3` : 'C0D3'}</title>
+    </Head>
     <AppNav />
     <div className="container-md">{children}</div>
     <Footer />

--- a/components/admin/AdminLayout.tsx
+++ b/components/admin/AdminLayout.tsx
@@ -5,7 +5,11 @@ import _ from 'lodash'
 import { GetAppProps } from '../../graphql'
 import Error, { StatusCode } from '../../components/Error'
 import { useRouter } from 'next/router'
-export const AdminLayout: React.FC<GetAppProps> = ({ data, children }) => {
+export const AdminLayout: React.FC<GetAppProps & { title?: string }> = ({
+  data,
+  children,
+  title
+}) => {
   const router = useRouter()
   const { loading, error, session } = data
 
@@ -23,7 +27,7 @@ export const AdminLayout: React.FC<GetAppProps> = ({ data, children }) => {
 
   if (!isAdmin) {
     return (
-      <Layout>
+      <Layout title={title}>
         <h1>You must be admin to access this page</h1>
       </Layout>
     )

--- a/components/mdx/LessonLayout.test.js
+++ b/components/mdx/LessonLayout.test.js
@@ -33,7 +33,7 @@ describe('Layout component', () => {
         <Layout
           lessonCoverUrl="test"
           lessonId="1"
-          lessonTitle="Test title"
+          title="Test title"
           isPassed={true}
         />
       </MockedProvider>

--- a/components/mdx/LessonLayout.tsx
+++ b/components/mdx/LessonLayout.tsx
@@ -5,7 +5,9 @@ import styles from '../../scss/mdx.module.scss'
 import { useRouter } from 'next/router'
 import _ from 'lodash'
 
-type LayoutProps = Partial<LessonTitleProps & { subLessons?: string[] }>
+type LayoutProps = Partial<
+  LessonTitleProps & { subLessons?: string[]; title?: string }
+>
 
 const ScrollTop: React.FC<{ scroll: boolean }> = ({ scroll }) => {
   return (
@@ -55,16 +57,19 @@ const LessonLayout: React.FC<LayoutProps> = props => {
       )
     })
   return (
-    <Layout>
+    <Layout title={props.title || 'C0D3'}>
       <div className="mt-4">
-        {props.lessonTitle && (
-          <LessonTitleCard {...(props as LessonTitleProps)} />
+        {props.lessonCoverUrl && (
+          <LessonTitleCard
+            {...(props as LessonTitleProps)}
+            lessonTitle={props.title!}
+          />
         )}
       </div>
       <div
         className={`${styles['lesson-wrapper']} card shadow-sm mt-3 d-block border-0 p-3 p-md-4 bg-white`}
       >
-        {!props.lessonTitle && (
+        {!props.lessonCoverUrl && (
           <button
             className="btn btn-link text-primary p-0"
             onClick={() => router.back()}
@@ -73,7 +78,7 @@ const LessonLayout: React.FC<LayoutProps> = props => {
           </button>
         )}
         <ScrollTop scroll={scroll} />
-        <div className={styles.title}>{props.lessonTitle}</div>
+        <div className={styles.title}>{props.title}</div>
         {lessonParts}
         {props.children}
       </div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "next --port $PORT",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --ext .js --ext .ts --ext .tsx",
+    "lint": "eslint . --ext .js --ext .ts --ext .tsx --ext .mdx",
     "lint:fix": "yarn lint --fix && prettier --write ./scss/",
     "autofix": "yarn lint:fix && svgo --folder=public --recursive && svgo --folder=assets --recursive",
     "storybook": "start-storybook -p $STORY_PORT -c .storybook -s ./public",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -39,7 +39,6 @@ function MyApp({ Component, pageProps, err }: IProps) {
       <MDXProvider components={MDXcomponents}>
         <Head>
           {/* <!-- Primary Meta Tags --> */}
-          <title>C0D3</title>
           <meta name="title" content="C0D3" />
           <meta
             name="description"

--- a/pages/admin/alerts.tsx
+++ b/pages/admin/alerts.tsx
@@ -64,7 +64,7 @@ const Alerts: React.FC<GetAppProps> = ({ data }) => {
   ))
 
   return (
-    <AdminLayout data={data}>
+    <AdminLayout data={data} title="Admin alerts">
       <Card
         primary={true}
         title="Alerts"

--- a/pages/admin/lessons.tsx
+++ b/pages/admin/lessons.tsx
@@ -10,7 +10,7 @@ const Lessons: React.FC<GetAppProps> = ({ data }) => {
   const [lessonsList, setLessons] = useState<null | Lesson[]>(null)
   const { lessons } = data
   return (
-    <AdminLayout data={data}>
+    <AdminLayout data={data} title="Admin lessons">
       <div className="row mt-4">
         <AdminLessonsSideBar
           setLessons={setLessons}

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -118,7 +118,7 @@ const LoadUsers: React.FC = withQueryLoader<AllUsersData>(
 
 const Users: React.FC<GetAppProps> = ({ data }) => {
   return (
-    <AdminLayout data={data}>
+    <AdminLayout data={data} title="Admin users">
       <LoadUsers />
     </AdminLayout>
   )

--- a/pages/confirm/[token].tsx
+++ b/pages/confirm/[token].tsx
@@ -92,7 +92,7 @@ export const ResetPassword: React.FC = () => {
 }
 
 export const ResetPasswordContainer = () => (
-  <Layout>
+  <Layout title="Confirm">
     <ResetPassword />
   </Layout>
 )

--- a/pages/contributors.tsx
+++ b/pages/contributors.tsx
@@ -13,7 +13,7 @@ export const Contributors = () => {
     )
   })
   return (
-    <Layout>
+    <Layout title="Contributors">
       <div className="row mt-4">{userData}</div>
     </Layout>
   )

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -132,7 +132,7 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
     )
   })
   return (
-    <Layout>
+    <Layout title="Curriculum">
       <div className="row">
         <AlertsDisplay alerts={alerts} page="curriculum" />
         <div className="col-xl-8 order-xl-0 order-1">{lessonsToRender}</div>

--- a/pages/curriculum/[lesson].tsx
+++ b/pages/curriculum/[lesson].tsx
@@ -38,7 +38,7 @@ const Challenges: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
   const isPassed = !!currentLessonStatus.isTeaching
   return (
     <div>
-      <Layout>
+      <Layout title={`${currentLesson.title}`}>
         <div className="row mt-4">
           {currentLesson && (
             <div className="challenges-container">

--- a/pages/curriculum/lessons/js0/functions_and_execution_context.mdx
+++ b/pages/curriculum/lessons/js0/functions_and_execution_context.mdx
@@ -1264,7 +1264,7 @@ Concepts you must know:
 export default ({ children }) => (
   <Layout
     lessonCoverUrl={`js-0-cover.svg`}
-    lessonTitle="Foundations of JavaScript"
+    title="Foundations of JavaScript"
     lessonUrl="/curriculum/lessons/js0/primitive_data_and_operators"
     lessonId="5"
     subLessons={[

--- a/pages/curriculum/lessons/js0/primitive_data_and_operators.mdx
+++ b/pages/curriculum/lessons/js0/primitive_data_and_operators.mdx
@@ -694,7 +694,7 @@ a = new EventEmitter()
 export default ({ children }) => (
   <Layout
     lessonCoverUrl={`js-0-cover.svg`}
-    lessonTitle="Foundations of JavaScript"
+    title="Foundations of JavaScript"
     lessonUrl="/curriculum/lessons/js0/primitive_data_and_operators"
     lessonId="5"
     subLessons={[

--- a/pages/docs/chromebook.mdx
+++ b/pages/docs/chromebook.mdx
@@ -1,7 +1,5 @@
 import LessonLayout from '../../components/mdx/LessonLayout'
 
-## Step 1 install Linux
-
 In order to install nodejs on a chromebook you must have linux enabled. If you
 do not have linux enabled on your computer please follow the steps outlined
 below.
@@ -50,4 +48,6 @@ Once all these is done, you should have node and npm installed. Type in
 
 ---
 
-export default ({ children }) => <LessonLayout>{children}</LessonLayout>
+export default ({ children }) => (
+  <LessonLayout title="Installing Linux on Chromebook">{children}</LessonLayout>
+)

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -1,7 +1,5 @@
 import LessonLayout from '../../components/mdx/LessonLayout'
 
-# Important Commands
-
 In this section we will be going over the following commonly used commands:
 
 > `pwd`, `ls`, `cd`, `mkdir`
@@ -65,4 +63,6 @@ Let's assume our current path is: `/home/cookie/Desktop/notes2357/curriculum`
 > Make sure you include a space between the command (`ls`) and the options (like
 > `..`, `../..`, etc.).
 
-export default ({ children }) => <LessonLayout>{children}</LessonLayout>
+export default ({ children }) => (
+  <LessonLayout title="Command line interface">{children}</LessonLayout>
+)

--- a/pages/docs/git.mdx
+++ b/pages/docs/git.mdx
@@ -1,7 +1,5 @@
 import LessonLayout from '../../components/mdx/LessonLayout'
 
-# Common Git Commands
-
 ## Git Overview
 
 Git is a version control system. Imagine working on a codebase with 3 engineers,
@@ -112,4 +110,6 @@ Check
 [The Missing Semester](https://missing.csail.mit.edu/2020/version-control/) if
 you want to learn more about git and other useful tools.
 
-export default ({ children }) => <LessonLayout>{children}</LessonLayout>
+export default ({ children }) => (
+  <LessonLayout title="Common Git commands">{children}</LessonLayout>
+)

--- a/pages/docs/numbers.mdx
+++ b/pages/docs/numbers.mdx
@@ -104,4 +104,6 @@ Get 52 from 5249
 
 </Spoiler>
 
-export default ({ children }) => <LessonLayout>{children}</LessonLayout>
+export default ({ children }) => (
+  <LessonLayout title="Division and Mod operations">{children}</LessonLayout>
+)

--- a/pages/docs/setup.mdx
+++ b/pages/docs/setup.mdx
@@ -1,9 +1,5 @@
 import LessonLayout from '../../components/mdx/LessonLayout'
 
-# Setup Instructions
-
-<br />
-
 ## Code Editor
 
 You can choose any editor you want VS Code, WebStorm IDE, Sublime Text or even
@@ -285,4 +281,6 @@ to run code directly in the browser. Now you are ready to start your journey.
 
 [JS 0 - Foundations](/curriculum/lessons/js0/primitive_data_and_operators)
 
-export default ({ children }) => <LessonLayout>{children}</LessonLayout>
+export default ({ children }) => (
+  <LessonLayout title="Development setup">{children}</LessonLayout>
+)

--- a/pages/forgotpassword.tsx
+++ b/pages/forgotpassword.tsx
@@ -78,7 +78,7 @@ export const ResetPassword: React.FC = () => {
 }
 
 export const ResetPasswordContainer = () => (
-  <Layout>
+  <Layout title="Reset password">
     <ResetPassword />
   </Layout>
 )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import AppNav from '../components/AppNav'
 import LandingPage from '../components/LandingPage'
 import Footer from '../components/Footer'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 const IndexPage: React.FC<{}> = () => {
   const router = useRouter()
@@ -14,6 +15,9 @@ const IndexPage: React.FC<{}> = () => {
   //render empty white background with AppNav before possible redirect to prevent 'flickering'
   return (
     <>
+      <Head>
+        <title key="title">Learn Javascript the old school way — C0D3</title>
+      </Head>
       <AppNav />
       {status ? (
         <>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -111,7 +111,7 @@ const LoginPage: React.FC = () => {
     } catch {} // catch error that's thrown by default from mutation
   }
   return (
-    <Layout>
+    <Layout title="Login">
       <Login handleSubmit={handleSubmit} loginErrors={loginErrors} />
     </Layout>
   )

--- a/pages/profile/[username].tsx
+++ b/pages/profile/[username].tsx
@@ -129,7 +129,7 @@ const UserProfile: React.FC = () => {
   )
 
   return (
-    <Layout>
+    <Layout title={userInfo.username}>
       <div className="row mt-4">
         <div className="mb-3 mb-md-0 col-md-4">
           <ProfileImageInfo user={userInfo} />

--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -69,7 +69,7 @@ const Review: React.FC<QueryDataProps<AppData>> = ({ queryData }) => {
     : []
   return (
     <div>
-      <Layout>
+      <Layout title={`Review - ${currentLesson.title}`}>
         <div className="row mt-4">
           <LessonTitleCard
             lessonCoverUrl={`js-${currentLesson.order}-cover.svg`}

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -155,7 +155,7 @@ const SignUpPage: React.FC = () => {
     setIsSubmitting(false)
   }
   return (
-    <Layout>
+    <Layout title="Sign up">
       <Signup
         handleSubmit={handleSubmit}
         isLoading={isSubmitting}

--- a/stories/components/mdx/Layout.stories.tsx
+++ b/stories/components/mdx/Layout.stories.tsx
@@ -45,8 +45,8 @@ export const WithLesson: React.FC = () => {
     <MockedProvider mocks={mocks} addTypename={false}>
       <Layout
         lessonCoverUrl={`js-0-cover.svg`}
-        lessonTitle="Foundations of JavaScript"
-        lessonUrl="/"
+        title="Foundations of JavaScript"
+        lessonUrl="/curriculum/lessons/js0/primitive_data_and_operators"
         lessonId="1"
         subLessons={[
           'Primitive data and operators',


### PR DESCRIPTION
* `Layout`, `AdminLayout` and `LessonLayout` components accept optional title variable. If no title is provided page gets default `C0D3` header. 
* Every page has it's own title in the format of `PageName - C0D3`. Index page is named `Learn Javascript the old school way — C0D3` (should I change it?).
* I added mdx files back to eslint ignore and updated `yarn lint` command (it wasn't formatting `.mdx` files previously unlike `npx lint-staged`).

~~I'm not sure what's wrong with history favicons on Firefox though. It works on Chrome and Chromium.~~ 
Edit. Turns out it was caching issue with Firefox. Adding `href="/favicon.ico?"` fixed it for me. Should we force refresh favicon in production? 

[Vercel](https://c0d3-app-e4gxl65zf-c0d3.vercel.app/). 