### PR TITLE
update #585 - remove refetching in CommentBox, add status prop

### DIFF
--- a/components/CommentBox.test.js
+++ b/components/CommentBox.test.js
@@ -1,10 +1,17 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import AddComment from '../graphql/queries/addComment'
 import '@testing-library/jest-dom'
 import CommentBox from './CommentBox'
 import { MockedProvider } from '@apollo/client/testing'
+import { InMemoryCache } from '@apollo/client'
+import GET_SUBMISSIONS from '../graphql/queries/getSubmissions'
+import GET_APP from '../graphql/queries/getApp'
+import dummySessionData from '../__dummy__/sessionData'
+import dummyLessonData from '../__dummy__/lessonData'
+import dummyAlertData from '../__dummy__/alertData'
+import { SubmissionStatus } from '../graphql'
 
 describe('CommentBox component', () => {
   const comments = [
@@ -59,9 +66,52 @@ describe('CommentBox component', () => {
       }
     }
   ]
-  test('Should add comment', async () => {
+  const submission = {
+    id: 0,
+    status: SubmissionStatus.Open,
+    mrUrl: '',
+    diff: 'diff --git a/js7/1.js b/js7/1.js\nindex 9c96b34..853bddf 100644\n--- a/js7/1.js\n+++ b/js7/1.js\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;\n',
+    viewCount: 0,
+    comment: 'Some comment',
+    order: 0,
+    challengeId: 146,
+    lessonId: 2,
+    user: {
+      username: 'fake user',
+      name: 'fake student',
+      email: 'fake@fakemail.com',
+      id: 1,
+      isAdmin: false
+    },
+    challenge: {
+      id: 23,
+      title: 'fake challenge',
+      description: 'fake description',
+      lessonId: 2,
+      order: 1
+    },
+    reviewer: {
+      id: 1,
+      username: 'fake reviewer',
+      name: 'fake reviewer',
+      email: 'fake@fakemail.com',
+      isAdmin: false
+    },
+    createdAt: '123',
+    updatedAt: '123',
+    comments: []
+  }
+  const submissionsData = [submission, { ...submission, id: 1 }]
+
+  test('Should add comment by reviewer', async () => {
+    const cache = new InMemoryCache({ addTypename: false })
+    cache.writeQuery({
+      query: GET_SUBMISSIONS,
+      variables: { lessonId: 1 },
+      data: { submissions: submissionsData }
+    })
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks} addTypename={false} cache={cache}>
         <CommentBox
           line={4}
           fileName="test.js"
@@ -70,13 +120,51 @@ describe('CommentBox component', () => {
           name="user"
           username="User User"
           commentsData={comments}
-          lessonId={2}
+          lessonId={1}
         />
       </MockedProvider>
     )
     userEvent.type(screen.getByTestId('textbox'), 'A very unique test comment!')
     userEvent.click(screen.getByText('Add comment'))
-    expect(screen.getAllByText('A very unique test comment!')[0]).toBeVisible()
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('A very unique test comment!')[0]
+      ).toBeVisible()
+    )
+  })
+  test('Should add comment by student', async () => {
+    const cache = new InMemoryCache({ addTypename: false })
+    cache.writeQuery({
+      query: GET_APP,
+      data: {
+        lessons: dummyLessonData,
+        alerts: dummyAlertData,
+        session: {
+          ...dummySessionData,
+          submissions: submissionsData
+        }
+      }
+    })
+    render(
+      <MockedProvider mocks={mocks} addTypename={false} cache={cache}>
+        <CommentBox
+          line={4}
+          fileName="test.js"
+          submissionId={0}
+          authorId={0}
+          name="user"
+          username="User User"
+          commentsData={comments}
+        />
+      </MockedProvider>
+    )
+    userEvent.type(screen.getByTestId('textbox'), 'A very unique test comment!')
+    userEvent.click(screen.getByText('Add comment'))
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('A very unique test comment!')[0]
+      ).toBeVisible()
+    )
   })
   test('Should not add comment if input is empty', async () => {
     const query = jest.fn()
@@ -105,6 +193,7 @@ describe('CommentBox component', () => {
           name="user"
           username="User User"
           commentsData={comments}
+          lessonId={2}
         />
       </MockedProvider>
     )


### PR DESCRIPTION
Previously CommentBox refetched GetApp and GetSubmission queries on every comment which is rather wasteful. This way it simply update local cache after each mutation. 

I added comment clarifying on how `lessonId` is used to differentiate between student and reviewer. And there is one new prop (status) which disables ability to add comments and hides conversations by default (it will be used in completed submissions). 