### PR TITLE
update #585 - add DiffView component

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2471,6 +2471,1720 @@ exports[`Storyshots Components/ContributorCard Basic 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/DiffView Closed 1`] = `
+<table
+  className="css-1n5o7vh-diff-container"
+>
+  <tbody>
+    <tr>
+      <td
+        className="css-1rwygp7-title-block"
+        colSpan={4}
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          js7/1.js
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          1
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">const</span> <span class=\\"token function-variable function\\">solution</span> <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=></span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          2
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token keyword\\">const</span> allT <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">[</span><span class=\\"token punctuation\\">]</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          3
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token keyword\\">const</span> old <span class=\\"token operator\\">=</span> setTimeout<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          4
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  window<span class=\\"token punctuation\\">.</span><span class=\\"token function-variable function\\">setTimeout</span> <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span><span class=\\"token parameter\\">func<span class=\\"token punctuation\\">,</span> delay</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=></span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          5
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    <span class=\\"token keyword\\">const</span> realTimeout <span class=\\"token operator\\">=</span> <span class=\\"token function\\">old</span><span class=\\"token punctuation\\">(</span>func<span class=\\"token punctuation\\">,</span> delay<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          6
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    allT<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">push</span><span class=\\"token punctuation\\">(</span>realTimeout<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          7
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    <span class=\\"token keyword\\">return</span> realTimeout<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          8
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          9
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  window<span class=\\"token punctuation\\">.</span><span class=\\"token function-variable function\\">clearAllTimouts</span> <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=></span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          10
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    <span class=\\"token keyword\\">while</span> <span class=\\"token punctuation\\">(</span>allT<span class=\\"token punctuation\\">.</span>length<span class=\\"token punctuation\\">)</span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          11
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "      <span class=\\"token function\\">clearTimeout</span><span class=\\"token punctuation\\">(</span>allT<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">pop</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          12
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    <span class=\\"token punctuation\\">}</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          13
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          14
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token function-variable function\\">cat</span> <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=></span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          15
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    window<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">clearAllTimouts</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          16
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          17
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          18
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          19
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "module<span class=\\"token punctuation\\">.</span>exports <span class=\\"token operator\\">=</span> solution<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Storyshots Components/DiffView Default 1`] = `
+<table
+  className="css-1n5o7vh-diff-container"
+>
+  <tbody>
+    <tr>
+      <td
+        className="css-1rwygp7-title-block"
+        colSpan={4}
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          js7/1.js
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          1
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token keyword\\">const</span> <span class=\\"token function-variable function\\">solution</span> <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=></span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          2
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token keyword\\">const</span> allT <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">[</span><span class=\\"token punctuation\\">]</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          3
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token keyword\\">const</span> old <span class=\\"token operator\\">=</span> setTimeout<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          4
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  window<span class=\\"token punctuation\\">.</span><span class=\\"token function-variable function\\">setTimeout</span> <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span><span class=\\"token parameter\\">func<span class=\\"token punctuation\\">,</span> delay</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=></span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          5
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    <span class=\\"token keyword\\">const</span> realTimeout <span class=\\"token operator\\">=</span> <span class=\\"token function\\">old</span><span class=\\"token punctuation\\">(</span>func<span class=\\"token punctuation\\">,</span> delay<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          6
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    allT<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">push</span><span class=\\"token punctuation\\">(</span>realTimeout<span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          7
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    <span class=\\"token keyword\\">return</span> realTimeout<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          8
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          9
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  window<span class=\\"token punctuation\\">.</span><span class=\\"token function-variable function\\">clearAllTimouts</span> <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=></span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          10
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    <span class=\\"token keyword\\">while</span> <span class=\\"token punctuation\\">(</span>allT<span class=\\"token punctuation\\">.</span>length<span class=\\"token punctuation\\">)</span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          11
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "      <span class=\\"token function\\">clearTimeout</span><span class=\\"token punctuation\\">(</span>allT<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">pop</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          12
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    <span class=\\"token punctuation\\">}</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          13
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          14
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token function-variable function\\">cat</span> <span class=\\"token operator\\">=</span> <span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=></span> <span class=\\"token punctuation\\">{</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          15
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "    window<span class=\\"token punctuation\\">.</span><span class=\\"token function\\">clearAllTimouts</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          16
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "  <span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          17
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<span class=\\"token punctuation\\">}</span><span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          18
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+    <tr
+      className="css-1n7ec1i-line"
+    >
+      <td
+        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        onClick={null}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        />
+      </td>
+      <td
+        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        onClick={[Function]}
+      >
+        <pre
+          className="css-h84nzi-line-number"
+        >
+          19
+        </pre>
+      </td>
+      <td
+        className="css-17vezug-marker css-cnnxkz-diff-added"
+      >
+        <pre>
+          +
+        </pre>
+      </td>
+      <td
+        className="css-vl0irh-content css-cnnxkz-diff-added"
+      >
+        <pre
+          className="css-pa3tg-content-text"
+        >
+          <span
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "module<span class=\\"token punctuation\\">.</span>exports <span class=\\"token operator\\">=</span> solution<span class=\\"token punctuation\\">;</span>",
+              }
+            }
+          />
+        </pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`Storyshots Components/DropdownMenu Basic 1`] = `
 <div
   className="dropdown"

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -2492,19 +2492,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           1
         </pre>
@@ -2536,19 +2536,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           2
         </pre>
@@ -2580,19 +2580,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           3
         </pre>
@@ -2624,19 +2624,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           4
         </pre>
@@ -2668,19 +2668,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           5
         </pre>
@@ -2712,19 +2712,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           6
         </pre>
@@ -2756,19 +2756,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           7
         </pre>
@@ -2800,19 +2800,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           8
         </pre>
@@ -2844,19 +2844,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           9
         </pre>
@@ -2888,19 +2888,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           10
         </pre>
@@ -2932,19 +2932,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           11
         </pre>
@@ -2976,19 +2976,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           12
         </pre>
@@ -3020,19 +3020,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           13
         </pre>
@@ -3064,19 +3064,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           14
         </pre>
@@ -3108,19 +3108,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           15
         </pre>
@@ -3152,19 +3152,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           16
         </pre>
@@ -3196,19 +3196,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           17
         </pre>
@@ -3240,19 +3240,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           18
         </pre>
@@ -3284,19 +3284,19 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           19
         </pre>
@@ -3349,19 +3349,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           1
         </pre>
@@ -3393,19 +3393,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           2
         </pre>
@@ -3437,19 +3437,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           3
         </pre>
@@ -3481,19 +3481,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           4
         </pre>
@@ -3525,19 +3525,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           5
         </pre>
@@ -3569,19 +3569,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           6
         </pre>
@@ -3613,19 +3613,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           7
         </pre>
@@ -3657,19 +3657,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           8
         </pre>
@@ -3701,19 +3701,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           9
         </pre>
@@ -3745,19 +3745,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           10
         </pre>
@@ -3789,19 +3789,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           11
         </pre>
@@ -3833,19 +3833,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           12
         </pre>
@@ -3877,19 +3877,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           13
         </pre>
@@ -3921,19 +3921,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           14
         </pre>
@@ -3965,19 +3965,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           15
         </pre>
@@ -4009,19 +4009,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           16
         </pre>
@@ -4053,19 +4053,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           17
         </pre>
@@ -4097,19 +4097,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           18
         </pre>
@@ -4141,19 +4141,19 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         />
       </td>
       <td
-        className="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        className="css-1548r9v-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
-          className="css-h84nzi-line-number"
+          className="css-14p8zw1-line-number"
         >
           19
         </pre>

--- a/components/DiffView.test.js
+++ b/components/DiffView.test.js
@@ -79,6 +79,23 @@ describe('DiffView component', () => {
     expect(container).toMatchSnapshot()
     expect(screen.getByText('Add comment')).toBeVisible()
   })
+  test('Should remove comment box with no comments', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <DiffView
+          diff={diff}
+          comments={[]}
+          name="Noob Newbie"
+          username="newbie"
+          id={1}
+        />
+      </MockedProvider>
+    )
+    userEvent.click(screen.getByText('4'))
+    expect(screen.getByText('Add comment')).toBeVisible()
+    userEvent.click(screen.getByText('4'))
+    expect(screen.queryByText('Add comment')).toBeFalsy()
+  })
   test('Should not add comment box if submission was accepted', async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>
@@ -103,7 +120,7 @@ describe('DiffView component', () => {
   })
   test('Should default to javascript if language is not supported', async () => {
     const cDiff =
-      'diff --git a/js7/1.c b/js7/1.c\nindex 9c96b34..853bddf 100644\n--- a/js7/1\n+++ b/js7/1\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
+      'diff --git a/js7/1.c b/js7/1.c\nindex 9c96b34..853bddf 100644\n--- a/js7/1.c\n+++ b/js7/1.c\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
     render(
       <DiffView
         comments={comments}
@@ -112,6 +129,7 @@ describe('DiffView component', () => {
         username="newbie"
       />
     )
+    expect(screen.getByText('js7/1.c')).toBeVisible()
   })
   test('Should do nothing with incorrect diff', async () => {
     const incorrectDiff =

--- a/components/DiffView.test.js
+++ b/components/DiffView.test.js
@@ -1,0 +1,114 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import DiffView from './DiffView'
+import { MockedProvider } from '@apollo/client/testing'
+
+describe('DiffView component', () => {
+  const diff =
+    'diff --git a/js7/1.js b/js7/1.js\nindex 9c96b34..853bddf 100644\n--- a/js7/1.js\n+++ b/js7/1.js\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
+  const comments = [
+    {
+      content: 'First Comment',
+      createdAt: '1620762267819',
+      fileName: 'js7/1.js',
+      submissionId: 1,
+      authorId: 3,
+      line: 4,
+      author: {
+        username: 'newbie',
+        name: 'Noob Newbie'
+      }
+    },
+    {
+      content: 'Second Comment',
+      createdAt: '1620762275096',
+      fileName: 'js7/1.js',
+      submissionId: 1,
+      authorId: 3,
+      line: 4,
+      author: {
+        username: 'newbie',
+        name: 'Noob Newbie'
+      }
+    },
+    {
+      content: 'Second Comment',
+      createdAt: '1620762275096',
+      fileName: 'js7/1.js',
+      submissionId: 1,
+      authorId: 3,
+      line: 5,
+      author: {
+        username: 'admin',
+        name: 'Admin Admin'
+      }
+    }
+  ]
+  test('Should render diff with comments', async () => {
+    const { container } = render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <DiffView
+          diff={diff}
+          comments={comments}
+          name="Noob Newbie"
+          username="newbie"
+          id={1}
+        />
+      </MockedProvider>
+    )
+    expect(container).toMatchSnapshot()
+    userEvent.click(screen.getByText('4'))
+    userEvent.click(screen.getByText('6'))
+    expect(screen.getByText('First Comment')).toBeVisible()
+  })
+  test('Should add comment box', async () => {
+    const { container } = render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <DiffView
+          diff={diff}
+          comments={[]}
+          name="Noob Newbie"
+          username="newbie"
+          id={1}
+        />
+      </MockedProvider>
+    )
+    userEvent.click(screen.getByText('4'))
+    expect(container).toMatchSnapshot()
+    expect(screen.getByText('Add comment')).toBeVisible()
+  })
+  test('Should render empty div if no diff is provided', async () => {
+    const { container } = render(
+      <DiffView comments={comments} name="Noob Newbie" username="newbie" />
+    )
+    expect(container.firstChild).toEqual(null)
+  })
+  test('Should default to javascript if language is not supported', async () => {
+    const cDiff =
+      'diff --git a/js7/1.c b/js7/1.c\nindex 9c96b34..853bddf 100644\n--- a/js7/1\n+++ b/js7/1\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
+    render(
+      <DiffView
+        comments={comments}
+        diff={cDiff}
+        name="Noob Newbie"
+        username="newbie"
+      />
+    )
+  })
+  test('Should do nothing with incorrect diff', async () => {
+    const incorrectDiff =
+      'diff --git \nindex 9c96b34..853bddf 100644\n---@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
+    render(
+      <DiffView
+        comments={comments}
+        diff={incorrectDiff}
+        name="Noob Newbie"
+        username="newbie"
+      />
+    )
+
+    expect(screen.firstChild).toBeUndefined()
+  })
+})

--- a/components/DiffView.test.js
+++ b/components/DiffView.test.js
@@ -79,6 +79,22 @@ describe('DiffView component', () => {
     expect(container).toMatchSnapshot()
     expect(screen.getByText('Add comment')).toBeVisible()
   })
+  test('Should not add comment box if submission was accepted', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <DiffView
+          diff={diff}
+          comments={[]}
+          name="Noob Newbie"
+          username="newbie"
+          id={1}
+          status="passed"
+        />
+      </MockedProvider>
+    )
+    userEvent.click(screen.getByText('4'))
+    expect(screen.queryByText('Add comment')).toBeFalsy()
+  })
   test('Should render empty div if no diff is provided', async () => {
     const { container } = render(
       <DiffView comments={comments} name="Noob Newbie" username="newbie" />

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, memo } from 'react'
+import gitDiffParser, { File } from 'gitdiff-parser'
+import Prism from 'prismjs'
+import ReactDiffViewer from 'c0d3-diff'
+import _ from 'lodash'
+import CommentBox from './CommentBox'
+import { Comment } from '../graphql'
+
+const prismLanguages = ['js', 'javascript', 'html', 'css', 'json', 'jsx']
+
+const DiffView: React.FC<{
+  diff?: string
+  id: number
+  name: string
+  username: string
+  comments: Comment[]
+  lessonId?: number
+  status?: string
+}> = ({ diff = '', id, name, username, comments, lessonId, status }) => {
+  const files = gitDiffParser.parse(diff)
+  type fileComments = Record<string, { lines?: number[]; comments?: Comment[] }>
+  //every file gets unique index in format of submissionId:fileName
+  const [commentsState, setCommentsState] = React.useState<fileComments>({})
+
+  useEffect(() => {
+    const commentMap: fileComments = {}
+    comments &&
+      comments.forEach(c => {
+        if (!commentMap[`${c.submissionId}:${c.fileName}`])
+          commentMap[`${c.submissionId}:${c.fileName}`] = {
+            lines: [],
+            comments: []
+          }
+        commentMap[`${c.submissionId}:${c.fileName}`].lines!.push(c.line)
+        commentMap[`${c.submissionId}:${c.fileName}`].comments!.push(c)
+      })
+    setCommentsState(commentMap)
+    //rerunning useEffect on id rerenders submission when student clicks on another challenge
+  }, [id, comments])
+
+  const renderFile = ({ hunks, newPath }: File) => {
+    const newValue: string[] = []
+
+    if (!hunks.length || !newPath) return
+    let extension = newPath.split('.').pop()!
+    if (!prismLanguages.includes(extension)) extension = 'javascript'
+    hunks.forEach(hunk => {
+      hunk.changes.forEach(change => {
+        if (!change.isDelete) newValue.push(change.content)
+      })
+    })
+
+    const syntaxHighlight = (str: string, n: number): any => {
+      const highlighted = Prism.highlight(
+        str,
+        Prism.languages[extension],
+        extension
+      )
+      return (
+        <>
+          <span dangerouslySetInnerHTML={{ __html: highlighted }} />
+          {commentsState[`${id}:${newPath}`]?.lines?.includes(n) && (
+            <CommentBox
+              fileName={newPath}
+              line={n}
+              submissionId={id}
+              commentsData={commentsState[`${id}:${newPath}`].comments}
+              name={name}
+              username={username}
+              lessonId={lessonId}
+              status={status}
+            />
+          )}
+        </>
+      )
+    }
+
+    return (
+      <ReactDiffViewer
+        key={_.uniqueId()}
+        newValue={newValue.join('\n')}
+        renderContent={syntaxHighlight}
+        splitView={false}
+        leftTitle={`${newPath}`}
+        onLineNumberClick={(n: string) => {
+          //line number is a string in format of L-10, R-4 and etc (left-right split views)
+          const lineNumber = Number.parseInt(n.split('-')[1])
+          if (!commentsState[`${id}:${newPath}`])
+            commentsState[`${id}:${newPath}`] = { lines: [], comments: [] }
+          if (commentsState[`${id}:${newPath}`].lines!.includes(lineNumber))
+            return
+          const copy = _.cloneDeep(commentsState)
+          copy[`${id}:${newPath}`].lines?.push(lineNumber)
+          setCommentsState(copy)
+        }}
+      />
+    )
+  }
+  return <>{files.map(renderFile)}</>
+}
+
+const MemoDiffView = memo(DiffView)
+
+export default MemoDiffView

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -107,10 +107,25 @@ const DiffView: React.FC<{
           const index = `${id}:${newPath}`
           if (!commentsState[index])
             commentsState[index] = { lines: [], comments: [] }
-          if (commentsState[index].lines!.includes(lineNumber)) return
-          const copy = _.cloneDeep(commentsState)
-          copy[index].lines?.push(lineNumber)
-          setCommentsState(copy)
+          //remove CommentBox on click if there are no comments for this line
+          if (
+            commentsState[index].lines!.includes(lineNumber) &&
+            !commentsState[index].comments?.filter(
+              comment => comment.line === lineNumber
+            )[0]
+          ) {
+            const copy = _.cloneDeep(commentsState)
+            copy[index].lines = copy[index].lines?.filter(
+              line => line !== lineNumber
+            )
+            setCommentsState(copy)
+          }
+          //add new CommentBox on click
+          if (!commentsState[index].lines!.includes(lineNumber)) {
+            const copy = _.cloneDeep(commentsState)
+            copy[index].lines?.push(lineNumber)
+            setCommentsState(copy)
+          }
         }}
       />
     )

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -22,17 +22,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             1
           </pre>
@@ -99,17 +99,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             2
           </pre>
@@ -164,17 +164,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             3
           </pre>
@@ -219,17 +219,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             4
           </pre>
@@ -343,17 +343,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             5
           </pre>
@@ -420,17 +420,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             6
           </pre>
@@ -484,17 +484,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             7
           </pre>
@@ -533,17 +533,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             8
           </pre>
@@ -581,17 +581,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             9
           </pre>
@@ -658,17 +658,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             10
           </pre>
@@ -725,17 +725,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             11
           </pre>
@@ -804,17 +804,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             12
           </pre>
@@ -847,17 +847,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             13
           </pre>
@@ -895,17 +895,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             14
           </pre>
@@ -967,17 +967,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             15
           </pre>
@@ -1030,17 +1030,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             16
           </pre>
@@ -1078,17 +1078,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             17
           </pre>
@@ -1125,17 +1125,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             18
           </pre>
@@ -1161,17 +1161,17 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             19
           </pre>
@@ -1239,17 +1239,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             1
           </pre>
@@ -1316,17 +1316,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             2
           </pre>
@@ -1381,17 +1381,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             3
           </pre>
@@ -1436,17 +1436,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             4
           </pre>
@@ -1616,17 +1616,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             5
           </pre>
@@ -1757,17 +1757,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             6
           </pre>
@@ -1821,17 +1821,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             7
           </pre>
@@ -1870,17 +1870,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             8
           </pre>
@@ -1918,17 +1918,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             9
           </pre>
@@ -1995,17 +1995,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             10
           </pre>
@@ -2062,17 +2062,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             11
           </pre>
@@ -2141,17 +2141,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             12
           </pre>
@@ -2184,17 +2184,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             13
           </pre>
@@ -2232,17 +2232,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             14
           </pre>
@@ -2304,17 +2304,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             15
           </pre>
@@ -2367,17 +2367,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             16
           </pre>
@@ -2415,17 +2415,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             17
           </pre>
@@ -2462,17 +2462,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             18
           </pre>
@@ -2498,17 +2498,17 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+          class="css-1548r9v-gutter css-cnnxkz-diff-added"
         >
           <pre
-            class="css-h84nzi-line-number"
+            class="css-14p8zw1-line-number"
           >
             19
           </pre>

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -1,0 +1,2555 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DiffView component Should add comment box 1`] = `
+<div>
+  <table
+    class="css-1n5o7vh-diff-container"
+  >
+    <tbody>
+      <tr>
+        <td
+          class="css-1rwygp7-title-block"
+          colspan="4"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            js7/1.js
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            1
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+              <span
+                class="token keyword"
+              >
+                const
+              </span>
+               
+              <span
+                class="token function-variable function"
+              >
+                solution
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =&gt;
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            2
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token keyword"
+              >
+                const
+              </span>
+               allT 
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                [
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ]
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            3
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token keyword"
+              >
+                const
+              </span>
+               old 
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               setTimeout
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            4
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                window
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function-variable function"
+              >
+                setTimeout
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token parameter"
+              >
+                func
+                <span
+                  class="token punctuation"
+                >
+                  ,
+                </span>
+                 delay
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =&gt;
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+            <div
+              class="showHide"
+            >
+              Hide conversation
+            </div>
+            <div
+              class="commentBox bg-white d-auto"
+            >
+              <div
+                style="background-color: white;"
+              >
+                <button
+                  class="btn"
+                  style="color: rgb(41, 41, 41);"
+                >
+                  Write
+                </button>
+                <button
+                  class="btn"
+                  style="color: rgb(142, 142, 142);"
+                >
+                  Preview
+                </button>
+                <textarea
+                  data-testid="textbox"
+                  placeholder="Type something..."
+                  style="padding: 1rem; width: 100%;"
+                />
+              </div>
+              <button
+                class="btn bg-success"
+                style="color: rgb(255, 255, 255);"
+              >
+                Add comment
+              </button>
+            </div>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            5
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  
+              <span
+                class="token keyword"
+              >
+                const
+              </span>
+               realTimeout 
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token function"
+              >
+                old
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              func
+              <span
+                class="token punctuation"
+              >
+                ,
+              </span>
+               delay
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            6
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  allT
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function"
+              >
+                push
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              realTimeout
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            7
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  
+              <span
+                class="token keyword"
+              >
+                return
+              </span>
+               realTimeout
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            8
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            9
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                window
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function-variable function"
+              >
+                clearAllTimouts
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =&gt;
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            10
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  
+              <span
+                class="token keyword"
+              >
+                while
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              allT
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              length
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            11
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                    
+              <span
+                class="token function"
+              >
+                clearTimeout
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              allT
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function"
+              >
+                pop
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            12
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            13
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            14
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token function-variable function"
+              >
+                cat
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =&gt;
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            15
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  window
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function"
+              >
+                clearAllTimouts
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            16
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            17
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            18
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span />
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            19
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+              module
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              exports 
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               solution
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DiffView component Should render diff with comments 1`] = `
+<div>
+  <table
+    class="css-1n5o7vh-diff-container"
+  >
+    <tbody>
+      <tr>
+        <td
+          class="css-1rwygp7-title-block"
+          colspan="4"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            js7/1.js
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            1
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+              <span
+                class="token keyword"
+              >
+                const
+              </span>
+               
+              <span
+                class="token function-variable function"
+              >
+                solution
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =&gt;
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            2
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token keyword"
+              >
+                const
+              </span>
+               allT 
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                [
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ]
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            3
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token keyword"
+              >
+                const
+              </span>
+               old 
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               setTimeout
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            4
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                window
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function-variable function"
+              >
+                setTimeout
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token parameter"
+              >
+                func
+                <span
+                  class="token punctuation"
+                >
+                  ,
+                </span>
+                 delay
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =&gt;
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+            <div
+              class="showHide"
+            >
+              Hide conversation
+            </div>
+            <div
+              class="commentBox bg-white d-auto"
+            >
+              <div
+                class="border"
+              >
+                <span
+                  wrapper="code_wrapper"
+                >
+                  First Comment
+                </span>
+                <div
+                  class="wrapper"
+                >
+                  <a
+                    class="comment_author__inline mt-2 d-block"
+                    href="/profile/newbie"
+                  >
+                    <div
+                      class="d-inline"
+                    >
+                      Noob Newbie
+                    </div>
+                    <div
+                      class="d-inline text-muted"
+                    >
+                       @newbie
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div
+                class="border"
+              >
+                <span
+                  wrapper="code_wrapper"
+                >
+                  Second Comment
+                </span>
+                <div
+                  class="wrapper"
+                >
+                  <a
+                    class="comment_author__inline mt-2 d-block"
+                    href="/profile/newbie"
+                  >
+                    <div
+                      class="d-inline"
+                    >
+                      Noob Newbie
+                    </div>
+                    <div
+                      class="d-inline text-muted"
+                    >
+                       @newbie
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div
+                style="background-color: white;"
+              >
+                <button
+                  class="btn"
+                  style="color: rgb(41, 41, 41);"
+                >
+                  Write
+                </button>
+                <button
+                  class="btn"
+                  style="color: rgb(142, 142, 142);"
+                >
+                  Preview
+                </button>
+                <textarea
+                  data-testid="textbox"
+                  placeholder="Type something..."
+                  style="padding: 1rem; width: 100%;"
+                />
+              </div>
+              <button
+                class="btn bg-success"
+                style="color: rgb(255, 255, 255);"
+              >
+                Add comment
+              </button>
+            </div>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            5
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  
+              <span
+                class="token keyword"
+              >
+                const
+              </span>
+               realTimeout 
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token function"
+              >
+                old
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              func
+              <span
+                class="token punctuation"
+              >
+                ,
+              </span>
+               delay
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+            <div
+              class="showHide"
+            >
+              Hide conversation
+            </div>
+            <div
+              class="commentBox bg-white d-auto"
+            >
+              <div
+                class="border"
+              >
+                <span
+                  wrapper="code_wrapper"
+                >
+                  Second Comment
+                </span>
+                <div
+                  class="wrapper"
+                >
+                  <a
+                    class="comment_author__inline mt-2 d-block"
+                    href="/profile/admin"
+                  >
+                    <div
+                      class="d-inline"
+                    >
+                      Admin Admin
+                    </div>
+                    <div
+                      class="d-inline text-muted"
+                    >
+                       @admin
+                    </div>
+                  </a>
+                </div>
+              </div>
+              <div
+                style="background-color: white;"
+              >
+                <button
+                  class="btn"
+                  style="color: rgb(41, 41, 41);"
+                >
+                  Write
+                </button>
+                <button
+                  class="btn"
+                  style="color: rgb(142, 142, 142);"
+                >
+                  Preview
+                </button>
+                <textarea
+                  data-testid="textbox"
+                  placeholder="Type something..."
+                  style="padding: 1rem; width: 100%;"
+                />
+              </div>
+              <button
+                class="btn bg-success"
+                style="color: rgb(255, 255, 255);"
+              >
+                Add comment
+              </button>
+            </div>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            6
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  allT
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function"
+              >
+                push
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              realTimeout
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            7
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  
+              <span
+                class="token keyword"
+              >
+                return
+              </span>
+               realTimeout
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            8
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            9
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                window
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function-variable function"
+              >
+                clearAllTimouts
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =&gt;
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            10
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  
+              <span
+                class="token keyword"
+              >
+                while
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              allT
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              length
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            11
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                    
+              <span
+                class="token function"
+              >
+                clearTimeout
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              allT
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function"
+              >
+                pop
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            12
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            13
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            14
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token function-variable function"
+              >
+                cat
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+               
+              <span
+                class="token operator"
+              >
+                =&gt;
+              </span>
+               
+              <span
+                class="token punctuation"
+              >
+                {
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            15
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                  window
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function"
+              >
+                clearAllTimouts
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            16
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+                
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            17
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+              <span
+                class="token punctuation"
+              >
+                }
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            18
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span />
+          </pre>
+        </td>
+      </tr>
+      <tr
+        class="css-1n7ec1i-line"
+      >
+        <td
+          class="css-1ks9aww-gutter css-1klnsbn-empty-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          />
+        </td>
+        <td
+          class="css-1ks9aww-gutter css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-h84nzi-line-number"
+          >
+            19
+          </pre>
+        </td>
+        <td
+          class="css-17vezug-marker css-cnnxkz-diff-added"
+        >
+          <pre>
+            +
+          </pre>
+        </td>
+        <td
+          class="css-vl0irh-content css-cnnxkz-diff-added"
+        >
+          <pre
+            class="css-pa3tg-content-text"
+          >
+            <span>
+              module
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              exports 
+              <span
+                class="token operator"
+              >
+                =
+              </span>
+               solution
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+            </span>
+          </pre>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/stories/components/DiffView.stories.tsx
+++ b/stories/components/DiffView.stories.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import DiffView from '../../components/DiffView'
+import { Comment } from '../../graphql/'
+import { MockedProvider } from '@apollo/client/testing'
+
+export default {
+  component: DiffView,
+  title: 'Components/DiffView'
+}
+
+const JsDiff =
+  'diff --git a/js7/1.js b/js7/1.js\nindex 9c96b34..853bddf 100644\n--- a/js7/1.js\n+++ b/js7/1.js\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
+const comments: Comment[] = [
+  {
+    content: 'First Comment',
+    createdAt: '1620762267819',
+    authorId: 3,
+    line: 4,
+    author: {
+      username: 'newbie',
+      name: 'Noob Newbie',
+      id: 1,
+      email: '',
+      isAdmin: false
+    },
+    id: 1,
+    fileName: 'js7/1.js',
+    submissionId: 1
+  },
+  {
+    content: 'Second Comment',
+    createdAt: '1620762275096',
+    authorId: 3,
+    line: 4,
+    author: {
+      username: 'newbie',
+      name: 'Noob Newbie',
+      id: 1,
+      email: '',
+      isAdmin: false
+    },
+    id: 2,
+    fileName: 'js7/1.js',
+    submissionId: 1
+  },
+  {
+    content: 'Third Comment',
+    createdAt: '1620762275096',
+    authorId: 3,
+    line: 5,
+    author: {
+      username: 'admin',
+      name: 'Admin Admin',
+      id: 2,
+      email: '',
+      isAdmin: true
+    },
+    id: 3,
+    fileName: 'js7/1.js',
+    submissionId: 1
+  }
+]
+export const Default: React.FC = () => {
+  return (
+    <MockedProvider>
+      <DiffView
+        diff={JsDiff}
+        comments={comments}
+        id={1}
+        name="User User"
+        username="user"
+      />
+    </MockedProvider>
+  )
+}
+
+export const Closed: React.FC = () => {
+  return (
+    <MockedProvider>
+      <DiffView
+        diff={JsDiff}
+        comments={comments}
+        id={1}
+        name="User User"
+        username="user"
+        status="passed"
+      />
+    </MockedProvider>
+  )
+}


### PR DESCRIPTION
The last new component for inline comments. 

DiffView will be used to render diff for student and reviewer both. If you check current `ReviewCard` and `ChallengMaterial` components you will find some duplicated logic. 

This components gets an array of comments along with other props. Since submission can consists of multiply files it creates state indexed by "id:fileName" ("1:1.js"). Every file has an array of line numbers and array of comments. Every time syntaxHyghlight runs it checks if current line number is included in the state and renders CommentBox if true. If you click on lineNumber you add it to the state.

Note: DiffView will render only new lines, just like current review page. So instead of green/red/white for new lines/deleted lines/unaffected lines everything will be green. It sounds like a big deal but it is not. Currently only the first three lessons are using full diff highlighting and in a very boring way (against the initial template file). 

This PR should not affect production in any way. 
[
Storybook](https://deploy-preview-814--youthful-thompson-448332.netlify.app/?path=/story/components-diffview--default) (real component will clear input after adding comment, it's a storybook bug). 