### PR TITLE
close #826 - wait for useRouter to be ready

### DIFF
--- a/__mocks__/next/router.js
+++ b/__mocks__/next/router.js
@@ -10,6 +10,7 @@ export const useRouter = jest.fn().mockImplementation(() => {
     push,
     replace: async () => true,
     reload: () => null,
-    back
+    back,
+    isReady: true
   }
 })

--- a/__tests__/pages/curriculum/[lesson].test.js
+++ b/__tests__/pages/curriculum/[lesson].test.js
@@ -1,5 +1,11 @@
 import React from 'react'
-import { render, waitFor, screen } from '@testing-library/react'
+import {
+  render,
+  waitFor,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react'
+import '@testing-library/jest-dom'
 import { MockedProvider } from '@apollo/client/testing'
 import GET_APP from '../../../graphql/queries/getApp'
 import Lesson from '../../../pages/curriculum/[lesson]'
@@ -194,5 +200,34 @@ describe('Lesson Page', () => {
     await waitFor(() =>
       screen.getByRole('heading', { name: /Variables & Functions/i })
     )
+  })
+  test('Should return loading spinner if useRouter is not ready', async () => {
+    useRouter.mockImplementation(() => ({
+      isReady: false
+    }))
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session,
+            lessons: dummyLessonData,
+            alerts: dummyAlertData
+          }
+        }
+      }
+    ]
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Lesson />
+      </MockedProvider>
+    )
+    //there are two spinners, one frow withQueryLoader, another from useRouter, so we need to wait to test the second one
+    expect(
+      await waitForElementToBeRemoved(() => screen.queryByText('Loading...'), {
+        onTimeout: () => {}
+      })
+    ).toBeNull()
   })
 })

--- a/pages/curriculum/[lesson].tsx
+++ b/pages/curriculum/[lesson].tsx
@@ -6,6 +6,7 @@ import LessonTitleCard from '../../components/LessonTitleCard'
 import AlertsDisplay from '../../components/AlertsDisplay'
 import ChallengeMaterial from '../../components/ChallengeMaterial'
 import GET_APP from '../../graphql/queries/getApp'
+import LoadingSpinner from '../../components/LoadingSpinner'
 import {
   Challenge,
   UserLesson,
@@ -21,14 +22,16 @@ const Challenges: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
   const { lessons, session, alerts } = queryData
   const [show, setShow] = useState(false)
   const router = useRouter()
+  if (!router.isReady) return <LoadingSpinner />
+
   const currentlessonId = Number(router.query.lesson)
-  if (!lessons || !alerts) {
+  if (!lessons || !alerts)
     return <Error code={StatusCode.INTERNAL_SERVER_ERROR} message="Bad data" />
-  }
+
   const currentLesson = lessons.find(lesson => lesson.id === currentlessonId)
-  if (!currentLesson) {
+  if (!currentLesson)
     return <Error code={StatusCode.NOT_FOUND} message="Lesson not found" />
-  }
+
   const userSubmissions: Submission[] =
     (_.get(session, 'submissions', []) as Submission[]) || []
   const lessonStatus: UserLesson[] = _.get(


### PR DESCRIPTION
Turns out useRouter [is not ready](https://nextjs.org/docs/routing/dynamic-routes#caveats) on first render:
_Pages that are statically optimized by Automatic Static Optimization will be hydrated without their route parameters provided, i.e query will be an empty object ({})._

Query is undefined and check for valid lesson fails resulting in flashing 404 Lesson Not Found Page. I added additional loading spinner until router is ready. 