### PR TITLE
update #956 - fix submission order

### DIFF
--- a/helpers/controllers/userInfoController.ts
+++ b/helpers/controllers/userInfoController.ts
@@ -48,6 +48,9 @@ export const userInfo = async (_parent: void, args: UserInfoQueryVariables) => {
             id: true
           }
         }
+      },
+      orderBy: {
+        id: 'asc'
       }
     }),
     prisma.star.findMany({

--- a/stories/profile/UserProfilePage.stories.tsx
+++ b/stories/profile/UserProfilePage.stories.tsx
@@ -9,6 +9,7 @@ import dummyStarsData from '../../__dummy__/starsData'
 import { withTestRouter } from '../../__tests__/utils/withTestRouter'
 import { Session } from '../../graphql'
 import { Star } from '../../graphql/index'
+import { useRouter } from 'next/router'
 
 export default {
   component: UserProfile,
@@ -77,7 +78,8 @@ const mocks = [
     }
   }
 ]
-
+const { query } = useRouter()
+query['username'] = 'fakeusername'
 export const _UserProfileZeroComments: React.FC = () => {
   return withTestRouter(
     <MockedProvider mocks={mocks} addTypename={false}>


### PR DESCRIPTION
### What happened?

Incorrect assumption about how `prisma.findMany` works. It doesn't enforce any order, it's a simple disk scan (that's why it's so hard to reproduce this issue). Previously it wasn't a problem because we had only one submission per challenge at any given time but with multiply submissions order is very important. Usually we want either the last of the first submission, I choose to sort them in ascending order and use reverse for profile page. It could be done otherwise with the same result.  

While investigation this issue Jasir pointed out that lesson progress could be incorrect too (it could exceed 100%). I added de duplication logic to profile page.

There is also non-related bug with profile page when we call grapql query without argument on first render (I wouldn't notice it if not for Sentry). It doesn't affect UX at all but I added skip case to prevent it. 