### PR TITLE
Autofocus form fields

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -19175,6 +19175,7 @@ Array [
               className="form-group"
             >
               <input
+                autoFocus={true}
                 className="form-control form-control-lg font-weight-light mb-3 "
                 data-testid="userOrEmail"
                 name="userOrEmail"
@@ -19828,6 +19829,7 @@ Array [
                 className="mt-3"
               >
                 <input
+                  autoFocus={true}
                   className="form-control form-control-lg font-weight-light mb-3 "
                   data-testid="username"
                   name="username"
@@ -19907,6 +19909,7 @@ exports[`Storyshots Pages/Login Login Basic 1`] = `
             className="mt-3"
           >
             <input
+              autoFocus={true}
               className="form-control form-control-lg font-weight-light mb-3 "
               data-testid="username"
               name="username"
@@ -19991,6 +19994,7 @@ exports[`Storyshots Pages/Login Login Error 1`] = `
             className="mt-3"
           >
             <input
+              autoFocus={true}
               className="form-control form-control-lg font-weight-light mb-3 "
               data-testid="username"
               name="username"
@@ -20161,6 +20165,7 @@ Array [
               className="form-group"
             >
               <input
+                autoFocus={true}
                 className="form-control form-control-lg font-weight-light mb-3 "
                 data-testid="password"
                 name="password"
@@ -20325,6 +20330,7 @@ Array [
               className="form-group "
             >
               <input
+                autoFocus={true}
                 className="form-control form-control-lg font-weight-light mb-3 "
                 data-testid="email"
                 name="email"
@@ -20424,6 +20430,7 @@ exports[`Storyshots Pages/Signup Signup Basic 1`] = `
           className="form-group "
         >
           <input
+            autoFocus={true}
             className="form-control form-control-lg font-weight-light mb-3 "
             data-testid="email"
             name="email"
@@ -20526,6 +20533,7 @@ exports[`Storyshots Pages/Signup Signup Errors 1`] = `
           className="form-group "
         >
           <input
+            autoFocus={true}
             className="form-control form-control-lg font-weight-light mb-3 "
             data-testid="email"
             name="email"
@@ -20628,6 +20636,7 @@ exports[`Storyshots Pages/Signup Signup Loading 1`] = `
           className="form-group "
         >
           <input
+            autoFocus={true}
             className="form-control form-control-lg font-weight-light mb-3 "
             data-testid="email"
             name="email"

--- a/pages/confirm/[token].tsx
+++ b/pages/confirm/[token].tsx
@@ -67,6 +67,7 @@ export const ResetPassword: React.FC = () => {
               data-testid="password"
               type="password"
               as={Input}
+              autoFocus
             />
 
             <Field

--- a/pages/forgotpassword.tsx
+++ b/pages/forgotpassword.tsx
@@ -61,6 +61,7 @@ export const ResetPassword: React.FC = () => {
               data-testid="userOrEmail"
               type="text"
               as={Input}
+              autoFocus
             />
 
             <button

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -53,6 +53,7 @@ export const Login: React.FC<LoginFormProps> = ({
                 placeholder="Username"
                 data-testid="username"
                 as={Input}
+                autoFocus
               />
 
               <Field

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -87,6 +87,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
               type="email"
               data-testid="email"
               as={Input}
+              autoFocus
             />
 
             <Field


### PR DESCRIPTION
for #968 

## Changes

Adds `autoFocus` prop to first input field of the forms on **login**, **sign up**, **forgot password** and **set new password** pages for quicker user input.
The effect will not always be apparent when running in dev mode because the browser will not autofocus elements added dynamically using JavaScript after page load, so this will not work every single time.
But in production mode `next.js` prerenders these pages so this will work as expected. Always correct behaviour can be observed by running `yarn build` and `yarn start` to look at the production build of the app.
Updates snapshots to reflect the change.

## Preview comparison:
- ### Login:
  - [With autofocus](https://c0d3-app-git-fork-jasirzaeem-autofocus-fields-c0d3.vercel.app/login)
  - [Without autofocus](https://www.c0d3.com/login)
- ### Signup:
  - [With autofocus](https://c0d3-app-git-fork-jasirzaeem-autofocus-fields-c0d3.vercel.app/signup)
  - [Without autofocus](https://www.c0d3.com/signup)
- ### Forgot Password:
  - [With autofocus](https://c0d3-app-git-fork-jasirzaeem-autofocus-fields-c0d3.vercel.app/forgotpassword)
  - [Without autofocus](https://www.c0d3.com/forgotpassword)
- ### Reset Password:
  - [With autofocus](https://c0d3-app-git-fork-jasirzaeem-autofocus-fields-c0d3.vercel.app/confirm/testtoken)
  - [Without autofocus](https://www.c0d3.com/confirm/testtoken)