### PR TITLE
Fix lesson pass check

### DIFF
--- a/helpers/updateSubmission.test.js
+++ b/helpers/updateSubmission.test.js
@@ -48,7 +48,9 @@ describe('updateSubmission', () => {
       user: userMock
     })
     prisma.challenge.count = jest.fn().mockResolvedValue(1)
-    prisma.submission.count = jest.fn().mockResolvedValue(1)
+    prisma.submission.findMany = jest
+      .fn()
+      .mockResolvedValue([{ challengeId: 1 }])
     prisma.userLesson.upsert = jest.fn().mockResolvedValue({
       isPassed: '1619821939579'
     })

--- a/helpers/updateSubmission.ts
+++ b/helpers/updateSubmission.ts
@@ -39,8 +39,12 @@ export const updateSubmission = async (
     const [lessonChallengeCount, passedLessonSubmissions, userLesson] =
       await Promise.all([
         prisma.challenge.count({ where: { lessonId } }),
-        prisma.submission.count({
-          where: { lessonId, userId: user.id, status: SubmissionStatus.Passed }
+        prisma.submission.findMany({
+          where: { lessonId, userId: user.id, status: SubmissionStatus.Passed },
+          distinct: ['challengeId'],
+          select: {
+            challengeId: true
+          }
         }),
         prisma.userLesson.upsert({
           where: {
@@ -62,7 +66,7 @@ export const updateSubmission = async (
     // immediately return and do not proceed
     if (
       userLesson.isPassed ||
-      lessonChallengeCount !== passedLessonSubmissions
+      lessonChallengeCount !== passedLessonSubmissions.length
     ) {
       return submission
     }


### PR DESCRIPTION
fixes #966 

Fixes incorrect passed lesson computation by counting only 1 submission per challengeId in a lesson by using a distinct clause.

The `submissions.count` query has been replaced by a findMany because `count` does not support the `distinct` clause. Only challengeId for each submission is fetched to fetch minimal extra data from the the db 