### PR TITLE
update #585 - add backend for comments under submissions

### DIFF
--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -47,7 +47,7 @@ const DiffView: React.FC<{
             lines: [],
             comments: []
           }
-        acc[index].lines.push(comment.line)
+        comment.line && acc[index].lines.push(comment.line)
         acc[index].comments.push(comment)
         return acc
       }, {})

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -58,8 +58,8 @@ export type Challenge = {
 export type Comment = {
   __typename?: 'Comment'
   id: Scalars['Int']
-  fileName: Scalars['String']
-  line: Scalars['Int']
+  fileName?: Maybe<Scalars['String']>
+  line?: Maybe<Scalars['Int']>
   content: Scalars['String']
   authorId: Scalars['Int']
   submissionId: Scalars['Int']
@@ -168,8 +168,8 @@ export type MutationRejectSubmissionArgs = {
 }
 
 export type MutationAddCommentArgs = {
-  line: Scalars['Int']
-  fileName: Scalars['String']
+  line?: Maybe<Scalars['Int']>
+  fileName?: Maybe<Scalars['String']>
   submissionId: Scalars['Int']
   content: Scalars['String']
 }
@@ -351,10 +351,10 @@ export type AddAlertMutation = { __typename?: 'Mutation' } & {
 }
 
 export type AddCommentMutationVariables = Exact<{
-  line: Scalars['Int']
+  line?: Maybe<Scalars['Int']>
   submissionId: Scalars['Int']
   content: Scalars['String']
-  fileName: Scalars['String']
+  fileName?: Maybe<Scalars['String']>
 }>
 
 export type AddCommentMutation = { __typename?: 'Mutation' } & {
@@ -1144,8 +1144,8 @@ export type CommentResolvers<
   ParentType extends ResolversParentTypes['Comment'] = ResolversParentTypes['Comment']
 > = {
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
-  fileName?: Resolver<ResolversTypes['String'], ParentType, ContextType>
-  line?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
+  fileName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  line?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
   content?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   authorId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
   submissionId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
@@ -1270,10 +1270,7 @@ export type MutationResolvers<
     Maybe<ResolversTypes['Comment']>,
     ParentType,
     ContextType,
-    RequireFields<
-      MutationAddCommentArgs,
-      'line' | 'fileName' | 'submissionId' | 'content'
-    >
+    RequireFields<MutationAddCommentArgs, 'submissionId' | 'content'>
   >
   createLesson?: Resolver<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
@@ -1692,10 +1689,10 @@ export type AddAlertMutationOptions = Apollo.BaseMutationOptions<
 >
 export const AddCommentDocument = gql`
   mutation addComment(
-    $line: Int!
+    $line: Int
     $submissionId: Int!
     $content: String!
-    $fileName: String!
+    $fileName: String
   ) {
     addComment(
       line: $line

--- a/graphql/queries/addComment.ts
+++ b/graphql/queries/addComment.ts
@@ -2,10 +2,10 @@ import { gql } from '@apollo/client'
 
 const ADD_COMMENT = gql`
   mutation addComment(
-    $line: Int!
+    $line: Int
     $submissionId: Int!
     $content: String!
-    $fileName: String!
+    $fileName: String
   ) {
     addComment(
       line: $line

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -47,8 +47,8 @@ export default gql`
     acceptSubmission(id: Int!, comment: String!, lessonId: Int!): Submission
     rejectSubmission(id: Int!, comment: String!, lessonId: Int!): Submission
     addComment(
-      line: Int!
-      fileName: String!
+      line: Int
+      fileName: String
       submissionId: Int!
       content: String!
     ): Comment
@@ -119,8 +119,8 @@ export default gql`
 
   type Comment {
     id: Int!
-    fileName: String!
-    line: Int!
+    fileName: String
+    line: Int
     content: String!
     authorId: Int!
     submissionId: Int!

--- a/prisma/migrations/20210607151440_make_comments_more_general/migration.sql
+++ b/prisma/migrations/20210607151440_make_comments_more_general/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Comment" ALTER COLUMN "fileName" DROP NOT NULL,
+ALTER COLUMN "line" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,8 +104,8 @@ model Submission {
 
 model Comment {
   id           Int        @id @default(autoincrement())
-  fileName     String
-  line         Int
+  fileName     String?
+  line         Int?
   content      String
   authorId     Int
   author       User       @relation(fields: [authorId], references: [id])


### PR DESCRIPTION
This PR will relax requirements for Comment model. Previously every comment was required to have line number and file name, updated model will allow comments which are indexed only by submission id. 