### PR TITLE
update #874 - add getPreviousSubmissions query

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -220,6 +220,7 @@ export type Query = {
   isTokenValid: Scalars['Boolean']
   submissions?: Maybe<Array<Submission>>
   alerts: Array<Alert>
+  getPreviousSubmissions?: Maybe<Array<Submission>>
 }
 
 export type QueryGetLessonMentorsArgs = {
@@ -236,6 +237,12 @@ export type QueryIsTokenValidArgs = {
 
 export type QuerySubmissionsArgs = {
   lessonId: Scalars['Int']
+}
+
+export type QueryGetPreviousSubmissionsArgs = {
+  lessonId: Scalars['Int']
+  challengeId: Scalars['Int']
+  userId: Scalars['Int']
 }
 
 export type Session = {
@@ -276,6 +283,7 @@ export type Submission = {
 }
 
 export enum SubmissionStatus {
+  Overwritten = 'overwritten',
   NeedMoreWork = 'needMoreWork',
   Open = 'open',
   Passed = 'passed'
@@ -575,6 +583,53 @@ export type LessonMentorsQuery = { __typename?: 'Query' } & {
   getLessonMentors?: Maybe<
     Array<
       Maybe<{ __typename?: 'User' } & Pick<User, 'username' | 'name' | 'id'>>
+    >
+  >
+}
+
+export type GetPreviousSubmissionsQueryVariables = Exact<{
+  lessonId: Scalars['Int']
+  challengeId: Scalars['Int']
+  userId: Scalars['Int']
+}>
+
+export type GetPreviousSubmissionsQuery = { __typename?: 'Query' } & {
+  getPreviousSubmissions?: Maybe<
+    Array<
+      { __typename?: 'Submission' } & Pick<
+        Submission,
+        | 'id'
+        | 'status'
+        | 'diff'
+        | 'comment'
+        | 'challengeId'
+        | 'lessonId'
+        | 'createdAt'
+        | 'updatedAt'
+      > & {
+          challenge: { __typename?: 'Challenge' } & Pick<Challenge, 'title'>
+          user: { __typename?: 'User' } & Pick<User, 'id' | 'username'>
+          reviewer?: Maybe<
+            { __typename?: 'User' } & Pick<User, 'id' | 'username' | 'name'>
+          >
+          comments?: Maybe<
+            Array<
+              { __typename?: 'Comment' } & Pick<
+                Comment,
+                | 'content'
+                | 'submissionId'
+                | 'createdAt'
+                | 'authorId'
+                | 'line'
+                | 'fileName'
+              > & {
+                  author?: Maybe<
+                    { __typename?: 'User' } & Pick<User, 'username' | 'name'>
+                  >
+                }
+            >
+          >
+        }
     >
   >
 }
@@ -1343,6 +1398,15 @@ export type QueryResolvers<
     RequireFields<QuerySubmissionsArgs, 'lessonId'>
   >
   alerts?: Resolver<Array<ResolversTypes['Alert']>, ParentType, ContextType>
+  getPreviousSubmissions?: Resolver<
+    Maybe<Array<ResolversTypes['Submission']>>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      QueryGetPreviousSubmissionsArgs,
+      'lessonId' | 'challengeId' | 'userId'
+    >
+  >
 }
 
 export type SessionResolvers<
@@ -2496,6 +2560,137 @@ export type LessonMentorsLazyQueryHookResult = ReturnType<
 export type LessonMentorsQueryResult = Apollo.QueryResult<
   LessonMentorsQuery,
   LessonMentorsQueryVariables
+>
+export const GetPreviousSubmissionsDocument = gql`
+  query getPreviousSubmissions(
+    $lessonId: Int!
+    $challengeId: Int!
+    $userId: Int!
+  ) {
+    getPreviousSubmissions(
+      lessonId: $lessonId
+      challengeId: $challengeId
+      userId: $userId
+    ) {
+      id
+      status
+      diff
+      comment
+      challenge {
+        title
+      }
+      challengeId
+      lessonId
+      user {
+        id
+        username
+      }
+      reviewer {
+        id
+        username
+        name
+      }
+      comments {
+        content
+        submissionId
+        createdAt
+        authorId
+        line
+        fileName
+        author {
+          username
+          name
+        }
+      }
+      createdAt
+      updatedAt
+    }
+  }
+`
+export type GetPreviousSubmissionsProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    GetPreviousSubmissionsQuery,
+    GetPreviousSubmissionsQueryVariables
+  >
+} &
+  TChildProps
+export function withGetPreviousSubmissions<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    GetPreviousSubmissionsQuery,
+    GetPreviousSubmissionsQueryVariables,
+    GetPreviousSubmissionsProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    GetPreviousSubmissionsQuery,
+    GetPreviousSubmissionsQueryVariables,
+    GetPreviousSubmissionsProps<TChildProps, TDataName>
+  >(GetPreviousSubmissionsDocument, {
+    alias: 'getPreviousSubmissions',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useGetPreviousSubmissionsQuery__
+ *
+ * To run a query within a React component, call `useGetPreviousSubmissionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetPreviousSubmissionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetPreviousSubmissionsQuery({
+ *   variables: {
+ *      lessonId: // value for 'lessonId'
+ *      challengeId: // value for 'challengeId'
+ *      userId: // value for 'userId'
+ *   },
+ * });
+ */
+export function useGetPreviousSubmissionsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetPreviousSubmissionsQuery,
+    GetPreviousSubmissionsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<
+    GetPreviousSubmissionsQuery,
+    GetPreviousSubmissionsQueryVariables
+  >(GetPreviousSubmissionsDocument, options)
+}
+export function useGetPreviousSubmissionsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetPreviousSubmissionsQuery,
+    GetPreviousSubmissionsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<
+    GetPreviousSubmissionsQuery,
+    GetPreviousSubmissionsQueryVariables
+  >(GetPreviousSubmissionsDocument, options)
+}
+export type GetPreviousSubmissionsQueryHookResult = ReturnType<
+  typeof useGetPreviousSubmissionsQuery
+>
+export type GetPreviousSubmissionsLazyQueryHookResult = ReturnType<
+  typeof useGetPreviousSubmissionsLazyQuery
+>
+export type GetPreviousSubmissionsQueryResult = Apollo.QueryResult<
+  GetPreviousSubmissionsQuery,
+  GetPreviousSubmissionsQueryVariables
 >
 export const GetSessionDocument = gql`
   query getSession {

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -240,7 +240,6 @@ export type QuerySubmissionsArgs = {
 }
 
 export type QueryGetPreviousSubmissionsArgs = {
-  lessonId: Scalars['Int']
   challengeId: Scalars['Int']
   userId: Scalars['Int']
 }
@@ -588,7 +587,6 @@ export type LessonMentorsQuery = { __typename?: 'Query' } & {
 }
 
 export type GetPreviousSubmissionsQueryVariables = Exact<{
-  lessonId: Scalars['Int']
   challengeId: Scalars['Int']
   userId: Scalars['Int']
 }>
@@ -1402,10 +1400,7 @@ export type QueryResolvers<
     Maybe<Array<ResolversTypes['Submission']>>,
     ParentType,
     ContextType,
-    RequireFields<
-      QueryGetPreviousSubmissionsArgs,
-      'lessonId' | 'challengeId' | 'userId'
-    >
+    RequireFields<QueryGetPreviousSubmissionsArgs, 'challengeId' | 'userId'>
   >
 }
 
@@ -2562,16 +2557,8 @@ export type LessonMentorsQueryResult = Apollo.QueryResult<
   LessonMentorsQueryVariables
 >
 export const GetPreviousSubmissionsDocument = gql`
-  query getPreviousSubmissions(
-    $lessonId: Int!
-    $challengeId: Int!
-    $userId: Int!
-  ) {
-    getPreviousSubmissions(
-      lessonId: $lessonId
-      challengeId: $challengeId
-      userId: $userId
-    ) {
+  query getPreviousSubmissions($challengeId: Int!, $userId: Int!) {
+    getPreviousSubmissions(challengeId: $challengeId, userId: $userId) {
       id
       status
       diff
@@ -2652,7 +2639,6 @@ export function withGetPreviousSubmissions<
  * @example
  * const { data, loading, error } = useGetPreviousSubmissionsQuery({
  *   variables: {
- *      lessonId: // value for 'lessonId'
  *      challengeId: // value for 'challengeId'
  *      userId: // value for 'userId'
  *   },

--- a/graphql/queries/getPreviousSubmissions.ts
+++ b/graphql/queries/getPreviousSubmissions.ts
@@ -1,0 +1,50 @@
+import { gql } from '@apollo/client'
+
+const GET_PREVIOUS_SUBMISSIONS = gql`
+  query getPreviousSubmissions(
+    $lessonId: Int!
+    $challengeId: Int!
+    $userId: Int!
+  ) {
+    getPreviousSubmissions(
+      lessonId: $lessonId
+      challengeId: $challengeId
+      userId: $userId
+    ) {
+      id
+      status
+      diff
+      comment
+      challenge {
+        title
+      }
+      challengeId
+      lessonId
+      user {
+        id
+        username
+      }
+      reviewer {
+        id
+        username
+        name
+      }
+      comments {
+        content
+        submissionId
+        createdAt
+        authorId
+        line
+        fileName
+        author {
+          username
+          name
+        }
+      }
+      createdAt
+      updatedAt
+    }
+  }
+`
+
+export default GET_PREVIOUS_SUBMISSIONS

--- a/graphql/queries/getPreviousSubmissions.ts
+++ b/graphql/queries/getPreviousSubmissions.ts
@@ -1,16 +1,8 @@
 import { gql } from '@apollo/client'
 
 const GET_PREVIOUS_SUBMISSIONS = gql`
-  query getPreviousSubmissions(
-    $lessonId: Int!
-    $challengeId: Int!
-    $userId: Int!
-  ) {
-    getPreviousSubmissions(
-      lessonId: $lessonId
-      challengeId: $challengeId
-      userId: $userId
-    ) {
+  query getPreviousSubmissions($challengeId: Int!, $userId: Int!) {
+    getPreviousSubmissions(challengeId: $challengeId, userId: $userId) {
       id
       status
       diff

--- a/graphql/queryResolvers/getPreviousSubmissions.test.js
+++ b/graphql/queryResolvers/getPreviousSubmissions.test.js
@@ -2,29 +2,16 @@ import { prisma } from '../../prisma'
 import { getPreviousSubmissions } from './getPreviousSubmissions'
 
 describe('getPreviousSubmissions test', () => {
-  test('Should await prisma query', async () => {
-    prisma.submission.findMany = jest.fn().mockResolvedValue([
+  test('Should invoke prisma query', async () => {
+    const query = (prisma.submission.findMany = jest.fn())
+    await getPreviousSubmissions(
+      {},
       {
-        title: 'testSubmissionA'
+        challengeId: 1,
+        userId: 1
       },
-      { title: 'testSubmissionB' }
-    ])
-    expect(
-      await getPreviousSubmissions(
-        {},
-        {
-          lessonId: 1,
-          challengeId: 1,
-          userId: 1
-        },
-
-        { req: { user: { id: 1 } } }
-      )
-    ).toEqual([
-      {
-        title: 'testSubmissionA'
-      },
-      { title: 'testSubmissionB' }
-    ])
+      {}
+    )
+    expect(query).toBeCalled()
   })
 })

--- a/graphql/queryResolvers/getPreviousSubmissions.test.js
+++ b/graphql/queryResolvers/getPreviousSubmissions.test.js
@@ -1,0 +1,30 @@
+import { prisma } from '../../prisma'
+import { getPreviousSubmissions } from './getPreviousSubmissions'
+
+describe('getPreviousSubmissions test', () => {
+  test('Should await prisma query', async () => {
+    prisma.submission.findMany = jest.fn().mockResolvedValue([
+      {
+        title: 'testSubmissionA'
+      },
+      { title: 'testSubmissionB' }
+    ])
+    expect(
+      await getPreviousSubmissions(
+        {},
+        {
+          lessonId: 1,
+          challengeId: 1,
+          userId: 1
+        },
+
+        { req: { user: { id: 1 } } }
+      )
+    ).toEqual([
+      {
+        title: 'testSubmissionA'
+      },
+      { title: 'testSubmissionB' }
+    ])
+  })
+})

--- a/graphql/queryResolvers/getPreviousSubmissions.ts
+++ b/graphql/queryResolvers/getPreviousSubmissions.ts
@@ -1,0 +1,31 @@
+import { prisma } from '../../prisma'
+import { QueryGetPreviousSubmissionsArgs } from '../../graphql'
+import { Context } from '../../@types/helpers'
+
+export const getPreviousSubmissions = async (
+  _parent: void,
+  arg: QueryGetPreviousSubmissionsArgs,
+  _ctx: Context
+) => {
+  const { lessonId, challengeId, userId } = arg
+  const submissions = await prisma.submission.findMany({
+    where: {
+      lessonId,
+      challengeId,
+      user: {
+        id: userId
+      }
+    },
+    include: {
+      challenge: true,
+      user: true,
+      reviewer: true,
+      comments: {
+        include: {
+          author: true
+        }
+      }
+    }
+  })
+  return submissions
+}

--- a/graphql/queryResolvers/getPreviousSubmissions.ts
+++ b/graphql/queryResolvers/getPreviousSubmissions.ts
@@ -7,10 +7,9 @@ export const getPreviousSubmissions = async (
   arg: QueryGetPreviousSubmissionsArgs,
   _ctx: Context
 ) => {
-  const { lessonId, challengeId, userId } = arg
-  const submissions = await prisma.submission.findMany({
+  const { challengeId, userId } = arg
+  return prisma.submission.findMany({
     where: {
-      lessonId,
       challengeId,
       user: {
         id: userId
@@ -27,5 +26,4 @@ export const getPreviousSubmissions = async (
       }
     }
   })
-  return submissions
 }

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -29,6 +29,7 @@ import {
   createLesson,
   updateLesson
 } from '../helpers/controllers/lessonsController'
+import { getPreviousSubmissions } from './queryResolvers/getPreviousSubmissions'
 
 export default {
   Query: {
@@ -39,7 +40,8 @@ export default {
     userInfo,
     lessons,
     session,
-    alerts
+    alerts,
+    getPreviousSubmissions
   },
 
   Mutation: {

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -10,6 +10,11 @@ export default gql`
     isTokenValid(cliToken: String!): Boolean!
     submissions(lessonId: Int!): [Submission!]
     alerts: [Alert!]!
+    getPreviousSubmissions(
+      lessonId: Int!
+      challengeId: Int!
+      userId: Int!
+    ): [Submission!]
   }
 
   type TokenResponse {
@@ -130,6 +135,7 @@ export default gql`
   }
 
   enum SubmissionStatus {
+    overwritten
     needMoreWork
     open
     passed

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -10,11 +10,7 @@ export default gql`
     isTokenValid(cliToken: String!): Boolean!
     submissions(lessonId: Int!): [Submission!]
     alerts: [Alert!]!
-    getPreviousSubmissions(
-      lessonId: Int!
-      challengeId: Int!
-      userId: Int!
-    ): [Submission!]
+    getPreviousSubmissions(challengeId: Int!, userId: Int!): [Submission!]
   }
 
   type TokenResponse {

--- a/prisma/migrations/20210625083303_update_status/migration.sql
+++ b/prisma/migrations/20210625083303_update_status/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "submissions"
+DROP CONSTRAINT "submissions_status_check",
+ADD CONSTRAINT "submissions_status_check"
+CHECK ("status" IN ('overwritten', 'needMoreWork', 'open', 'passed'))


### PR DESCRIPTION
Part of backend changes for #874. This new query will be used to fetch previous submissions for specified challenge. 

`Submission.Status` got a new option - 'overwritten'. This will be used when user resubmits challenge without waiting for reviewer to accept or reject his previous attempt. This way I hopefully will not break our metabase statistics. 

Nothing here will affect production yet. 