### PR TITLE
Redirect broken route /book -> /docs/learn

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,15 @@ const withMDX = require('@next/mdx')({
   }
 })
 const moduleExports = withMDX({
+  async redirects() {
+    return [
+      {
+        source: '/book',
+        destination: '/docs/learn',
+        permanent: true
+      }
+    ]
+  },
   pageExtensions: ['tsx', 'js', 'jsx', 'mdx', 'ts']
 })
 


### PR DESCRIPTION
Broken link: https://c0d3.com/book  (meetup.com has a link and maybe a few other places)

Old link from the version 1 of c0d3? used to redirect users to: https://www.notion.so/garagescript/Table-of-Contents-a83980f81560429faca3821a9af8a5e2

Decided it was best to keep them at c0d3.com and this pr redirects them to https://c0d3.com/docs/learn
