### PR TITLE
update #837 - change fetch policy for submission query

### DIFF
--- a/components/LessonCard.tsx
+++ b/components/LessonCard.tsx
@@ -14,7 +14,8 @@ import { SubmissionStatus } from '../graphql'
 
 const ReviewCount: React.FC<ReviewCountProps> = props => {
   const { loading, data } = useQuery(GET_SUBMISSIONS, {
-    variables: { lessonId: props.lessonId }
+    variables: { lessonId: props.lessonId },
+    fetchPolicy: 'network-only'
   })
 
   if (loading) {


### PR DESCRIPTION
An attempt to fix incorrect submission counter. I believe it should work but I have no way to test it locally. 

Changing policy should force submission query to ignore local cache. It will result in slightly longer loading time for counter but I think it's a worthy tradeoff since it's non-blocking.  