### PR TITLE
Add `post-merge` git hook, remove tests from `pre-commit`

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,48 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# Don't need to run this on CI environments
+[ -n "$CI" ] && exit 0
+
+##
+# This command will run after `git pull`, and check if new modules need to be
+# installed.
+
+# Collect a list of changed files
+changedFiles="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+
+# NOTE - Uncomment one of the below lines to test against yarn or npm changes
+# changedFiles="$changedFiles"$'\n'"yarn.lock"
+# changedFiles="$changedFiles"$'\n'"package-lock.json"
+
+depsChanged=$(echo "$changedFiles" | grep -e "package-lock.json" -e "yarn.lock")
+
+prismaChanged=$(echo "$changedFiles" | grep -e "schema.prisma")
+
+# Define update msg variable
+upgradeMsg=$(cat <<-DOC
+ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+ ┃ Node dependencies have changed. ┃
+ ┃     Updating dependencies...    ┃
+ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+DOC
+)
+
+prismaMsg=$(cat <<-DOC
+ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+ ┃   Prisma schema has changed.    ┃
+ ┃       Generating client..       ┃
+ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+DOC
+)
+
+# Update deps
+if [ -n "$depsChanged" ]; then
+  echo "$upgradeMsg"
+  yarn
+  exit 0
+fi
+if [ -n "$prismaChanged" ]; then
+  echo "$prismaMsg"
+  yarn prisma generate
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged && npm run type-check && npm test
+npx lint-staged


### PR DESCRIPTION
- Added a new `post-merge` git hook to husky
  - This hook is executed after `git pull`
  - First checks if it's running on a CI, skipping the script if true
  - If the updated files includes `yarn.lock` then runs `yarn` to update dependencies
  - Else if the updated files includes `schema.prisma` then runs `yarn prisma generate` to update the Prisma client.
  - Source: https://gist.github.com/the0neWhoKnocks/c05fd2a082936fc95642849bddb7205b

- Removed the tests and type-check from the `pre-commit` hook
  - I think everybody skipped this hook anyway, at least I did. I run tests after I done everything I wanted.
  - Now the hook only runs `lint-staged` to auto-format the files.

The git hook scripts also works on Windows, even though it's a shell script, git for Windows includes git bash which is able to run it (https://typicode.github.io/husky/#/?id=does-it-work-on-windows).