### PR TITLE
update#545 updates User type on prisma and graphql

### DIFF
--- a/__dummy__/sessionData.js
+++ b/__dummy__/sessionData.js
@@ -3,6 +3,7 @@ export default {
     id: 1,
     username: 'fakeusername',
     name: 'fake user',
+    email: 'fake@fakemail.com',
     isAdmin: true
   },
   submissions: [],

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -271,10 +271,10 @@ export type TokenResponse = {
 export type User = {
   __typename?: 'User'
   id: Scalars['Int']
-  username?: Maybe<Scalars['String']>
+  username: Scalars['String']
   userLesson?: Maybe<UserLesson>
-  email?: Maybe<Scalars['String']>
-  name?: Maybe<Scalars['String']>
+  email: Scalars['String']
+  name: Scalars['String']
   isAdmin: Scalars['Boolean']
   cliToken?: Maybe<Scalars['String']>
 }
@@ -1321,14 +1321,14 @@ export type UserResolvers<
   ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
 > = {
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
-  username?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  username?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   userLesson?: Resolver<
     Maybe<ResolversTypes['UserLesson']>,
     ParentType,
     ContextType
   >
-  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   isAdmin?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
   cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -118,10 +118,10 @@ export default gql`
 
   type User {
     id: Int!
-    username: String
+    username: String!
     userLesson: UserLesson
-    email: String
-    name: String
+    email: String!
+    name: String!
     isAdmin: Boolean!
     cliToken: String
   }

--- a/helpers/controllers/authController.ts
+++ b/helpers/controllers/authController.ts
@@ -149,7 +149,8 @@ export const signup = async (_parent: void, arg: SignUp, ctx: Context) => {
       data: {
         name,
         username,
-        email
+        email,
+        password
       }
     })
 

--- a/prisma/migrations/20210428060853_user_username_email_required_unique/migration.sql
+++ b/prisma/migrations/20210428060853_user_username_email_required_unique/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[username]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[email]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+  - Made the column `name` on table `users` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `username` on table `users` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `password` on table `users` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `email` on table `users` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "name" SET NOT NULL,
+ALTER COLUMN "username" SET NOT NULL,
+ALTER COLUMN "password" SET NOT NULL,
+ALTER COLUMN "email" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users.username_unique" ON "users"("username");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users.email_unique" ON "users"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,10 +114,10 @@ model UserLesson {
 
 model User {
   id                     Int          @id @default(autoincrement())
-  name                   String?      @db.VarChar(255)
-  username               String?      @db.VarChar(255)
-  password               String?      @db.VarChar(255)
-  email                  String?      @db.VarChar(255)
+  name                   String       @db.VarChar(255)
+  username               String       @db.VarChar(255) @unique
+  password               String       @db.VarChar(255)
+  email                  String       @db.VarChar(255) @unique
   gsId                   Int?
   isOnline               Boolean?
   createdAt              DateTime     @default(now()) @db.Timestamptz(6)

--- a/stories/components/ChallengeMaterial.stories.tsx
+++ b/stories/components/ChallengeMaterial.stories.tsx
@@ -86,7 +86,13 @@ export const WithDiff: React.FC = () => (
           order: 1,
           lessonId: 23
         },
-        user: { id: 1, isAdmin: false },
+        user: {
+          id: 1,
+          username: 'fakeuser',
+          name: 'fake user',
+          email: 'fake@fakemail.com',
+          isAdmin: false
+        },
         reviewerId: '',
         createdAt: '',
         updatedAt: Date.now().toString()
@@ -107,7 +113,13 @@ export const WithDiff: React.FC = () => (
           order: 1,
           lessonId: 23
         },
-        user: { id: 1, isAdmin: false },
+        user: {
+          id: 1,
+          username: 'fakeuser',
+          name: 'fake user',
+          email: 'fake@fakemail.com',
+          isAdmin: false
+        },
         reviewerId: '',
         createdAt: '',
         updatedAt: Date.now().toString()
@@ -141,10 +153,18 @@ export const WithComments: React.FC = () => (
           order: 1,
           lessonId: 23
         },
-        user: { id: 1, isAdmin: false },
+        user: {
+          id: 1,
+          username: 'fakeuser',
+          name: 'fake user',
+          email: 'fake@fakemail.com',
+          isAdmin: false
+        },
         reviewer: {
           id: 1,
           username: 'dan',
+          name: 'danny boy',
+          email: 'danny@fakemail.com',
           isAdmin: false
         },
         reviewerId: '1',
@@ -167,7 +187,13 @@ export const WithComments: React.FC = () => (
           order: 1,
           lessonId: 23
         },
-        user: { id: 1, isAdmin: false },
+        user: {
+          id: 1,
+          username: 'fakeuser',
+          name: 'fake user',
+          email: 'fake@fakemail.com',
+          isAdmin: false
+        },
         reviewerId: '',
         createdAt: '',
         updatedAt: Date.now().toString()
@@ -214,10 +240,18 @@ export const FinalChallenge: React.FC = () => (
             order: 1,
             lessonId: 23
           },
-          user: { id: 5, isAdmin: false },
+          user: {
+            id: 1,
+            username: 'fakeuser',
+            name: 'fake user',
+            email: 'fake@fakemail.com',
+            isAdmin: false
+          },
           reviewer: {
             id: 1,
             username: 'dan',
+            name: 'danny boy',
+            email: 'danny@fakemail.com',
             isAdmin: false
           },
           reviewerId: '1',
@@ -242,6 +276,9 @@ export const FinalChallenge: React.FC = () => (
           },
           user: {
             id: 1,
+            username: 'fakeuser',
+            name: 'fake user',
+            email: 'fake@fakemail.com',
             isAdmin: false
           },
           reviewerId: '',

--- a/stories/components/ReviewCard.stories.tsx
+++ b/stories/components/ReviewCard.stories.tsx
@@ -56,6 +56,8 @@ const submissionData = {
   lessonId: 2,
   user: {
     username: 'fake user',
+    name: 'fake student',
+    email: 'fake@fakemail.com',
     id: 1,
     isAdmin: false
   },
@@ -69,6 +71,8 @@ const submissionData = {
   reviewer: {
     id: 1,
     username: 'fake reviewer',
+    name: 'fake reviewer',
+    email: 'fake@fakemail.com',
     isAdmin: false
   },
   createdAt: '123',

--- a/stories/pages/Curriculum.stories.tsx
+++ b/stories/pages/Curriculum.stories.tsx
@@ -61,6 +61,7 @@ export const CompletedLessons: React.FC<{}> = () => {
       id: 1,
       username: 'fakeusername',
       name: 'fake user',
+      email: 'fake@fakemail.com',
       isAdmin: true
     },
     submissions: [],

--- a/stories/profile/ProfileStarComments.stories.tsx
+++ b/stories/profile/ProfileStarComments.stories.tsx
@@ -14,6 +14,7 @@ const stars: StarType[] = [
       id: 1,
       name: 'Alexandra',
       username: 'ale',
+      email: 'ale@fakemail.com',
       isAdmin: false
     },
     lessonId: 23,
@@ -31,6 +32,7 @@ const stars: StarType[] = [
       id: 2,
       name: 'Charles',
       username: 'cko',
+      email: 'cko@fakemail.com',
       isAdmin: false
     },
     lessonId: 33,

--- a/stories/profile/ProfileSubmissions.stories.tsx
+++ b/stories/profile/ProfileSubmissions.stories.tsx
@@ -13,6 +13,7 @@ const student = {
   id: 2,
   username: 'fakeusername',
   name: 'fake user',
+  email: 'student@fakemail.com',
   isAdmin: false
 }
 
@@ -20,6 +21,7 @@ const mentor = {
   id: 1,
   username: 'admin',
   name: 'Admin Admin',
+  email: 'mentor@fakemail.com',
   isAdmin: true
 }
 


### PR DESCRIPTION
Graphql - User typeDef now requires username, email, and name

Prisma - User table now requires username, email, name, password, with username and email unique constraints added.

Only 'real' change besides that is the addition of password in authController (line 153)

    let newUser = await prisma.user.create({
      data: {
        name,
        username,
        email,
        password <-- now required by schema
      }
    })