### PR TITLE
Remove Object-Fit - Invalid property causes warning to appear on tests. 

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -3017,7 +3017,6 @@ Array [
             className="img-fluid"
             height={1200}
             layout="responsive"
-            objectFit="contain"
             src="/assets/errors/500.svg"
             width={1200}
           />
@@ -3181,7 +3180,6 @@ Array [
             className="img-fluid"
             height={1200}
             layout="responsive"
-            objectFit="contain"
             src="/assets/errors/404.svg"
             width={1200}
           />
@@ -4748,7 +4746,6 @@ exports[`Storyshots Components/LessonCard Basic 1`] = `
       alt="js-4-cover.svg"
       className="img-fluid"
       height="165"
-      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
       width="116"
     />
@@ -4807,7 +4804,6 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
       alt="js-4-cover.svg"
       className="img-fluid"
       height="165"
-      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
       width="116"
     />
@@ -4909,7 +4905,6 @@ exports[`Storyshots Components/LessonCard With In Progress 1`] = `
       alt="js-4-cover.svg"
       className="img-fluid"
       height="165"
-      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
       width="116"
     />
@@ -8533,7 +8528,6 @@ Array [
               alt="js-0-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -8589,7 +8583,6 @@ Array [
               alt="js-1-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -8645,7 +8638,6 @@ Array [
               alt="js-2-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -8701,7 +8693,6 @@ Array [
               alt="js-3-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -8757,7 +8748,6 @@ Array [
               alt="js-4-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -8813,7 +8803,6 @@ Array [
               alt="js-5-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -8869,7 +8858,6 @@ Array [
               alt="js-6-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -8925,7 +8913,6 @@ Array [
               alt="js-7-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -8981,7 +8968,6 @@ Array [
               alt="js-8-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -9037,7 +9023,6 @@ Array [
               alt="js-9-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />
@@ -9428,7 +9413,6 @@ Array [
               alt="js-0-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -9484,7 +9468,6 @@ Array [
               alt="js-1-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -9540,7 +9523,6 @@ Array [
               alt="js-2-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -9596,7 +9578,6 @@ Array [
               alt="js-3-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -9652,7 +9633,6 @@ Array [
               alt="js-4-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -9708,7 +9688,6 @@ Array [
               alt="js-5-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -9764,7 +9743,6 @@ Array [
               alt="js-6-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -9820,7 +9798,6 @@ Array [
               alt="js-7-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -9876,7 +9853,6 @@ Array [
               alt="js-8-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -9932,7 +9908,6 @@ Array [
               alt="js-9-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />
@@ -10323,7 +10298,6 @@ Array [
               alt="js-0-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -10379,7 +10353,6 @@ Array [
               alt="js-1-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -10435,7 +10408,6 @@ Array [
               alt="js-2-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -10491,7 +10463,6 @@ Array [
               alt="js-3-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -10547,7 +10518,6 @@ Array [
               alt="js-4-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -10603,7 +10573,6 @@ Array [
               alt="js-5-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -10659,7 +10628,6 @@ Array [
               alt="js-6-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -10715,7 +10683,6 @@ Array [
               alt="js-7-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -10771,7 +10738,6 @@ Array [
               alt="js-8-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -10827,7 +10793,6 @@ Array [
               alt="js-9-cover.svg"
               className="img-fluid"
               height="165"
-              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />

--- a/__tests__/pages/__snapshots__/404.test.js.snap
+++ b/__tests__/pages/__snapshots__/404.test.js.snap
@@ -123,7 +123,6 @@ exports[`404 Error Page should render 1`] = `
           <img
             height="1200"
             layout="responsive"
-            objectfit="contain"
             src="/assets/errors/404.svg"
             width="1200"
           />

--- a/__tests__/pages/__snapshots__/500.test.js.snap
+++ b/__tests__/pages/__snapshots__/500.test.js.snap
@@ -121,7 +121,6 @@ exports[`500 Error Page should render 1`] = `
           <img
             height="1200"
             layout="responsive"
-            objectfit="contain"
             src="/assets/errors/500.svg"
             width="1200"
           />

--- a/__tests__/pages/__snapshots__/_error.test.js.snap
+++ b/__tests__/pages/__snapshots__/_error.test.js.snap
@@ -121,7 +121,6 @@ exports[`_error page Should capture error when component is loading 1`] = `
           <img
             height="1200"
             layout="responsive"
-            objectfit="contain"
             src="/assets/errors/500.svg"
             width="1200"
           />
@@ -260,7 +259,6 @@ exports[`_error page Should return Error 500 component 1`] = `
           <img
             height="1200"
             layout="responsive"
-            objectfit="contain"
             src="/assets/errors/500.svg"
             width="1200"
           />

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -100,7 +100,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-0-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -154,7 +153,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-1-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -208,7 +206,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-2-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -262,7 +259,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-3-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -316,7 +312,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-4-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -370,7 +365,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-5-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -424,7 +418,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-6-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -478,7 +471,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-7-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -532,7 +524,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-8-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -586,7 +577,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
               alt="js-9-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />
@@ -982,7 +972,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-0-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -1054,7 +1043,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-1-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -1108,7 +1096,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-2-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -1162,7 +1149,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-3-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -1216,7 +1202,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-4-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -1270,7 +1255,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-5-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -1324,7 +1308,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-6-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -1378,7 +1361,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-7-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -1432,7 +1414,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-8-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -1486,7 +1467,6 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
               alt="js-9-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />
@@ -1927,7 +1907,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-0-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -2019,7 +1998,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-1-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -2111,7 +2089,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-2-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -2203,7 +2180,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-3-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -2275,7 +2251,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-4-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -2329,7 +2304,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-5-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -2383,7 +2357,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-6-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -2437,7 +2410,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-7-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -2491,7 +2463,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-8-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -2545,7 +2516,6 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               alt="js-9-cover.svg"
               class="align-self-center"
               height="165"
-              objectfit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />

--- a/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
@@ -545,7 +545,6 @@ exports[`Lesson Page Should render correctly with invalid lesson route 1`] = `
           <img
             height="1200"
             layout="responsive"
-            objectfit="contain"
             src="/assets/errors/404.svg"
             width="1200"
           />
@@ -1136,7 +1135,6 @@ exports[`Lesson Page Should return Internal server Error if alerts or lessons ar
           <img
             height="1200"
             layout="responsive"
-            objectfit="contain"
             src="/assets/errors/500.svg"
             width="1200"
           />

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -137,7 +137,6 @@ exports[`Lesson Page Should render Error component if route is invalid 1`] = `
           <img
             height="1200"
             layout="responsive"
-            objectfit="contain"
             src="/assets/errors/404.svg"
             width="1200"
           />

--- a/components/Error.tsx
+++ b/components/Error.tsx
@@ -36,7 +36,6 @@ const Error: React.FC<ErrorProps> = ({ code, message }) => {
             <Image
               src={`/assets/errors/${code}.svg`}
               layout="responsive"
-              objectFit="contain"
               width={1200}
               height={1200}
             />

--- a/components/LessonCard.tsx
+++ b/components/LessonCard.tsx
@@ -66,7 +66,6 @@ const LessonCard: React.FC<Props> = props => {
         <Image
           src={`/assets/curriculum/${props.coverImg}`}
           alt={props.coverImg}
-          objectFit="contain"
           className="align-self-center"
           width="116"
           height="165"

--- a/components/__snapshots__/LessonCard.test.js.snap
+++ b/components/__snapshots__/LessonCard.test.js.snap
@@ -11,7 +11,6 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
       <img
         class="align-self-center"
         height="165"
-        objectfit="contain"
         src="/assets/curriculum/undefined"
         width="116"
       />
@@ -102,7 +101,6 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
       <img
         class="align-self-center"
         height="165"
-        objectfit="contain"
         src="/assets/curriculum/undefined"
         width="116"
       />
@@ -192,7 +190,6 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
       <img
         class="align-self-center"
         height="165"
-        objectfit="contain"
         src="/assets/curriculum/undefined"
         width="116"
       />
@@ -282,7 +279,6 @@ exports[`Lesson Card Should render ellpsis when no data is present 1`] = `
       <img
         class="align-self-center"
         height="165"
-        objectfit="contain"
         src="/assets/curriculum/undefined"
         width="116"
       />
@@ -335,7 +331,6 @@ exports[`Lesson Card Should render lessonCard with inProgress currentState prop 
       <img
         class="align-self-center"
         height="165"
-        objectfit="contain"
         src="/assets/curriculum/undefined"
         width="116"
       />
@@ -391,7 +386,6 @@ exports[`Lesson Card Should render lessonCard with lessonId prop 1`] = `
       <img
         class="align-self-center"
         height="165"
-        objectfit="contain"
         src="/assets/curriculum/undefined"
         width="116"
       />
@@ -444,7 +438,6 @@ exports[`Lesson Card Should render lessonCard with no submission count 1`] = `
       <img
         class="align-self-center"
         height="165"
-        objectfit="contain"
         src="/assets/curriculum/undefined"
         width="116"
       />
@@ -497,7 +490,6 @@ exports[`Lesson Card Should render loading card when loading 1`] = `
       <img
         class="align-self-center"
         height="165"
-        objectfit="contain"
         src="/assets/curriculum/undefined"
         width="116"
       />

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "next --port $PORT",
     "build": "next build",
     "start": "next start",
+    "jest": "jest",
     "lint": "eslint . --ext .js --ext .ts --ext .tsx",
     "lint:fix": "yarn lint --fix && prettier --write ./scss/",
     "autofix": "yarn lint:fix && svgo --folder=public --recursive && svgo --folder=assets --recursive",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "dev": "next --port $PORT",
     "build": "next build",
     "start": "next start",
-    "jest": "jest",
     "lint": "eslint . --ext .js --ext .ts --ext .tsx",
     "lint:fix": "yarn lint --fix && prettier --write ./scss/",
     "autofix": "yarn lint:fix && svgo --folder=public --recursive && svgo --folder=assets --recursive",


### PR DESCRIPTION
`objectFit` is only needed when `layout="fill" when using `Next/Image`.  

This is causing the following warning in tests:

```
   console.error
      Warning: React does not recognize the `objectFit` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `objectfit` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
          at img
          at Image
          at div
          at div
          at div
          at div
          at Layout (/home/runner/work/c0d3-app/c0d3-app/components/Layout.tsx:5:49)
          at Error (/home/runner/work/c0d3-app/c0d3-app/components/Error.tsx:19:40)
          at UserProfile (/home/runner/work/c0d3-app/c0d3-app/pages/profile/[username].tsx:34:36)
          at ApolloProvider (/home/runner/work/c0d3-app/c0d3-app/node_modules/@apollo/client/react/context/ApolloProvider.js:5:21)
          at MockedProvider (/home/runner/work/c0d3-app/c0d3-app/node_modules/@apollo/client/utilities/testing/mocking/MockedProvider.js:10:28)
```

Reference: https://nextjs.org/docs/api-reference/next/image#objectfit

