### PR TITLE
Highlight submission selection buttons

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -13620,7 +13620,7 @@ exports[`Storyshots Components/SelectIteration Active 1`] = `
       onClick={[Function]}
     >
       <button
-        className="button m-2 btn btn-success"
+        className="button  m-2 btn btn-outline-danger"
         disabled={false}
         type="button"
       >
@@ -13638,7 +13638,7 @@ exports[`Storyshots Components/SelectIteration Active 1`] = `
       onClick={[Function]}
     >
       <button
-        className="button m-2 btn btn-info"
+        className="button active m-2 btn active btn-outline-warning"
         disabled={false}
         type="button"
       >
@@ -13656,7 +13656,7 @@ exports[`Storyshots Components/SelectIteration Active 1`] = `
       onClick={[Function]}
     >
       <button
-        className="button m-2 btn btn-success"
+        className="button  m-2 btn btn-outline-warning"
         disabled={false}
         type="button"
       >

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -651,7 +651,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         data-testid="iteration 0"
                       >
                         <button
-                          class="button m-2 btn btn-success"
+                          class="button  m-2 btn btn-outline-danger"
                           type="button"
                         >
                           1
@@ -667,7 +667,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         data-testid="iteration 1"
                       >
                         <button
-                          class="button m-2 btn btn-success"
+                          class="button  m-2 btn btn-outline-warning"
                           type="button"
                         >
                           2
@@ -683,7 +683,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         data-testid="iteration 2"
                       >
                         <button
-                          class="button m-2 btn btn-info"
+                          class="button active m-2 btn active btn-outline-warning"
                           type="button"
                         >
                           3

--- a/components/ChallengeMaterial.test.js
+++ b/components/ChallengeMaterial.test.js
@@ -224,11 +224,11 @@ describe('Curriculum challenge page', () => {
     await screen.findByText('Select submission')
     expect(
       await screen.findByRole('button', { name: '3 2 comment count' })
-    ).toHaveClass('btn-info')
+    ).toHaveClass('active')
     userEvent.click(screen.getByTestId('iteration 1'))
     expect(
       await screen.findByRole('button', { name: '3 2 comment count' })
-    ).not.toHaveClass('btn-info')
+    ).not.toHaveClass('active')
     expect(container).toMatchSnapshot()
   })
   test('Should be able to select another challenge', async () => {

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -95,7 +95,7 @@ exports[`Curriculum challenge page Should be able to select another challenge 1`
                 data-testid="iteration 0"
               >
                 <button
-                  class="button m-2 btn btn-success"
+                  class="button  m-2 btn btn-outline-danger"
                   type="button"
                 >
                   1
@@ -111,7 +111,7 @@ exports[`Curriculum challenge page Should be able to select another challenge 1`
                 data-testid="iteration 1"
               >
                 <button
-                  class="button m-2 btn btn-success"
+                  class="button  m-2 btn btn-outline-warning"
                   type="button"
                 >
                   2
@@ -127,7 +127,7 @@ exports[`Curriculum challenge page Should be able to select another challenge 1`
                 data-testid="iteration 2"
               >
                 <button
-                  class="button m-2 btn btn-info"
+                  class="button active m-2 btn active btn-outline-warning"
                   type="button"
                 >
                   3
@@ -7463,7 +7463,7 @@ exports[`Curriculum challenge page Should select previous iterations 1`] = `
                 data-testid="iteration 0"
               >
                 <button
-                  class="button m-2 btn btn-success"
+                  class="button  m-2 btn btn-outline-danger"
                   type="button"
                 >
                   1
@@ -7479,7 +7479,7 @@ exports[`Curriculum challenge page Should select previous iterations 1`] = `
                 data-testid="iteration 1"
               >
                 <button
-                  class="button m-2 btn btn-info"
+                  class="button active m-2 btn active btn-outline-warning"
                   type="button"
                 >
                   2
@@ -7495,7 +7495,7 @@ exports[`Curriculum challenge page Should select previous iterations 1`] = `
                 data-testid="iteration 2"
               >
                 <button
-                  class="button m-2 btn btn-success"
+                  class="button  m-2 btn btn-outline-warning"
                   type="button"
                 >
                   3

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -581,7 +581,7 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 data-testid="iteration 0"
               >
                 <button
-                  class="button m-2 btn btn-info"
+                  class="button active m-2 btn active btn-outline-danger"
                   type="button"
                 >
                   1
@@ -597,7 +597,7 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 data-testid="iteration 1"
               >
                 <button
-                  class="button m-2 btn btn-success"
+                  class="button  m-2 btn btn-outline-warning"
                   type="button"
                 >
                   2
@@ -613,7 +613,7 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 data-testid="iteration 2"
               >
                 <button
-                  class="button m-2 btn btn-success"
+                  class="button  m-2 btn btn-outline-warning"
                   type="button"
                 >
                   3

--- a/components/__snapshots__/SelectIteration.test.js.snap
+++ b/components/__snapshots__/SelectIteration.test.js.snap
@@ -54,7 +54,7 @@ exports[`SelectIteration component Should be able to select submissions 1`] = `
         data-testid="iteration 0"
       >
         <button
-          class="button m-2 btn btn-success"
+          class="button  m-2 btn btn-outline-danger"
           type="button"
         >
           1
@@ -70,7 +70,7 @@ exports[`SelectIteration component Should be able to select submissions 1`] = `
         data-testid="iteration 1"
       >
         <button
-          class="button m-2 btn btn-info"
+          class="button active m-2 btn active btn-outline-warning"
           type="button"
         >
           2
@@ -86,7 +86,7 @@ exports[`SelectIteration component Should be able to select submissions 1`] = `
         data-testid="iteration 2"
       >
         <button
-          class="button m-2 btn btn-success"
+          class="button  m-2 btn btn-outline-warning"
           type="button"
         >
           3
@@ -123,7 +123,7 @@ exports[`SelectIteration component Should treat negative index as last iteration
         data-testid="iteration 0"
       >
         <button
-          class="button m-2 btn btn-success"
+          class="button  m-2 btn btn-outline-danger"
           type="button"
         >
           1
@@ -139,7 +139,7 @@ exports[`SelectIteration component Should treat negative index as last iteration
         data-testid="iteration 1"
       >
         <button
-          class="button m-2 btn btn-info"
+          class="button active m-2 btn active btn-outline-warning"
           type="button"
         >
           2
@@ -155,7 +155,7 @@ exports[`SelectIteration component Should treat negative index as last iteration
         data-testid="iteration 2"
       >
         <button
-          class="button m-2 btn btn-success"
+          class="button  m-2 btn btn-outline-warning"
           type="button"
         >
           3

--- a/scss/selectIteration.module.scss
+++ b/scss/selectIteration.module.scss
@@ -9,6 +9,12 @@
   min-width: 2.5rem;
   min-height: 2.5rem;
   max-width: max-content;
+
+  &.active, &:hover {
+    // Warning variant button has non-white color
+    color: white !important;
+  }
+
   & .badge {
     color: rgb(122, 126, 120);
     position: absolute;
@@ -17,6 +23,7 @@
     border: 1px solid gainsboro;
     border-radius: 50%;
   }
+
   &.loading {
     min-height: 3rem;
   }


### PR DESCRIPTION
Closes #937 

Currently the buttons to select a specific iteration of a submission are the same color, except the one currently selected.
e.g.
![image](https://user-images.githubusercontent.com/20666236/129456547-27eabc4a-8f88-4afe-96b1-4bb0eab64baa.png)

In this PR, 
- the appearance of the buttons have been changed to be outlined.
- The buttons are coloured according to the status of their respective submission.
- The selected button has the active class and is filled.

![image](https://user-images.githubusercontent.com/20666236/129456623-14b822f9-6bc9-40a7-846b-3f8c1712255f.png)
![image](https://user-images.githubusercontent.com/20666236/129456624-e059c107-692e-417a-91b0-8bff44e51c6c.png)
![image](https://user-images.githubusercontent.com/20666236/129456637-09ffd53d-ec70-436e-9b76-6817cc43cbb5.png)



