### PR TITLE
fix image stretching

### DIFF
--- a/__mocks__/next/image.tsx
+++ b/__mocks__/next/image.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import type { ImageProps } from 'next/image'
+import _ from 'lodash'
 
-const Image = (props: ImageProps) => <img {...props} />
+const Image = (props: ImageProps) => {
+  //not all Image properties are allowed in <img/> tag
+  const copy = _.omit(props, 'objectFit')
+  return <img {...copy} />
+}
 
 export default Image

--- a/__mocks__/next/image.tsx
+++ b/__mocks__/next/image.tsx
@@ -3,7 +3,9 @@ import type { ImageProps } from 'next/image'
 import _ from 'lodash'
 
 const Image = (props: ImageProps) => {
-  //not all Image properties are allowed in <img/> tag
+  /*not all Image properties are allowed in <img/> tag
+  ObjectFit causes warnings, but otherwise lessons/error images won't keep their dimensions 
+  see https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit*/
   const copy = _.omit(props, 'objectFit')
   return <img {...copy} />
 }

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2712,6 +2712,7 @@ Array [
             className="img-fluid"
             height={1200}
             layout="responsive"
+            objectFit="contain"
             src="/assets/errors/500.svg"
             width={1200}
           />
@@ -2875,6 +2876,7 @@ Array [
             className="img-fluid"
             height={1200}
             layout="responsive"
+            objectFit="contain"
             src="/assets/errors/404.svg"
             width={1200}
           />
@@ -4441,6 +4443,7 @@ exports[`Storyshots Components/LessonCard Basic 1`] = `
       alt="js-4-cover.svg"
       className="img-fluid"
       height="165"
+      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
       width="116"
     />
@@ -4499,6 +4502,7 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
       alt="js-4-cover.svg"
       className="img-fluid"
       height="165"
+      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
       width="116"
     />
@@ -4600,6 +4604,7 @@ exports[`Storyshots Components/LessonCard With In Progress 1`] = `
       alt="js-4-cover.svg"
       className="img-fluid"
       height="165"
+      objectFit="contain"
       src="/assets/curriculum/js-4-cover.svg"
       width="116"
     />
@@ -8223,6 +8228,7 @@ Array [
               alt="js-0-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -8278,6 +8284,7 @@ Array [
               alt="js-1-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -8333,6 +8340,7 @@ Array [
               alt="js-2-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -8388,6 +8396,7 @@ Array [
               alt="js-3-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -8443,6 +8452,7 @@ Array [
               alt="js-4-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -8498,6 +8508,7 @@ Array [
               alt="js-5-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -8553,6 +8564,7 @@ Array [
               alt="js-6-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -8608,6 +8620,7 @@ Array [
               alt="js-7-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -8663,6 +8676,7 @@ Array [
               alt="js-8-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -8718,6 +8732,7 @@ Array [
               alt="js-9-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />
@@ -9108,6 +9123,7 @@ Array [
               alt="js-0-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -9163,6 +9179,7 @@ Array [
               alt="js-1-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -9218,6 +9235,7 @@ Array [
               alt="js-2-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -9273,6 +9291,7 @@ Array [
               alt="js-3-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -9328,6 +9347,7 @@ Array [
               alt="js-4-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -9383,6 +9403,7 @@ Array [
               alt="js-5-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -9438,6 +9459,7 @@ Array [
               alt="js-6-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -9493,6 +9515,7 @@ Array [
               alt="js-7-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -9548,6 +9571,7 @@ Array [
               alt="js-8-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -9603,6 +9627,7 @@ Array [
               alt="js-9-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />
@@ -9993,6 +10018,7 @@ Array [
               alt="js-0-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-0-cover.svg"
               width="116"
             />
@@ -10048,6 +10074,7 @@ Array [
               alt="js-1-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-1-cover.svg"
               width="116"
             />
@@ -10103,6 +10130,7 @@ Array [
               alt="js-2-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-2-cover.svg"
               width="116"
             />
@@ -10158,6 +10186,7 @@ Array [
               alt="js-3-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-3-cover.svg"
               width="116"
             />
@@ -10213,6 +10242,7 @@ Array [
               alt="js-4-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-4-cover.svg"
               width="116"
             />
@@ -10268,6 +10298,7 @@ Array [
               alt="js-5-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-5-cover.svg"
               width="116"
             />
@@ -10323,6 +10354,7 @@ Array [
               alt="js-6-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-6-cover.svg"
               width="116"
             />
@@ -10378,6 +10410,7 @@ Array [
               alt="js-7-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-7-cover.svg"
               width="116"
             />
@@ -10433,6 +10466,7 @@ Array [
               alt="js-8-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-8-cover.svg"
               width="116"
             />
@@ -10488,6 +10522,7 @@ Array [
               alt="js-9-cover.svg"
               className="img-fluid"
               height="165"
+              objectFit="contain"
               src="/assets/curriculum/js-9-cover.svg"
               width="116"
             />

--- a/components/Error.tsx
+++ b/components/Error.tsx
@@ -38,6 +38,7 @@ const Error: React.FC<ErrorProps> = ({ code, message }) => {
               layout="responsive"
               width={1200}
               height={1200}
+              objectFit="contain"
             />
           </div>
         </div>

--- a/components/LessonCard.tsx
+++ b/components/LessonCard.tsx
@@ -69,6 +69,7 @@ const LessonCard: React.FC<Props> = props => {
           className="align-self-center"
           width="116"
           height="165"
+          objectFit="contain"
         />
 
         <div className={`${styles['lesson-card__description']} pl-4`}>


### PR DESCRIPTION
#744 fixed test warnings but it broke image stretching (check 500 error screen or compare J4 and J5 lesson images on curriculum page). This PR fixes mismatch between `Image` and `img` props. 