### PR TITLE
update #874 - remove index from submission table

### DIFF
--- a/helpers/controllers/submissionController.test.js
+++ b/helpers/controllers/submissionController.test.js
@@ -4,7 +4,6 @@
 
 jest.mock('../hasPassedLesson')
 jest.mock('../updateSubmission')
-import exp from 'constants'
 import { SubmissionStatus } from '../../graphql'
 import { prisma } from '../../prisma'
 import { hasPassedLesson } from '../hasPassedLesson'

--- a/helpers/controllers/submissionController.test.js
+++ b/helpers/controllers/submissionController.test.js
@@ -4,6 +4,7 @@
 
 jest.mock('../hasPassedLesson')
 jest.mock('../updateSubmission')
+import exp from 'constants'
 import { SubmissionStatus } from '../../graphql'
 import { prisma } from '../../prisma'
 import { hasPassedLesson } from '../hasPassedLesson'
@@ -44,31 +45,32 @@ describe('Submissions Mutations', () => {
     }
 
     beforeEach(() => {
-      prisma.submission.upsert = jest
+      prisma.submission.create = jest
         .fn()
         .mockResolvedValue({ id: 1, ...submissionMock })
       prisma.lesson.findFirst = jest.fn().mockResolvedValue(null)
+      prisma.submission.findFirst = jest.fn()
     })
 
     test('should save and return submission', async () => {
       await expect(createSubmission(null, args)).resolves.toEqual({
         id: 1,
-        diff: 'fakeDiff'
+        diff: 'fakeDiff',
+        lesson: {
+          order: 1,
+          title: 'Fake lesson',
+          chatUrl: 'https://fake.com/lesson-chat'
+        },
+        challenge: { title: 'Fake challenge' },
+        user: { email: 'fake@email.com' }
       })
-      expect(prisma.submission.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          create: expect.objectContaining({
-            diff: args.diff,
-            status: SubmissionStatus.Open,
-            challengeId: args.challengeId,
-            lessonId: args.lessonId
-          }),
-          update: expect.objectContaining({
-            diff: args.diff,
-            status: SubmissionStatus.Open
-          })
-        })
-      )
+    })
+
+    test('should overwrite previous submission status if it exists', async () => {
+      prisma.submission.findFirst = jest.fn().mockResolvedValue({ id: 1 })
+      prisma.submission.update = jest.fn()
+      await createSubmission(null, args)
+      expect(prisma.submission.update).toBeCalled()
     })
 
     test('should throw error Invalid args', () => {

--- a/helpers/controllers/submissionController.ts
+++ b/helpers/controllers/submissionController.ts
@@ -21,7 +21,6 @@ export const createSubmission = async (
     if (!args) throw new Error('Invalid args')
     const { challengeId, cliToken, diff, lessonId } = args
     const { id } = decode(cliToken)
-    const submissionData = { diff, status: SubmissionStatus.Open }
     const previousSubmission = await prisma.submission.findFirst({
       where: {
         challengeId,
@@ -42,20 +41,15 @@ export const createSubmission = async (
         }
       })
     }
-    const submission = await prisma.submission.create({
+    return prisma.submission.create({
       data: {
-        ...submissionData,
         challengeId,
         lessonId,
-        userId: Number(id)
-      },
-      include: {
-        user: true,
-        lesson: true,
-        challenge: true
+        userId: id,
+        diff,
+        status: SubmissionStatus.Open
       }
     })
-    return submission
   } catch (error) {
     throw new Error(error)
   }

--- a/prisma/migrations/20210628135725_remove_submission_index/migration.sql
+++ b/prisma/migrations/20210628135725_remove_submission_index/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "submissions.userId_lessonId_challengeId_unique";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,7 +98,6 @@ model Submission {
   user        User      @relation("userSubmissions", fields: [userId], references: [id])
   comments    Comment[]
 
-  @@unique([userId, lessonId, challengeId])
   @@map("submissions")
 }
 


### PR DESCRIPTION
This PR removes unique requirement for submission, meaning that our db will be able to store multiply submissions for the same challenge by the same user. 

Submission controller checks if there is an existing open submission and changes its status to 'overwritten' before creating new row in db. 

Reviewing process won't be affected by this change. Students and reviewers will see only the last open submission. 