### PR TITLE
Give new user password change link upon signup success

### DIFF
--- a/@types/signup.d.ts
+++ b/@types/signup.d.ts
@@ -10,8 +10,13 @@ export type SignupFormProps = {
   isLoading?: boolean
   signupErrors?: string[]
   isSuccess?: boolean
+  forgotToken?: string
 }
 
 export type ErrorDisplayProps = {
   signupErrors?: string[]
+}
+
+export type SignupSuccessProps = {
+  forgotToken?: string
 }

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -16603,9 +16603,10 @@ exports[`Storyshots Pages/Signup Signup Success 1`] = `
         className="card-text"
       />
       <p>
-        Link to set your password:
-        <a>
-          https://www.c0d3.com/confirm/undefined
+        <a
+          href="https://www.c0d3.com/confirm/undefined"
+        >
+          Link to set your password
         </a>
       </p>
     </div>

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -16603,7 +16603,7 @@ exports[`Storyshots Pages/Signup Signup Success 1`] = `
         className="card-text"
       />
       <p>
-        You will receive a link to confirm your email address and to set your password.
+        Link to set your password: https://www.c0d3.com/confirm/undefined
       </p>
     </div>
   </div>

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -16603,7 +16603,10 @@ exports[`Storyshots Pages/Signup Signup Success 1`] = `
         className="card-text"
       />
       <p>
-        Link to set your password: https://www.c0d3.com/confirm/undefined
+        Link to set your password:
+        <a>
+          https://www.c0d3.com/confirm/undefined
+        </a>
       </p>
     </div>
   </div>

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -16602,13 +16602,14 @@ exports[`Storyshots Pages/Signup Signup Success 1`] = `
       <p
         className="card-text"
       />
-      <p>
-        <a
-          href="https://www.c0d3.com/confirm/undefined"
-        >
-          Link to set your password
-        </a>
-      </p>
+      <a
+        className="btn btn-primary"
+        href="/confirm/undefined"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+      >
+        Click here to set your password.
+      </a>
     </div>
   </div>
 </div>

--- a/__tests__/pages/__snapshots__/signup.test.js.snap
+++ b/__tests__/pages/__snapshots__/signup.test.js.snap
@@ -273,9 +273,10 @@ exports[`Signup Page Should render success component on success 1`] = `
             class="card-text"
           />
           <p>
-            Link to set your password:
-            <a>
-              https://www.c0d3.com/confirm/undefined
+            <a
+              href="https://www.c0d3.com/confirm/undefined"
+            >
+              Link to set your password
             </a>
           </p>
         </div>

--- a/__tests__/pages/__snapshots__/signup.test.js.snap
+++ b/__tests__/pages/__snapshots__/signup.test.js.snap
@@ -273,7 +273,10 @@ exports[`Signup Page Should render success component on success 1`] = `
             class="card-text"
           />
           <p>
-            Link to set your password: https://www.c0d3.com/confirm/undefined
+            Link to set your password:
+            <a>
+              https://www.c0d3.com/confirm/undefined
+            </a>
           </p>
         </div>
       </div>

--- a/__tests__/pages/__snapshots__/signup.test.js.snap
+++ b/__tests__/pages/__snapshots__/signup.test.js.snap
@@ -273,7 +273,7 @@ exports[`Signup Page Should render success component on success 1`] = `
             class="card-text"
           />
           <p>
-            You will receive a link to confirm your email address and to set your password.
+            Link to set your password: https://www.c0d3.com/confirm/undefined
           </p>
         </div>
       </div>

--- a/__tests__/pages/__snapshots__/signup.test.js.snap
+++ b/__tests__/pages/__snapshots__/signup.test.js.snap
@@ -272,13 +272,12 @@ exports[`Signup Page Should render success component on success 1`] = `
           <p
             class="card-text"
           />
-          <p>
-            <a
-              href="https://www.c0d3.com/confirm/undefined"
-            >
-              Link to set your password
-            </a>
-          </p>
+          <a
+            class="btn btn-primary"
+            href="/confirm/undefined"
+          >
+            Click here to set your password.
+          </a>
         </div>
       </div>
     </div>

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -766,7 +766,7 @@ export type SignupMutation = { __typename?: 'Mutation' } & {
   signup?: Maybe<
     { __typename?: 'AuthResponse' } & Pick<
       AuthResponse,
-      'success' | 'username' | 'error'
+      'success' | 'username' | 'error' | 'cliToken'
     >
   >
 }
@@ -3270,6 +3270,7 @@ export const SignupDocument = gql`
       success
       username
       error
+      cliToken
     }
   }
 `

--- a/graphql/queries/signupUser.ts
+++ b/graphql/queries/signupUser.ts
@@ -16,6 +16,7 @@ const SIGNUP_USER = gql`
       success
       username
       error
+      forgotToken
     }
   }
 `

--- a/graphql/queries/signupUser.ts
+++ b/graphql/queries/signupUser.ts
@@ -16,7 +16,7 @@ const SIGNUP_USER = gql`
       success
       username
       error
-      forgotToken
+      cliToken
     }
   }
 `

--- a/helpers/controllers/authController.test.js
+++ b/helpers/controllers/authController.test.js
@@ -181,7 +181,8 @@ describe('auth controller', () => {
       })
       expect(result).toEqual({
         username: 'user',
-        success: true
+        success: true,
+        forgotToken: result.forgotToken
       })
       expect(prisma.user.update).toBeCalled()
     })

--- a/helpers/controllers/authController.test.js
+++ b/helpers/controllers/authController.test.js
@@ -182,7 +182,7 @@ describe('auth controller', () => {
       expect(result).toEqual({
         username: 'user',
         success: true,
-        forgotToken: result.forgotToken
+        cliToken: result.cliToken
       })
       expect(prisma.user.update).toBeCalled()
     })

--- a/helpers/controllers/authController.ts
+++ b/helpers/controllers/authController.ts
@@ -175,7 +175,7 @@ export const signup = async (_parent: void, arg: SignUp, ctx: Context) => {
     return {
       success: true,
       username: newUser.username,
-      forgotToken
+      cliToken: forgotToken
     }
   } catch (err) {
     if (!err.extensions) {

--- a/helpers/controllers/authController.ts
+++ b/helpers/controllers/authController.ts
@@ -174,7 +174,8 @@ export const signup = async (_parent: void, arg: SignUp, ctx: Context) => {
 
     return {
       success: true,
-      username: newUser.username
+      username: newUser.username,
+      forgotToken
     }
   } catch (err) {
     if (!err.extensions) {

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -15,7 +15,12 @@ import { signupValidation } from '../helpers/formValidation'
 import SIGNUP_USER from '../graphql/queries/signupUser'
 
 //import types
-import { SignupFormProps, Values, ErrorDisplayProps } from '../@types/signup'
+import {
+  SignupFormProps,
+  Values,
+  ErrorDisplayProps,
+  SignupSuccessProps
+} from '../@types/signup'
 
 const initialValues: Values = {
   email: '',
@@ -41,15 +46,14 @@ const ErrorMessage: React.FC<ErrorDisplayProps> = ({ signupErrors }) => {
   return <>{errorMessages}</>
 }
 
-const SignupSuccess: React.FC = () => (
+const SignupSuccess: React.FC<SignupSuccessProps> = ({ forgotToken }) => (
   <Card
     type="success"
     data-testid="signup-success"
     title="Account created successfully!"
   >
     <p>
-      You will receive a link to confirm your email address and to set your
-      password.
+      {`Link to set your password: https://www.c0d3.com/confirm/${forgotToken}`}
     </p>
   </Card>
 )
@@ -128,6 +132,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
 
 const SignUpPage: React.FC = () => {
   const [signupSuccess, setSignupSuccess] = useState(false)
+  const [forgotToken, setForgotToken] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [signupErrors, setSignupErrors] = useState<string[]>([])
   const [signupUser] = useMutation(SIGNUP_USER)
@@ -136,6 +141,7 @@ const SignUpPage: React.FC = () => {
     try {
       const { data } = await signupUser({ variables: values })
       if (data.signup.success) {
+        setForgotToken(data.signup.forgotToken)
         return setSignupSuccess(true)
       }
       const err = new Error(
@@ -160,6 +166,7 @@ const SignUpPage: React.FC = () => {
         handleSubmit={handleSubmit}
         isLoading={isSubmitting}
         isSuccess={signupSuccess}
+        forgotToken={forgotToken}
         signupErrors={signupErrors}
       />
     </Layout>
@@ -170,12 +177,13 @@ export const Signup: React.FC<SignupFormProps> = ({
   handleSubmit,
   isSuccess,
   signupErrors,
-  isLoading
+  isLoading,
+  forgotToken
 }) => {
   return (
     <>
       {isSuccess ? (
-        <SignupSuccess />
+        <SignupSuccess forgotToken={forgotToken} />
       ) : (
         <SignupForm
           handleSubmit={handleSubmit}

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -137,11 +137,13 @@ const SignUpPage: React.FC = () => {
   const [signupErrors, setSignupErrors] = useState<string[]>([])
   const [signupUser] = useMutation(SIGNUP_USER)
   const handleSubmit = async (values: Values) => {
+    console.log('submitting')
     setIsSubmitting(true)
     try {
       const { data } = await signupUser({ variables: values })
       if (data.signup.success) {
-        setForgotToken(data.signup.forgotToken)
+        console.log('success!!', data.signup)
+        setForgotToken(data.signup.cliToken)
         return setSignupSuccess(true)
       }
       const err = new Error(

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -52,11 +52,9 @@ const SignupSuccess: React.FC<SignupSuccessProps> = ({ forgotToken }) => (
     data-testid="signup-success"
     title="Account created successfully!"
   >
-    <p>
-      <a href={`https://www.c0d3.com/confirm/${forgotToken}`}>
-        Link to set your password
-      </a>
-    </p>
+    <NavLink path={`/confirm/${forgotToken}`} className="btn btn-primary">
+      Click here to set your password.
+    </NavLink>
   </Card>
 )
 

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -53,8 +53,9 @@ const SignupSuccess: React.FC<SignupSuccessProps> = ({ forgotToken }) => (
     title="Account created successfully!"
   >
     <p>
-      Link to set your password:
-      <a>{`https://www.c0d3.com/confirm/${forgotToken}`}</a>
+      <a href={`https://www.c0d3.com/confirm/${forgotToken}`}>
+        Link to set your password
+      </a>
     </p>
   </Card>
 )
@@ -138,12 +139,10 @@ const SignUpPage: React.FC = () => {
   const [signupErrors, setSignupErrors] = useState<string[]>([])
   const [signupUser] = useMutation(SIGNUP_USER)
   const handleSubmit = async (values: Values) => {
-    console.log('submitting')
     setIsSubmitting(true)
     try {
       const { data } = await signupUser({ variables: values })
       if (data.signup.success) {
-        console.log('success!!', data.signup)
         setForgotToken(data.signup.cliToken)
         return setSignupSuccess(true)
       }

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -53,7 +53,8 @@ const SignupSuccess: React.FC<SignupSuccessProps> = ({ forgotToken }) => (
     title="Account created successfully!"
   >
     <p>
-      {`Link to set your password: https://www.c0d3.com/confirm/${forgotToken}`}
+      Link to set your password:
+      <a>{`https://www.c0d3.com/confirm/${forgotToken}`}</a>
     </p>
   </Card>
 )


### PR DESCRIPTION
This is a bandaid fix for users not receiving mailgun emails.

It provides the c0d3.com/confirm/forgotToken link in the SignupSuccess component

It will likely to be reverted after switching to AWS or just letting user set their password on signup.