### PR TITLE
Replace Sequelize on `lessonsController` and `starsController`

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -163,13 +163,13 @@ export type MutationCreateLessonArgs = {
 
 export type MutationUpdateLessonArgs = {
   id: Scalars['Int']
-  description?: Maybe<Scalars['String']>
+  description: Scalars['String']
   docUrl?: Maybe<Scalars['String']>
   githubUrl?: Maybe<Scalars['String']>
   videoUrl?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
+  title: Scalars['String']
   chatUrl?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
+  order: Scalars['Int']
 }
 
 export type MutationCreateChallengeArgs = {
@@ -719,9 +719,9 @@ export type UpdateLessonMutationVariables = Exact<{
   githubUrl?: Maybe<Scalars['String']>
   videoUrl?: Maybe<Scalars['String']>
   chatUrl?: Maybe<Scalars['String']>
-  order?: Maybe<Scalars['Int']>
-  description?: Maybe<Scalars['String']>
-  title?: Maybe<Scalars['String']>
+  order: Scalars['Int']
+  description: Scalars['String']
+  title: Scalars['String']
 }>
 
 export type UpdateLessonMutation = { __typename?: 'Mutation' } & {
@@ -1178,7 +1178,10 @@ export type MutationResolvers<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
     ParentType,
     ContextType,
-    RequireFields<MutationUpdateLessonArgs, 'id'>
+    RequireFields<
+      MutationUpdateLessonArgs,
+      'id' | 'description' | 'title' | 'order'
+    >
   >
   createChallenge?: Resolver<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
@@ -3091,9 +3094,9 @@ export const UpdateLessonDocument = gql`
     $githubUrl: String
     $videoUrl: String
     $chatUrl: String
-    $order: Int
-    $description: String
-    $title: String
+    $order: Int!
+    $description: String!
+    $title: String!
   ) {
     updateLesson(
       docUrl: $docUrl

--- a/graphql/queries/updateLesson.ts
+++ b/graphql/queries/updateLesson.ts
@@ -7,9 +7,9 @@ const UPDATE_LESSON = gql`
     $githubUrl: String
     $videoUrl: String
     $chatUrl: String
-    $order: Int
-    $description: String
-    $title: String
+    $order: Int!
+    $description: String!
+    $title: String!
   ) {
     updateLesson(
       docUrl: $docUrl

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -57,13 +57,13 @@ export default gql`
     ): [Lesson]
     updateLesson(
       id: Int!
-      description: String
+      description: String!
       docUrl: String
       githubUrl: String
       videoUrl: String
-      title: String
+      title: String!
       chatUrl: String
-      order: Int
+      order: Int!
     ): [Lesson]
     createChallenge(
       lessonId: Int!

--- a/helpers/controllers/lessonsController.test.js
+++ b/helpers/controllers/lessonsController.test.js
@@ -1,15 +1,11 @@
-jest.mock('../dbload')
 jest.mock('../mattermost')
 jest.mock('../validateLessonId')
 jest.mock('../../graphql/queryResolvers/lessons')
-import db from '../dbload'
-import { createLesson, updateLesson } from './lessonsController'
+import { lessons } from '../../graphql/queryResolvers/lessons'
+import { prisma } from '../../prisma'
 import lessonData from '../../__dummy__/lessonData'
 import { validateLessonId } from '../validateLessonId'
-import { lessons } from '../../graphql/queryResolvers/lessons'
-
-lessons.mockReturnValue(lessonData)
-const { Lesson } = db
+import { createLesson, updateLesson } from './lessonsController'
 
 const mockLessonData = {
   lessonId: 5,
@@ -23,9 +19,9 @@ const mockLessonData = {
   chatUrl: ''
 }
 
-Lesson.findAll.mockReturnValue(lessonData)
-Lesson.update.mockReturnValue(() => {})
-Lesson.build.mockReturnValue({ save: () => {} })
+lessons.mockReturnValue(lessonData)
+prisma.lesson.update = jest.fn()
+prisma.lesson.create = jest.fn()
 
 describe('Lessons controller tests', () => {
   beforeEach(() => {

--- a/helpers/controllers/lessonsController.ts
+++ b/helpers/controllers/lessonsController.ts
@@ -1,37 +1,27 @@
-import db from '../dbload'
 import { Context } from '../../@types/helpers'
-import _ from 'lodash'
-import { isAdmin } from '../isAdmin'
+import type {
+  CreateLessonMutation,
+  CreateLessonMutationVariables,
+  UpdateLessonMutation,
+  UpdateLessonMutationVariables
+} from '../../graphql'
 import { lessons } from '../../graphql/queryResolvers/lessons'
+import { prisma } from '../../prisma'
+import { isAdmin } from '../isAdmin'
 import { validateLessonId } from '../validateLessonId'
-const { Lesson } = db
-
-type lessonData = {
-  id: number
-  order: number
-  description: string
-  docUrl: string
-  githubUrl: string
-  videoUrl: string
-  title: string
-  chatUrl: string
-}
 
 export const createLesson = async (
   _parent: void,
-  arg: lessonData,
+  arg: CreateLessonMutationVariables,
   ctx: Context
-) => {
+): Promise<CreateLessonMutation['createLesson']> => {
   const { req } = ctx
   try {
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
-    const newLesson = Lesson.build(arg)
-
-    await newLesson.save()
-
-    return await lessons()
+    await prisma.lesson.create({ data: arg })
+    return lessons()
   } catch (err) {
     throw new Error(err)
   }
@@ -39,22 +29,18 @@ export const createLesson = async (
 
 export const updateLesson = async (
   _parent: void,
-  arg: lessonData,
+  arg: UpdateLessonMutationVariables,
   ctx: Context
-) => {
+): Promise<UpdateLessonMutation['updateLesson']> => {
   const { req } = ctx
   try {
     if (!isAdmin(req)) {
       throw new Error('User is not an admin')
     }
-
-    const { id } = arg
-
+    const { id, ...data } = arg
     await validateLessonId(id)
-
-    await Lesson.update(arg, { where: { id } })
-
-    return await lessons()
+    await prisma.lesson.update({ where: { id }, data })
+    return lessons()
   } catch (err) {
     throw new Error(err)
   }

--- a/helpers/controllers/starsController.test.js
+++ b/helpers/controllers/starsController.test.js
@@ -1,71 +1,58 @@
-jest.mock('../../helpers/dbload')
 jest.mock('../../helpers/validateLessonId')
 jest.mock('../mattermost')
 import { setStar } from './starsController'
 import { validateLessonId } from '../validateLessonId'
 import { getUserByEmail } from '../mattermost'
-import db from '../dbload'
+import { prisma } from '../../prisma'
 
-const ctx = {
-  req: {
-    error: jest.fn(),
-    user: { id: 1337 }
-  }
-}
-const { Star, Lesson, User } = db
-Lesson.findByPk = jest.fn().mockReturnValue({ chatUrl: 'jim/flam' })
-User.findByPk = jest.fn().mockReturnValue({ email: 'potatoLove@potatus.com' })
 getUserByEmail.mockReturnValue({ username: 'flam' })
 
 describe('setStar resolver', () => {
+  let ctx
   beforeEach(() => {
     jest.clearAllMocks()
+    ctx = {
+      req: {
+        error: jest.fn(),
+        user: { id: 1337 }
+      }
+    }
+    prisma.star.upsert = jest.fn().mockResolvedValue({
+      lesson: { chatUrl: 'jim/flam' },
+      mentor: { email: 'potatoLove@potatus.com' }
+    })
     validateLessonId.mockReturnValue(true)
-    Star.findAll = jest.fn().mockReturnValue([])
-    Star.create = jest.fn().mockReturnValue({ success: true })
   })
 
   test('should throw error if studentId and mentorId is the same', async () => {
     await expect(
       setStar(null, { lessonId: 52226, mentorId: 1337 }, ctx)
     ).rejects.toThrowError('Unable to give star to yourself')
-    expect(Star.create).toHaveBeenCalledTimes(0)
+    expect(prisma.star.upsert).not.toBeCalled()
     expect(ctx.req.error).toHaveBeenCalledTimes(1)
   })
 
   test('should return success object if no errors are thrown, and Star.create is called', async () => {
     const res = await setStar(null, { lessonId: 52226, mentorId: 815 }, ctx)
-    expect(Star.create).toHaveBeenCalledTimes(1)
+    expect(prisma.star.upsert).toBeCalled()
     expect(res).toEqual({ success: true })
   })
 
   test('should jump to catch block and call req.error when calling Star.create creates an error', async () => {
-    Star.create = jest.fn().mockImplementation(() => {
-      throw new Error()
-    })
+    prisma.star.upsert = jest.fn().mockRejectedValueOnce(new Error())
     await expect(
       setStar(null, { lessonId: 5, mentorId: 815 }, ctx)
     ).rejects.toThrowError()
-    expect(Star.create).toHaveBeenCalledTimes(1)
+    expect(prisma.star.upsert).toBeCalled()
     expect(ctx.req.error).toHaveBeenCalledTimes(1)
   })
 
-  test('should call Star.destroy when relationship between studentId and lessonId \
-   has already been made inside the Stars table of the database', async () => {
-    Star.findAll = jest.fn().mockReturnValue(['Potatus Maximus'])
-    await setStar(null, { lessonId: 5, mentorId: 5 }, ctx)
-    expect(Star.destroy).toHaveBeenCalledTimes(1)
-    expect(Star.create).toHaveBeenCalledTimes(1)
-  })
-
   test('should throw error if lessonId does not exist', async () => {
-    validateLessonId.mockImplementation(() => {
-      throw new Error()
-    })
+    validateLessonId.mockRejectedValueOnce(new Error())
     await expect(
       setStar(null, { lessonId: 5, mentorId: 815 }, ctx)
     ).rejects.toThrowError()
-    expect(Star.create).toHaveBeenCalledTimes(0)
+    expect(prisma.star.upsert).not.toBeCalled()
   })
 
   test('should throw error if user is not logged in', async () => {
@@ -73,6 +60,15 @@ describe('setStar resolver', () => {
     await expect(
       setStar(null, { lessonId: 5, mentorId: 815 }, ctx)
     ).rejects.toThrowError()
-    expect(Star.create).toHaveBeenCalledTimes(0)
+    expect(prisma.star.upsert).not.toBeCalled()
+  })
+
+  test('should not send chat message if chatUrl or mentor email are null', async () => {
+    prisma.star.upsert = jest.fn().mockResolvedValue({
+      lesson: { chatUrl: null },
+      mentor: { email: null }
+    })
+    await setStar(null, { lessonId: 52226, mentorId: 815 }, ctx)
+    expect(getUserByEmail).not.toBeCalled()
   })
 })

--- a/helpers/controllers/starsController.ts
+++ b/helpers/controllers/starsController.ts
@@ -1,18 +1,15 @@
-import db from '../dbload'
-import { LoggedRequest } from '../../@types/helpers'
-import { Star as StarType } from '../../@types/lesson'
-import _ from 'lodash'
+import type { LoggedRequest } from '../../@types/helpers'
+import type { SetStarMutation, SetStarMutationVariables } from '../../graphql'
+import { prisma } from '../../prisma'
+import { getUserByEmail, publicChannelMessage } from '../mattermost'
 import { validateLessonId } from '../validateLessonId'
 import { validateStudentId } from '../validation/validateStudentId'
-import { getUserByEmail, publicChannelMessage } from '../mattermost'
-
-const { Star, Lesson, User } = db
 
 export const setStar = async (
   _parent: void,
-  arg: StarType,
+  arg: SetStarMutationVariables,
   ctx: { req: LoggedRequest }
-) => {
+): Promise<SetStarMutation['setStar']> => {
   const { req } = ctx
   try {
     const studentId = validateStudentId(req)
@@ -22,28 +19,37 @@ export const setStar = async (
       throw new Error('Unable to give star to yourself')
     }
     await validateLessonId(lessonId)
+    const starData = { studentId, ...arg }
 
-    const lookupData = { where: { studentId, lessonId } }
-    const starsList = await Star.findAll(lookupData)
-    /*
-      If there is an element in starsList, then that means the student has already given
-      a star to someone for this lessonId. Students can only give one star per lesson, so
-      delete the previous star(s) already in the database before creating a new one
-    */
-    if (starsList.length) {
-      await Star.destroy(lookupData)
+    const { lesson, mentor } = await prisma.star.upsert({
+      where: {
+        studentId_lessonId: {
+          studentId,
+          lessonId
+        }
+      },
+      create: starData,
+      update: starData,
+      select: {
+        lesson: {
+          select: {
+            chatUrl: true
+          }
+        },
+        mentor: {
+          select: {
+            email: true
+          }
+        }
+      }
+    })
+
+    if (lesson.chatUrl && mentor.email) {
+      const channelName = lesson.chatUrl.split('/').pop()!
+      const { username } = await getUserByEmail(mentor.email)
+      publicChannelMessage(channelName, `@${username} received a star!`)
     }
 
-    await Star.create({ ...arg, studentId })
-
-    const [{ chatUrl }, { email }] = await Promise.all([
-      Lesson.findByPk(lessonId, { raw: true }),
-      User.findByPk(mentorId, { raw: true })
-    ])
-
-    const channelName = chatUrl.split('/').pop()
-    const { username } = await getUserByEmail(email)
-    publicChannelMessage(channelName, `@${username} received a star!`)
     return { success: true }
   } catch (err) {
     req.error(`Failed to add Star into Database: ${err}`)

--- a/prisma/migrations/20210430031031_stars_unique_student_id_lesson_id/migration.sql
+++ b/prisma/migrations/20210430031031_stars_unique_student_id_lesson_id/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[studentId,lessonId]` on the table `stars` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- Delete duplicates (2 rows)
+DELETE FROM stars s
+WHERE s.id in (
+  SELECT s1.id
+  FROM stars s1, stars s2
+  WHERE s1.id < s2.id
+    AND s1."studentId" = s2."studentId"
+    AND s1."lessonId" = s2."lessonId"
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stars.studentId_lessonId_unique" ON "stars"("studentId", "lessonId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,7 @@ model Star {
   mentor    User     @relation("starMentor", fields: [mentorId], references: [id])
   student   User     @relation("starStudent", fields: [studentId], references: [id])
 
+  @@unique([studentId, lessonId])
   @@map("stars")
 }
 


### PR DESCRIPTION
- Replaced Sequelize with Prisma on `lessonsController`
  - Also replaced the types with the ones auto-generated
  - Fixed non-optional types on the `updateLesson` mutation
  - Included return types to detect API breaking changes.

- Added migration to create unique index on stars table
  - Makes the tuple (`lessonId`, `studentId`) unique, since a student can only give a star per lesson.
  - Removes 2 rows of duplicated entries before applying migration.

- Replaced Sequelize with Prisma on `starsController`
  - The entire logic to remove a star if it already existed was replaced with just an `upsert`, which creates the entry if doesn't exist, or updates it if it exists.
  - Included return types to detect API breaking changes.