### PR TITLE
Update the local setup instructions

### DIFF
--- a/pages/docs/setup.mdx
+++ b/pages/docs/setup.mdx
@@ -149,6 +149,7 @@ machine, downloading the codebase, and setting up the codebase.
 
 1. Install [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
    and familiarize yourself with [common git commands](/docs/git).
+1. Install [yarn](https://yarnpkg.com/getting-started) by running `npm install -g yarn`.
 1. Use git to [clone the curriculum](https://github.com/garageScript/curriculum)
    into your machine: `git clone https://github.com/garageScript/curriculum`.
 1. Go into the curriculum root folder by typing `cd curriculum`.


### PR DESCRIPTION
The step for installing yarn was missing although it was required for setting up the curriculum repo, so i updated the local setup instructions section to include the step for installing yarn globally.