### PR TITLE
Closes #993 Feature/static layouts

### DIFF
--- a/@types/page.d.ts
+++ b/@types/page.d.ts
@@ -1,0 +1,14 @@
+import { NextPage } from 'next'
+import { ReactElement, ReactNode } from 'react'
+
+export type LayoutGetter<LayoutProps = any> = (
+  page: ReactElement,
+  pageProps: LayoutProps
+) => ReactNode
+export interface WithLayout {
+  getLayout: LayoutGetter
+}
+
+export type NextPageWithLayout = NextPage<P> & {
+  getLayout?: LayoutGetter
+}

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -19688,179 +19688,76 @@ exports[`Storyshots Pages/Lesson With Alerts 1`] = `
 `;
 
 exports[`Storyshots Pages/Login Login 1`] = `
-Array [
-  <nav
-    className="navbar navbar-expand-lg navbar-light bg-white"
-  >
-    <div
-      className="container"
-    >
-      <a
-        className="navbar-brand"
-        href="/"
-      >
-        <div
-          className="navbar-brand text-primary font-weight-bold"
-        >
-          C0D3
-        </div>
-      </a>
-      <button
-        aria-controls="basic-navbar-nav"
-        aria-label="Toggle navigation"
-        className="navbar-toggler collapsed"
-        onClick={[Function]}
-        type="button"
-      >
-        <span
-          className="navbar-toggler-icon"
-        />
-      </button>
-      <div
-        aria-expanded={null}
-        className="text-center navbar-collapse collapse"
-        id="basic-navbar-nav"
-      >
-        <div
-          className="m-auto navbar-nav"
-          onKeyDown={[Function]}
-        >
-          <a
-            className="nav-item nav-link"
-            href="/curriculum"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Curriculum
-          </a>
-          <a
-            className="nav-item nav-link"
-            href="https://github.com/garageScript/c0d3-app"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Repo
-          </a>
-          <a
-            className="nav-item nav-link"
-            href="/docs/learn"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Learn
-          </a>
-          <a
-            className="nav-item nav-link"
-            href="https://discord.gg/c0d3"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Community
-          </a>
-        </div>
-        <div
-          className="nav-buttons"
-        >
-          <a
-            className="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/login"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Login
-          </a>
-          <a
-            className="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/signup"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Signup
-          </a>
-        </div>
-      </div>
-    </div>
-  </nav>,
+<div
+  className="row mt-5"
+>
   <div
-    className="container-md"
+    className="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
   >
     <div
-      className="row mt-5"
+      className="card-body text-center pt-5 pb-5"
     >
-      <div
-        className="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
+      <h1
+        className="card-title h2 font-weight-bold mb-5"
+      >
+        Login
+      </h1>
+      <p
+        className="card-text"
+      />
+      <form
+        action="#"
+        data-testid="form"
+        onReset={[Function]}
+        onSubmit={[Function]}
       >
         <div
-          className="card-body text-center pt-5 pb-5"
+          className="form-group"
         >
-          <h1
-            className="card-title h2 font-weight-bold mb-5"
+          <div
+            className="mt-3"
           >
-            Login
-          </h1>
-          <p
-            className="card-text"
-          />
-          <form
-            action="#"
-            data-testid="form"
-            onReset={[Function]}
-            onSubmit={[Function]}
-          >
-            <div
-              className="form-group"
+            <input
+              autoFocus={true}
+              className="form-control form-control-lg font-weight-light mb-3 "
+              data-testid="username"
+              name="username"
+              onBlur={[Function]}
+              onChange={[Function]}
+              placeholder="Username"
+              value=""
+            />
+            <input
+              className="form-control form-control-lg font-weight-light mb-3 "
+              data-testid="password"
+              name="password"
+              onBlur={[Function]}
+              onChange={[Function]}
+              placeholder="Password"
+              type="password"
+              value=""
+            />
+            <button
+              className="btn btn-primary btn-lg btn-block mb-3"
+              data-testid="submit"
+              type="submit"
             >
-              <div
-                className="mt-3"
-              >
-                <input
-                  autoFocus={true}
-                  className="form-control form-control-lg font-weight-light mb-3 "
-                  data-testid="username"
-                  name="username"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  placeholder="Username"
-                  value=""
-                />
-                <input
-                  className="form-control form-control-lg font-weight-light mb-3 "
-                  data-testid="password"
-                  name="password"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  placeholder="Password"
-                  type="password"
-                  value=""
-                />
-                <button
-                  className="btn btn-primary btn-lg btn-block mb-3"
-                  data-testid="submit"
-                  type="submit"
-                >
-                  Login to Your Account
-                </button>
-              </div>
-            </div>
-          </form>
-          <a
-            className=""
-            href="/forgotpassword"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Forgot your password?
-          </a>
+              Login to Your Account
+            </button>
+          </div>
         </div>
-      </div>
+      </form>
+      <a
+        className=""
+        href="/forgotpassword"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+      >
+        Forgot your password?
+      </a>
     </div>
-  </div>,
-  <footer
-    className="mt-5 font-weight-light text-center pb-5 text-muted"
-  >
-    © Copyright 2021 GarageScript
-  </footer>,
-]
+  </div>
+</div>
 `;
 
 exports[`Storyshots Pages/Login Login Basic 1`] = `
@@ -20192,199 +20089,96 @@ Array [
 `;
 
 exports[`Storyshots Pages/Signup Signup 1`] = `
-Array [
-  <nav
-    className="navbar navbar-expand-lg navbar-light bg-white"
-  >
-    <div
-      className="container"
-    >
-      <a
-        className="navbar-brand"
-        href="/"
-      >
-        <div
-          className="navbar-brand text-primary font-weight-bold"
-        >
-          C0D3
-        </div>
-      </a>
-      <button
-        aria-controls="basic-navbar-nav"
-        aria-label="Toggle navigation"
-        className="navbar-toggler collapsed"
-        onClick={[Function]}
-        type="button"
-      >
-        <span
-          className="navbar-toggler-icon"
-        />
-      </button>
-      <div
-        aria-expanded={null}
-        className="text-center navbar-collapse collapse"
-        id="basic-navbar-nav"
-      >
-        <div
-          className="m-auto navbar-nav"
-          onKeyDown={[Function]}
-        >
-          <a
-            className="nav-item nav-link"
-            href="/curriculum"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Curriculum
-          </a>
-          <a
-            className="nav-item nav-link"
-            href="https://github.com/garageScript/c0d3-app"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Repo
-          </a>
-          <a
-            className="nav-item nav-link"
-            href="/docs/learn"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Learn
-          </a>
-          <a
-            className="nav-item nav-link"
-            href="https://discord.gg/c0d3"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Community
-          </a>
-        </div>
-        <div
-          className="nav-buttons"
-        >
-          <a
-            className="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/login"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Login
-          </a>
-          <a
-            className="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/signup"
-            onClick={[Function]}
-            onMouseEnter={[Function]}
-          >
-            Signup
-          </a>
-        </div>
-      </div>
-    </div>
-  </nav>,
+<div
+  className="row mt-5"
+>
   <div
-    className="container-md"
+    className="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
   >
     <div
-      className="row mt-5"
+      className="card-body text-center pt-5 pb-5"
     >
-      <div
-        className="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
+      <h1
+        className="card-title h2 font-weight-bold mb-5"
+      >
+        Create Account
+      </h1>
+      <p
+        className="card-text"
+      />
+      <form
+        action="#"
+        data-testid="form"
+        onReset={[Function]}
+        onSubmit={[Function]}
       >
         <div
-          className="card-body text-center pt-5 pb-5"
+          className="form-group "
         >
-          <h1
-            className="card-title h2 font-weight-bold mb-5"
+          <input
+            autoFocus={true}
+            className="form-control form-control-lg font-weight-light mb-3 "
+            data-testid="email"
+            name="email"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="Email address"
+            type="email"
+            value=""
+          />
+          <input
+            className="form-control form-control-lg font-weight-light mb-3 "
+            data-testid="username"
+            name="username"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="Username"
+            value=""
+          />
+          <input
+            className="form-control form-control-lg font-weight-light mb-3 "
+            data-testid="firstName"
+            name="firstName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="First name"
+            value=""
+          />
+          <input
+            className="form-control form-control-lg font-weight-light mb-3 "
+            data-testid="lastName"
+            name="lastName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="Last name"
+            value=""
+          />
+          <button
+            className="btn btn-primary btn-lg btn-block mb-3"
+            data-testid="submit"
+            type="submit"
           >
             Create Account
-          </h1>
-          <p
-            className="card-text"
-          />
-          <form
-            action="#"
-            data-testid="form"
-            onReset={[Function]}
-            onSubmit={[Function]}
-          >
-            <div
-              className="form-group "
-            >
-              <input
-                autoFocus={true}
-                className="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="email"
-                name="email"
-                onBlur={[Function]}
-                onChange={[Function]}
-                placeholder="Email address"
-                type="email"
-                value=""
-              />
-              <input
-                className="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="username"
-                name="username"
-                onBlur={[Function]}
-                onChange={[Function]}
-                placeholder="Username"
-                value=""
-              />
-              <input
-                className="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="firstName"
-                name="firstName"
-                onBlur={[Function]}
-                onChange={[Function]}
-                placeholder="First name"
-                value=""
-              />
-              <input
-                className="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="lastName"
-                name="lastName"
-                onBlur={[Function]}
-                onChange={[Function]}
-                placeholder="Last name"
-                value=""
-              />
-              <button
-                className="btn btn-primary btn-lg btn-block mb-3"
-                data-testid="submit"
-                type="submit"
-              >
-                Create Account
-              </button>
-            </div>
-          </form>
-          <p
-            className="text-black-50"
-          >
-            Already have an account?
-             
-            <a
-              className="text-primary"
-              href="/login"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-            >
-              Login
-            </a>
-          </p>
+          </button>
         </div>
-      </div>
+      </form>
+      <p
+        className="text-black-50"
+      >
+        Already have an account?
+         
+        <a
+          className="text-primary"
+          href="/login"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          Login
+        </a>
+      </p>
     </div>
-  </div>,
-  <footer
-    className="mt-5 font-weight-light text-center pb-5 text-muted"
-  >
-    © Copyright 2021 GarageScript
-  </footer>,
-]
+  </div>
+</div>
 `;
 
 exports[`Storyshots Pages/Signup Signup Basic 1`] = `

--- a/__tests__/pages/__snapshots__/login.test.js.snap
+++ b/__tests__/pages/__snapshots__/login.test.js.snap
@@ -2,168 +2,78 @@
 
 exports[`Login Page Should set alert visible on invalid credentials 1`] = `
 <div>
-  <nav
-    class="navbar navbar-expand-lg navbar-light bg-white"
-  >
-    <div
-      class="container"
-    >
-      <a
-        class="navbar-brand"
-        href="/"
-      >
-        <div
-          class="navbar-brand text-primary font-weight-bold"
-        >
-          C0D3
-        </div>
-      </a>
-      <button
-        aria-controls="basic-navbar-nav"
-        aria-label="Toggle navigation"
-        class="navbar-toggler collapsed"
-        type="button"
-      >
-        <span
-          class="navbar-toggler-icon"
-        />
-      </button>
-      <div
-        class="text-center navbar-collapse collapse"
-        id="basic-navbar-nav"
-      >
-        <div
-          class="m-auto navbar-nav"
-        >
-          <a
-            class="nav-item nav-link"
-            href="/curriculum"
-          >
-            Curriculum
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="https://github.com/garageScript/c0d3-app"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Repo
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="/docs/learn"
-          >
-            Learn
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="https://discord.gg/c0d3"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Community
-          </a>
-        </div>
-        <div
-          class="nav-buttons"
-        >
-          <a
-            class="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/login"
-          >
-            Login
-          </a>
-          <a
-            class="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/signup"
-          >
-            Signup
-          </a>
-        </div>
-      </div>
-    </div>
-  </nav>
   <div
-    class="container-md"
+    class="row mt-5"
   >
     <div
-      class="row mt-5"
+      class="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
     >
       <div
-        class="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
+        class="card-body text-center pt-5 pb-5"
       >
-        <div
-          class="card-body text-center pt-5 pb-5"
+        <h1
+          class="card-title h2 font-weight-bold mb-5"
         >
-          <h1
-            class="card-title h2 font-weight-bold mb-5"
-          >
-            Login
-          </h1>
-          <p
-            class="card-text"
-          />
-          <form
-            action="#"
-            data-testid="form"
+          Login
+        </h1>
+        <p
+          class="card-text"
+        />
+        <form
+          action="#"
+          data-testid="form"
+        >
+          <div
+            class="form-group"
           >
             <div
-              class="form-group"
+              class="alert d-flex justify-content-between mt-3 alert-danger"
+              role="alert"
             >
-              <div
-                class="alert d-flex justify-content-between mt-3 alert-danger"
-                role="alert"
-              >
-                <div>
-                  <img
-                    class="mr-3 alert-icon"
-                    src="/assets/curriculum/icons/exclamation.svg"
-                  />
-                   User does not exist! 
-                </div>
-              </div>
-              <div
-                class="mt-3"
-              >
-                <input
-                  class="form-control form-control-lg font-weight-light mb-3 "
-                  data-testid="username"
-                  name="username"
-                  placeholder="Username"
-                  value="fake username"
+              <div>
+                <img
+                  class="mr-3 alert-icon"
+                  src="/assets/curriculum/icons/exclamation.svg"
                 />
-                <input
-                  class="form-control form-control-lg font-weight-light mb-3 "
-                  data-testid="password"
-                  name="password"
-                  placeholder="Password"
-                  type="password"
-                  value="fake password"
-                />
-                <button
-                  class="btn btn-primary btn-lg btn-block mb-3"
-                  data-testid="submit"
-                  type="submit"
-                >
-                  Login to Your Account
-                </button>
+                 User does not exist! 
               </div>
             </div>
-          </form>
-          <a
-            class=""
-            href="/forgotpassword"
-          >
-            Forgot your password?
-          </a>
-        </div>
+            <div
+              class="mt-3"
+            >
+              <input
+                class="form-control form-control-lg font-weight-light mb-3 "
+                data-testid="username"
+                name="username"
+                placeholder="Username"
+                value="fake username"
+              />
+              <input
+                class="form-control form-control-lg font-weight-light mb-3 "
+                data-testid="password"
+                name="password"
+                placeholder="Password"
+                type="password"
+                value="fake password"
+              />
+              <button
+                class="btn btn-primary btn-lg btn-block mb-3"
+                data-testid="submit"
+                type="submit"
+              >
+                Login to Your Account
+              </button>
+            </div>
+          </div>
+        </form>
+        <a
+          class=""
+          href="/forgotpassword"
+        >
+          Forgot your password?
+        </a>
       </div>
     </div>
   </div>
-  <footer
-    class="mt-5 font-weight-light text-center pb-5 text-muted"
-  >
-    © Copyright 2021 GarageScript
-  </footer>
 </div>
 `;

--- a/__tests__/pages/__snapshots__/signup.test.js.snap
+++ b/__tests__/pages/__snapshots__/signup.test.js.snap
@@ -2,310 +2,130 @@
 
 exports[`Signup Page Should render errors on fail 1`] = `
 <div>
-  <nav
-    class="navbar navbar-expand-lg navbar-light bg-white"
+  <div
+    class="row mt-5"
   >
     <div
-      class="container"
+      class="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
     >
-      <a
-        class="navbar-brand"
-        href="/"
-      >
-        <div
-          class="navbar-brand text-primary font-weight-bold"
-        >
-          C0D3
-        </div>
-      </a>
-      <button
-        aria-controls="basic-navbar-nav"
-        aria-label="Toggle navigation"
-        class="navbar-toggler collapsed"
-        type="button"
-      >
-        <span
-          class="navbar-toggler-icon"
-        />
-      </button>
       <div
-        class="text-center navbar-collapse collapse"
-        id="basic-navbar-nav"
+        class="card-body text-center pt-5 pb-5"
       >
-        <div
-          class="m-auto navbar-nav"
+        <h1
+          class="card-title h2 font-weight-bold mb-5"
         >
-          <a
-            class="nav-item nav-link"
-            href="/curriculum"
+          Create Account
+        </h1>
+        <p
+          class="card-text"
+        />
+        <div
+          class="bg-light m-auto px-5 border-0"
+          data-testid="error-message"
+        >
+          <h5
+            class="text-danger"
           >
-            Curriculum
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="https://github.com/garageScript/c0d3-app"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Repo
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="/docs/learn"
-          >
-            Learn
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="https://discord.gg/c0d3"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Community
-          </a>
+             Server cannot be reached. Please try again. If this problem persists, please send an email to support@c0d3.com
+          </h5>
         </div>
-        <div
-          class="nav-buttons"
+        <form
+          action="#"
+          data-testid="form"
         >
+          <div
+            class="form-group "
+          >
+            <input
+              class="form-control form-control-lg font-weight-light mb-3 "
+              data-testid="email"
+              name="email"
+              placeholder="Email address"
+              type="email"
+              value="fake@email.com"
+            />
+            <input
+              class="form-control form-control-lg font-weight-light mb-3 "
+              data-testid="username"
+              name="username"
+              placeholder="Username"
+              value="fakeusername"
+            />
+            <input
+              class="form-control form-control-lg font-weight-light mb-3 "
+              data-testid="firstName"
+              name="firstName"
+              placeholder="First name"
+              value="fakefirstname"
+            />
+            <input
+              class="form-control form-control-lg font-weight-light mb-3 "
+              data-testid="lastName"
+              name="lastName"
+              placeholder="Last name"
+              value="fakelastname"
+            />
+            <button
+              class="btn btn-primary btn-lg btn-block mb-3"
+              data-testid="submit"
+              type="submit"
+            >
+              Create Account
+            </button>
+          </div>
+        </form>
+        <p
+          class="text-black-50"
+        >
+          Already have an account?
+           
           <a
-            class="btn btn-secondary border m-2 mr-lg-3 bg-light"
+            class="text-primary"
             href="/login"
           >
             Login
           </a>
-          <a
-            class="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/signup"
-          >
-            Signup
-          </a>
-        </div>
-      </div>
-    </div>
-  </nav>
-  <div
-    class="container-md"
-  >
-    <div
-      class="row mt-5"
-    >
-      <div
-        class="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
-      >
-        <div
-          class="card-body text-center pt-5 pb-5"
-        >
-          <h1
-            class="card-title h2 font-weight-bold mb-5"
-          >
-            Create Account
-          </h1>
-          <p
-            class="card-text"
-          />
-          <div
-            class="bg-light m-auto px-5 border-0"
-            data-testid="error-message"
-          >
-            <h5
-              class="text-danger"
-            >
-               Server cannot be reached. Please try again. If this problem persists, please send an email to support@c0d3.com
-            </h5>
-          </div>
-          <form
-            action="#"
-            data-testid="form"
-          >
-            <div
-              class="form-group "
-            >
-              <input
-                class="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="email"
-                name="email"
-                placeholder="Email address"
-                type="email"
-                value="fake@email.com"
-              />
-              <input
-                class="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="username"
-                name="username"
-                placeholder="Username"
-                value="fakeusername"
-              />
-              <input
-                class="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="firstName"
-                name="firstName"
-                placeholder="First name"
-                value="fakefirstname"
-              />
-              <input
-                class="form-control form-control-lg font-weight-light mb-3 "
-                data-testid="lastName"
-                name="lastName"
-                placeholder="Last name"
-                value="fakelastname"
-              />
-              <button
-                class="btn btn-primary btn-lg btn-block mb-3"
-                data-testid="submit"
-                type="submit"
-              >
-                Create Account
-              </button>
-            </div>
-          </form>
-          <p
-            class="text-black-50"
-          >
-            Already have an account?
-             
-            <a
-              class="text-primary"
-              href="/login"
-            >
-              Login
-            </a>
-          </p>
-        </div>
+        </p>
       </div>
     </div>
   </div>
-  <footer
-    class="mt-5 font-weight-light text-center pb-5 text-muted"
-  >
-    © Copyright 2021 GarageScript
-  </footer>
 </div>
 `;
 
 exports[`Signup Page Should render success component on success 1`] = `
 <div>
-  <nav
-    class="navbar navbar-expand-lg navbar-light bg-white"
-  >
-    <div
-      class="container"
-    >
-      <a
-        class="navbar-brand"
-        href="/"
-      >
-        <div
-          class="navbar-brand text-primary font-weight-bold"
-        >
-          C0D3
-        </div>
-      </a>
-      <button
-        aria-controls="basic-navbar-nav"
-        aria-label="Toggle navigation"
-        class="navbar-toggler collapsed"
-        type="button"
-      >
-        <span
-          class="navbar-toggler-icon"
-        />
-      </button>
-      <div
-        class="text-center navbar-collapse collapse"
-        id="basic-navbar-nav"
-      >
-        <div
-          class="m-auto navbar-nav"
-        >
-          <a
-            class="nav-item nav-link"
-            href="/curriculum"
-          >
-            Curriculum
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="https://github.com/garageScript/c0d3-app"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Repo
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="/docs/learn"
-          >
-            Learn
-          </a>
-          <a
-            class="nav-item nav-link"
-            href="https://discord.gg/c0d3"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Community
-          </a>
-        </div>
-        <div
-          class="nav-buttons"
-        >
-          <a
-            class="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/login"
-          >
-            Login
-          </a>
-          <a
-            class="btn btn-secondary border m-2 mr-lg-3 bg-light"
-            href="/signup"
-          >
-            Signup
-          </a>
-        </div>
-      </div>
-    </div>
-  </nav>
   <div
-    class="container-md"
+    class="row mt-5"
   >
     <div
-      class="row mt-5"
+      class="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
     >
       <div
-        class="card shadow-sm col-sm-8 col-md-7 col-lg-6 col-xl-6 m-auto px-md-5 border-0"
+        class="card-body text-center pt-5 pb-5"
       >
-        <div
-          class="card-body text-center pt-5 pb-5"
+        <img
+          alt="Green circle with a checkmark inside."
+          class="mb-4"
+          height="100px"
+          src="/assets/curriculum/icons/checked.svg"
+          width="100px"
+        />
+        <h1
+          class="card-title h2 font-weight-bold mb-5"
         >
-          <img
-            alt="Green circle with a checkmark inside."
-            class="mb-4"
-            height="100px"
-            src="/assets/curriculum/icons/checked.svg"
-            width="100px"
-          />
-          <h1
-            class="card-title h2 font-weight-bold mb-5"
-          >
-            Account created successfully!
-          </h1>
-          <p
-            class="card-text"
-          />
-          <a
-            class="btn btn-primary"
-            href="/confirm/undefined"
-          >
-            Click here to set your password.
-          </a>
-        </div>
+          Account created successfully!
+        </h1>
+        <p
+          class="card-text"
+        />
+        <a
+          class="btn btn-primary"
+          href="/confirm/undefined"
+        >
+          Click here to set your password.
+        </a>
       </div>
     </div>
   </div>
-  <footer
-    class="mt-5 font-weight-light text-center pb-5 text-muted"
-  >
-    © Copyright 2021 GarageScript
-  </footer>
 </div>
 `;

--- a/__tests__/pages/_app.test.js
+++ b/__tests__/pages/_app.test.js
@@ -14,6 +14,7 @@ import dummyLessonData from '../../__dummy__/lessonData'
 import dummySessionData from '../../__dummy__/sessionData'
 import dummyAlertData from '../../__dummy__/alertData'
 import posthog from 'posthog-js'
+import { getLayout } from '../../components/Layout'
 
 jest.mock('posthog-js')
 jest.spyOn(Sentry, 'captureException')
@@ -41,7 +42,22 @@ describe('MyApp component', () => {
   afterEach(() => {
     process.env = OLD_ENV
   })
-
+  test('should call layout getter if present', async () => {
+    const getLayout = jest.fn(page => <>{page}</>)
+    const ComponentWithLayout = () => <></>
+    ComponentWithLayout.getLayout = getLayout
+    render(<MyApp Component={ComponentWithLayout} pageProps={{}} />)
+    expect(getLayout).toHaveBeenCalled()
+  })
+  test('should render components without layout getter', async () => {
+    const SimpleComponent = () => <h1>No Layout Here</h1>
+    render(<MyApp Component={SimpleComponent} pageProps={{}} />)
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: 'No Layout Here' })
+      ).toBeTruthy()
+    )
+  })
   test('posthog init function should not be called if not in production environment', async () => {
     render(
       <MockedProvider mocks={mocks} addTypename={false}>

--- a/__tests__/pages/login.test.js
+++ b/__tests__/pages/login.test.js
@@ -7,6 +7,7 @@ import GET_APP from '../../graphql/queries/getApp'
 import LOGIN_USER from '../../graphql/queries/loginUser'
 import LoginPage from '../../pages/login'
 import { useRouter } from 'next/router'
+import { getLayout } from '../../components/Layout'
 
 describe('Login Page', () => {
   const fakeUsername = 'fake username'
@@ -24,6 +25,10 @@ describe('Login Page', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
+  test('Should use Layout component getLayout ', async () => {
+    expect(LoginPage.getLayout === getLayout).toBe(true)
+  })
+
   test('Should redirect to /curriculum on success', async () => {
     const mocks = [
       {

--- a/__tests__/pages/signup.test.js
+++ b/__tests__/pages/signup.test.js
@@ -5,6 +5,7 @@ import GET_APP from '../../graphql/queries/getApp'
 import SIGNUP_USER from '../../graphql/queries/signupUser'
 import SignupPage from '../../pages/signup'
 import userEvent from '@testing-library/user-event'
+import { getLayout } from '../../components/Layout'
 
 describe('Signup Page', () => {
   const fakeEmail = 'fake@email.com'
@@ -25,6 +26,9 @@ describe('Signup Page', () => {
     await userEvent.type(lastNameField, fakeLastName, { delay: 1 })
   }
 
+  test('Should use Layout component getLayout ', async () => {
+    expect(SignupPage.getLayout === getLayout).toBe(true)
+  })
   test('Should render success component on success', async () => {
     const mocks = [
       {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import AppNav from './AppNav'
 import Footer from './Footer'
 import Head from 'next/head'
+import type { LayoutGetter } from '../@types/page'
 const Layout: React.FC<{ title?: string }> = ({ children, title }) => (
   <>
     <Head>
@@ -13,4 +14,5 @@ const Layout: React.FC<{ title?: string }> = ({ children, title }) => (
   </>
 )
 
+export const getLayout: LayoutGetter = page => <Layout>{page}</Layout>
 export default Layout

--- a/components/Title.test.js
+++ b/components/Title.test.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import Title from './Title'
+
+jest.mock('next/head', () => {
+  return ({ children }) => children
+})
+
+describe('Title Component', () => {
+  test('should render title', async () => {
+    const { container } = render(<Title title="test" />, {
+      container: document.head
+    })
+    expect(document.title).toEqual('test — C0D3')
+  })
+  test('should render default title', async () => {
+    const { container } = render(<Title />, {
+      container: document.head
+    })
+    expect(document.title).toEqual('C0D3')
+  })
+})

--- a/components/Title.tsx
+++ b/components/Title.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import Head from 'next/head'
+
+const Title: React.FC<{ title?: string }> = ({ title }) => (
+  <Head>
+    <title>{title ? `${title} — C0D3` : 'C0D3'}</title>
+  </Head>
+)
+
+export default Title

--- a/components/Title.tsx
+++ b/components/Title.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head'
 
 const Title: React.FC<{ title?: string }> = ({ title }) => (
   <Head>
-    <title>{title ? `${title} — C0D3` : 'C0D3'}</title>
+    <title>{title && `${title} — `}C0D3</title>
   </Head>
 )
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,12 +14,15 @@ import '../scss/index.scss'
 import MDXcomponents from '../helpers/mdxComponents'
 import { useApollo } from '../helpers/apolloClient'
 import { ContextProvider } from '../helpers/globalContext'
+import type { NextPageWithLayout } from '../@types/page'
 interface IProps extends AppProps {
   err: any
   apollo: ApolloClient<NormalizedCacheObject>
+  Component: NextPageWithLayout
 }
 
 function MyApp({ Component, pageProps, err }: IProps) {
+  const getLayout = Component.getLayout || (page => page)
   const apolloClient = useApollo(pageProps)
   useEffect(() => {
     if (process.env.NODE_ENV === 'production' && process.env.POSTHOG_API_KEY) {
@@ -76,7 +79,7 @@ function MyApp({ Component, pageProps, err }: IProps) {
             {/* <!-- Safari Web Content --> */}
             <meta name="apple-mobile-web-app-title" content="C0d3" />
           </Head>
-          <Component {...pageProps} err={err} />
+          {getLayout(<Component {...pageProps} err={err} />, pageProps)}
         </ContextProvider>
       </MDXProvider>
     </ApolloProvider>

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react'
 import { Formik, Form, Field } from 'formik'
 import Input from '../components/Input'
 import { loginValidation } from '../helpers/formValidation'
-import Layout from '../components/Layout'
+import { getLayout } from '../components/Layout'
 import Card from '../components/Card'
 import NavLink from '../components/NavLink'
 import Alert from '../components/Alert'
@@ -12,6 +12,8 @@ import { Values, LoginFormProps, ErrorDisplayProps } from '../@types/login'
 import _ from 'lodash'
 import { useRouter } from 'next/router'
 import GET_APP from '../graphql/queries/getApp'
+import { WithLayout } from '../@types/page'
+import Title from '../components/Title'
 
 const initialValues = {
   username: '',
@@ -80,7 +82,7 @@ export const Login: React.FC<LoginFormProps> = ({
   )
 }
 
-const LoginPage: React.FC = () => {
+const LoginPage: React.FC & WithLayout = () => {
   const router = useRouter()
   const [loginErrors, setLoginErrors] = useState<string[]>([])
   const [loginUser, { data, error }] = useMutation(LOGIN_USER, {
@@ -112,10 +114,12 @@ const LoginPage: React.FC = () => {
     } catch {} // catch error that's thrown by default from mutation
   }
   return (
-    <Layout title="Login">
+    <>
+      <Title title="Login" />
       <Login handleSubmit={handleSubmit} loginErrors={loginErrors} />
-    </Layout>
+    </>
   )
 }
 
+LoginPage.getLayout = getLayout
 export default LoginPage

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -6,7 +6,7 @@ import _ from 'lodash'
 
 //import components
 import Card from '../components/Card'
-import Layout from '../components/Layout'
+import { getLayout } from '../components/Layout'
 import Input from '../components/Input'
 import NavLink from '../components/NavLink'
 
@@ -21,6 +21,8 @@ import {
   ErrorDisplayProps,
   SignupSuccessProps
 } from '../@types/signup'
+import { WithLayout } from '../@types/page'
+import Title from '../components/Title'
 
 const initialValues: Values = {
   email: '',
@@ -131,7 +133,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
   )
 }
 
-const SignUpPage: React.FC = () => {
+const SignUpPage: React.FC & WithLayout = () => {
   const [signupSuccess, setSignupSuccess] = useState(false)
   const [forgotToken, setForgotToken] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -162,7 +164,8 @@ const SignUpPage: React.FC = () => {
     setIsSubmitting(false)
   }
   return (
-    <Layout title="Sign up">
+    <>
+      <Title title="Sign up" />
       <Signup
         handleSubmit={handleSubmit}
         isLoading={isSubmitting}
@@ -170,7 +173,7 @@ const SignUpPage: React.FC = () => {
         forgotToken={forgotToken}
         signupErrors={signupErrors}
       />
-    </Layout>
+    </>
   )
 }
 
@@ -196,4 +199,5 @@ export const Signup: React.FC<SignupFormProps> = ({
   )
 }
 
+SignUpPage.getLayout = getLayout
 export default SignUpPage


### PR DESCRIPTION
This pr includes the minimal changes to enable [static layouts with nextjs](https://nextjs.org/docs/basic-features/layouts#per-page-layouts)

I only added the static layout support to `Login` & `Signup` pages to show the pattern can be used as an optin basic and all the other pages still work without any changes

- Add `getLayout` support to `_app.tsx`
- Add LayoutGetter function to Layout component
- Create a simple Title component for setting page titles. (This is a simpler solution than having to pass the title prop to the Layout component through the `getLayout` function)
- Implemented static layout on 2 pages: `Login` & `Signup`
  - Add test to check getLayout is set on pages
  - Updated snapshots without layout <br> \* Layouts can be added back to the snapshots but I believe the snapshots are cleaner without

Only thing I'm uncertain about is if I included my Typescript types in the best location `@types/pages.d.ts`? and I'm open to suggestions on changing them. Next does not have documentation on typescript implementation of the pattern and I ended up following this SO post as an example https://stackoverflow.com/a/65898224