### PR TITLE
Redirect on login Closes #1031

### DIFF
--- a/__tests__/pages/login.test.js
+++ b/__tests__/pages/login.test.js
@@ -8,6 +8,7 @@ import LOGIN_USER from '../../graphql/queries/loginUser'
 import LoginPage from '../../pages/login'
 import { useRouter } from 'next/router'
 import { getLayout } from '../../components/Layout'
+import { cloneDeep } from 'lodash'
 
 describe('Login Page', () => {
   const fakeUsername = 'fake username'
@@ -21,7 +22,7 @@ describe('Login Page', () => {
     await userEvent.type(usernameField, fakeUsername, { delay: 1 })
     await userEvent.type(passwordField, fakePassword, { delay: 1 })
   }
-  const { push } = useRouter()
+  const { push, query } = useRouter()
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -29,51 +30,54 @@ describe('Login Page', () => {
     expect(LoginPage.getLayout === getLayout).toBe(true)
   })
 
-  test('Should redirect to /curriculum on success', async () => {
-    const mocks = [
-      {
-        request: { query: GET_APP },
-        result: {
-          data: {
-            session: null,
-            lessons: [],
-            alerts: []
-          }
+  const successfulLoginMocks = [
+    {
+      request: { query: GET_APP },
+      result: {
+        data: {
+          session: null,
+          lessons: [],
+          alerts: []
+        }
+      }
+    },
+    {
+      request: { query: GET_APP },
+      result: {
+        data: {
+          session: null,
+          lessons: [],
+          alerts: []
+        }
+      }
+    },
+    {
+      request: {
+        query: LOGIN_USER,
+        variables: {
+          username: fakeUsername,
+          password: fakePassword
         }
       },
-      {
-        request: { query: GET_APP },
-        result: {
-          data: {
-            session: null,
-            lessons: [],
-            alerts: []
-          }
-        }
-      },
-      {
-        request: {
-          query: LOGIN_USER,
-          variables: {
+      result: {
+        data: {
+          login: {
+            success: true,
             username: fakeUsername,
-            password: fakePassword
-          }
-        },
-        result: {
-          data: {
-            login: {
-              success: true,
-              username: fakeUsername,
-              cliToken: 'fake token',
-              error: null
-            }
+            cliToken: 'fake token',
+            error: null
           }
         }
       }
-    ]
+    }
+  ]
 
+  test('Should redirect to /curriculum on success', async () => {
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider
+        mocks={cloneDeep(successfulLoginMocks)}
+        addTypename={false}
+      >
         <LoginPage />
       </MockedProvider>
     )
@@ -84,6 +88,26 @@ describe('Login Page', () => {
     fireEvent.click(submitButton)
 
     await waitFor(() => expect(push).toBeCalledWith('/curriculum'))
+  })
+
+  test('Should redirect to the path in `next` on success', async () => {
+    query.next = 'url-to-go-to-post-login'
+
+    const { getByTestId } = render(
+      <MockedProvider
+        mocks={cloneDeep(successfulLoginMocks)}
+        addTypename={false}
+      >
+        <LoginPage />
+      </MockedProvider>
+    )
+
+    const submitButton = getByTestId('submit')
+
+    await fillOutLoginForm(getByTestId)
+    fireEvent.click(submitButton)
+
+    await waitFor(() => expect(push).toBeCalledWith(query.next))
   })
 
   test('Should set alert visible on invalid credentials', async () => {

--- a/__tests__/pages/review/[lesson].test.js
+++ b/__tests__/pages/review/[lesson].test.js
@@ -69,7 +69,6 @@ const getSubmissionsMock = {
     }
   }
 }
-
 const getPreviousSubmissionsMock = {
   request: {
     query: GET_PREVIOUS_SUBMISSIONS,
@@ -79,9 +78,10 @@ const getPreviousSubmissionsMock = {
     data: getPreviousSubmissions
   }
 }
+
 const mocks = [getAppMock, getSubmissionsMock, getPreviousSubmissionsMock]
 describe('Lesson Page', () => {
-  const { query, push } = useRouter()
+  const { query, push, asPath } = useRouter()
   query['lesson'] = '2'
   test('Should render new submissions', async () => {
     const { container } = render(
@@ -100,7 +100,7 @@ describe('Lesson Page', () => {
   test('Should return loading spinner when loading', () => {
     expectLoading(<Review />)
   })
-  test('Should redirect to login if no session', async () => {
+  test('Should redirect to login if no user is logged in', async () => {
     const noSessionMock = {
       request: { query: GET_APP },
       result: {
@@ -120,7 +120,12 @@ describe('Lesson Page', () => {
       </MockedProvider>
     )
 
-    await waitFor(() => expect(push).toBeCalledWith('/login'))
+    await waitFor(() =>
+      expect(push).toBeCalledWith({
+        pathname: '/login',
+        query: { next: asPath }
+      })
+    )
   })
   test("Should redirect to curriculum if user hasn't completed lesson yet", async () => {
     const noSessionMock = {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -95,7 +95,8 @@ const LoginPage: React.FC & WithLayout = () => {
     const { success } = _.get(data, 'login', false)
     if (success) {
       window.localStorage.setItem('loggedIn', 'true')
-      router.push('/curriculum')
+      const { next } = router.query
+      router.push(next ? (next as string) : '/curriculum')
     }
     if (error) {
       const graphQLErrors: any = _.get(error, 'graphQLErrors', [])

--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -44,8 +44,11 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
   if (loading) {
     return <LoadingSpinner />
   }
-  if (!session) {
-    router.push('/login')
+  if (!session?.user) {
+    router.push({
+      pathname: '/login',
+      query: { next: router.asPath }
+    })
     return <LoadingSpinner />
   }
   const currentLesson = lessons.find(lesson => lesson.id === currentlessonId)


### PR DESCRIPTION
Closes #1031 

# Changes

## Add `next` query param to `/login` page

Links to login page can now be of the form `/login?next=further-path` if the `next` param is present in the query, the user will be redirected to `/further-path` on successful login.

## Fix redirection from `/review/[lesson]`

Logged out users who visit a review page will be redirected to the login page with the correct `next` parameter so that they are redirected back to this page on successful login.