### PR TITLE
[Migration] Add 'slug' field to Lesson

### DIFF
--- a/__dummy__/lessonData.ts
+++ b/__dummy__/lessonData.ts
@@ -11,6 +11,7 @@ const dummyLessonsData: Lesson[] = [
     videoUrl:
       'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
     order: 0,
+    slug: 'js0',
     challenges: [
       {
         id: 107,
@@ -106,6 +107,7 @@ const dummyLessonsData: Lesson[] = [
     videoUrl:
       'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
     order: 1,
+    slug: 'js1',
     challenges: [
       {
         id: 146,
@@ -218,6 +220,7 @@ const dummyLessonsData: Lesson[] = [
     videoUrl:
       'https://www.youtube.com/watch?v=rem796-hPY8&index=3&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7',
     order: 2,
+    slug: 'js2',
     challenges: [
       {
         id: 84,
@@ -322,6 +325,7 @@ const dummyLessonsData: Lesson[] = [
     videoUrl:
       'https://www.youtube.com/watch?v=Npn275pNXYw&index=4&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7',
     order: 3,
+    slug: 'js3',
     challenges: [
       {
         id: 91,
@@ -416,6 +420,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 4,
+    slug: 'js4',
     challenges: [
       {
         id: 177,
@@ -486,6 +491,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 5,
+    slug: 'js5',
     challenges: [
       {
         id: 73,
@@ -570,6 +576,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 6,
+    slug: 'js6',
     challenges: [
       {
         id: 192,
@@ -648,6 +655,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 7,
+    slug: 'js7',
     challenges: [
       {
         id: 180,
@@ -748,6 +756,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 8,
+    slug: 'js8',
     challenges: [
       {
         id: 160,
@@ -858,6 +867,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 9,
+    slug: 'js9',
     challenges: [
       {
         id: 167,

--- a/__dummy__/starsData.ts
+++ b/__dummy__/starsData.ts
@@ -13,6 +13,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Foundations of JavaScript',
       order: 0,
+      slug: 'js0',
       id: 5,
       description: 'A super simple introduction to help you get started!',
       challenges: []
@@ -32,6 +33,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Variables & Functions',
       order: 1,
+      slug: 'js1',
       id: 2,
       description:
         'Learn how to solve simple algorithm problems recursively with the following exercises. ',
@@ -52,6 +54,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Arrays',
       order: 2,
+      slug: 'js2',
       id: 1,
       description:
         'These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.',
@@ -72,6 +75,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Objects',
       order: 3,
+      slug: 'js3',
       id: 4,
       description:
         'These exercises will test your understanding of objects, which includes linked lists and trees',
@@ -92,6 +96,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Front End Engineering',
       order: 4,
+      slug: 'js4',
       id: 24,
       description:
         'Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)',
@@ -112,6 +117,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'End To End',
       order: 5,
+      slug: 'js5',
       id: 3,
       description:
         'These exercises will help you build a strong understanding of how the web works.',
@@ -132,6 +138,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'React, GraphQL, SocketIO',
       order: 6,
+      slug: 'js6',
       id: 29,
       description: 'React and GraphQL Lessons',
       challenges: []
@@ -151,6 +158,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Foundations of JavaScript',
       order: 0,
+      slug: 'js0',
       id: 5,
       description: 'A super simple introduction to help you get started!',
       challenges: []
@@ -171,6 +179,8 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Variables & Functions',
       order: 1,
+      slug: 'js1',
+
       id: 2,
       description:
         'Learn how to solve simple algorithm problems recursively with the following exercises. ',
@@ -191,6 +201,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Arrays',
       order: 2,
+      slug: 'js2',
       id: 1,
       description:
         'These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.',
@@ -211,6 +222,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Objects',
       order: 3,
+      slug: 'js3',
       id: 4,
       description:
         'These exercises will test your understanding of objects, which includes linked lists and trees',
@@ -231,6 +243,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Front End Engineering',
       order: 4,
+      slug: 'js4',
       id: 24,
       description:
         'Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)',
@@ -251,6 +264,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'End To End',
       order: 5,
+      slug: 'js5',
       id: 3,
       description:
         'These exercises will help you build a strong understanding of how the web works.',
@@ -271,6 +285,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'React, GraphQL, SocketIO',
       order: 6,
+      slug: 'js6',
       id: 29,
       description: 'React and GraphQL Lessons',
       challenges: []

--- a/__tests__/pages/admin/__snapshots__/lessons.test.js.snap
+++ b/__tests__/pages/admin/__snapshots__/lessons.test.js.snap
@@ -393,13 +393,29 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 1`] 
                   class="d-flex flex-column ml-3 mr-3 mb-4"
                 >
                   <h5
-                    data-testid="h5chatUrl7"
+                    data-testid="h5slug7"
+                  >
+                    Slug
+                  </h5>
+                  <input
+                    class="form-control"
+                    data-testid="input7"
+                    placeholder=""
+                    type="text"
+                    value="js0"
+                  />
+                </div>
+                <div
+                  class="d-flex flex-column ml-3 mr-3 mb-4"
+                >
+                  <h5
+                    data-testid="h5chatUrl8"
                   >
                     Chaturl
                   </h5>
                   <input
                     class="form-control"
-                    data-testid="input7"
+                    data-testid="input8"
                     placeholder=""
                     type="text"
                     value="https://chat.c0d3.com/c0d3/channels/js1-variablesfunction"
@@ -1991,13 +2007,29 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 2`] 
                   class="d-flex flex-column ml-3 mr-3 mb-4"
                 >
                   <h5
-                    data-testid="h5chatUrl7"
+                    data-testid="h5slug7"
+                  >
+                    Slug
+                  </h5>
+                  <input
+                    class="form-control"
+                    data-testid="input7"
+                    placeholder=""
+                    type="text"
+                    value="js3"
+                  />
+                </div>
+                <div
+                  class="d-flex flex-column ml-3 mr-3 mb-4"
+                >
+                  <h5
+                    data-testid="h5chatUrl8"
                   >
                     Chaturl
                   </h5>
                   <input
                     class="form-control"
-                    data-testid="input7"
+                    data-testid="input8"
                     placeholder=""
                     type="text"
                     value="https://chat.c0d3.com/c0d3/channels/js5-htmlcssjs"

--- a/__tests__/pages/profile/username.test.js
+++ b/__tests__/pages/profile/username.test.js
@@ -340,6 +340,7 @@ describe('user profile test', () => {
         videoUrl:
           'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
         order: null,
+        slug: null,
         challenges: [null, null, null],
         chatUrl: 'https://chat.c0d3.com/c0d3/channels/js1-variablesfunction'
       }

--- a/components/FormCard.test.js
+++ b/components/FormCard.test.js
@@ -88,6 +88,19 @@ describe('FormCard Component', () => {
     expect(container).toMatchSnapshot()
   })
 
+  test('Should display submit error message', () => {
+    const mockError = 'Helpful Error Message Here :)'
+    const { queryByText } = render(
+      <FormCard
+        onChange={() => {}}
+        values={[{ title: '' }]}
+        submitError={mockError}
+        onSubmit={mockBtn}
+      />
+    )
+    expect(queryByText(mockError)).toBeTruthy()
+  })
+
   test('Should render nothing if id is a title', () => {
     mockValues = [{ title: 'id' }]
     const { container } = render(

--- a/components/FormCard.tsx
+++ b/components/FormCard.tsx
@@ -26,6 +26,7 @@ type Btn = {
 type FormCardProps = {
   values: Option[]
   onSubmit: Btn
+  submitError?: string
   capitalizeTitle?: boolean
   onChange: Function
   title?: string
@@ -95,6 +96,7 @@ const OptionInfo: React.FC<OptionInfoProps> = ({
 export const FormCard: React.FC<FormCardProps> = ({
   values,
   onSubmit,
+  submitError,
   capitalizeTitle = true,
   title,
   onChange,
@@ -121,6 +123,7 @@ export const FormCard: React.FC<FormCardProps> = ({
           )}
         </div>
         <div className="text-left">{optionsList}</div>
+        {submitError && <h6 className="text-danger">{submitError}</h6>}
         <div className="text-center mb-4">
           <Button onClick={btnOnClick} type="primary" color="white">
             {onSubmit.title}

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -10,7 +10,7 @@ import {
   makeGraphqlVariable,
   errorCheckAllFields
 } from '../../../helpers/admin/adminHelpers'
-import { lessonSchema } from '../../../helpers/formValidation'
+import { challengeSchema } from '../../../helpers/formValidation'
 import { formChange } from '../../../helpers/formChange'
 
 const challengeAttributes = {
@@ -51,7 +51,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
   // alter gets called when someone clicks button to create a lesson
   const alter = async () => {
     const newProperties = [...challengeProperties]
-    const valid = await errorCheckAllFields(newProperties, lessonSchema)
+    const valid = await errorCheckAllFields(newProperties, challengeSchema)
     if (!valid) {
       setChallengeProperties(newProperties)
       return
@@ -74,7 +74,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
       propertyIndex,
       challengeProperties,
       setChallengeProperties,
-      lessonSchema
+      challengeSchema
     )
   }
 
@@ -109,7 +109,7 @@ const LessonChallenge: React.FC<LessonChallengeProps> = ({
       propertyIndex,
       challengeProperties,
       setChallengeProperties,
-      lessonSchema
+      challengeSchema
     )
   }
 
@@ -117,7 +117,7 @@ const LessonChallenge: React.FC<LessonChallengeProps> = ({
     title: 'Update Challenge',
     onClick: async () => {
       const newProperties = [...challengeProperties]
-      const valid = await errorCheckAllFields(newProperties, lessonSchema)
+      const valid = await errorCheckAllFields(newProperties, challengeSchema)
       if (!valid) {
         setChallengeProperties(newProperties)
         return

--- a/components/admin/lessons/AdminLessonInfo.test.js
+++ b/components/admin/lessons/AdminLessonInfo.test.js
@@ -22,6 +22,7 @@ const updateLessonMock = {
       videoUrl:
         'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
       order: 10,
+      slug: 'js0',
       chatUrl: 'https://chat.c0d3.com/c0d3/channels/js1-variablesfunction'
     }
   },

--- a/components/admin/lessons/AdminLessonInfo.test.js
+++ b/components/admin/lessons/AdminLessonInfo.test.js
@@ -39,6 +39,7 @@ const createLessonMock = {
       githubUrl: '',
       videoUrl: '',
       order: 12,
+      slug: 'js12',
       chatUrl: ''
     }
   },
@@ -79,6 +80,8 @@ describe('AdminLessonsInfo component', () => {
     )
     //new lesson order
     await userEvent.type(screen.getByTestId('input5'), '12', { delay: 1 })
+    //new lesson slug
+    await userEvent.type(screen.getByTestId('input6'), 'js12', { delay: 1 })
     await waitFor(() =>
       userEvent.click(screen.getByRole('button', { name: 'Create Lesson' }))
     )
@@ -185,6 +188,7 @@ describe('AdminLessonsInfo component', () => {
       { delay: 1 }
     )
     await userEvent.type(screen.getByTestId('input5'), '12', { delay: 1 })
+    await userEvent.type(screen.getByTestId('input6'), 'js12', { delay: 1 })
     await waitFor(() =>
       userEvent.click(screen.getByRole('button', { name: 'Create Lesson' }))
     )

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -90,6 +90,7 @@ const newLessonAttributes = {
   githubUrl: '',
   videoUrl: '',
   order: '',
+  slug: '',
   chatUrl: ''
 }
 

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -32,7 +32,7 @@ type NewLessonProps = {
 
 // Creates card for a lessons's information to update
 const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
-  const [alterLesson, { loading, data }] = useMutation(updateLesson)
+  const [alterLesson, { loading, data, error }] = useMutation(updateLesson)
   const [lessonProperties, setLessonProperties] = useState(
     getPropertyArr(lesson, ['challenges', '__typename'])
   )
@@ -75,6 +75,7 @@ const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
         <FormCard
           onChange={handleChange}
           values={lessonProperties}
+          submitError={error?.message}
           onSubmit={{ title: 'Update Lesson', onClick: alter }}
           title={lesson && lesson.title + ''}
         />
@@ -96,7 +97,7 @@ const newLessonAttributes = {
 
 // Renders when someone clicks on `create new button` on the sidebar
 const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
-  const [createLesson, { loading, data }] = useMutation(createNewLesson)
+  const [createLesson, { loading, data, error }] = useMutation(createNewLesson)
   const [lessonProperties, setLessonProperties] = useState(
     getPropertyArr(newLessonAttributes)
   )
@@ -142,6 +143,7 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
       <FormCard
         onChange={handleChange}
         values={lessonProperties}
+        submitError={error?.message}
         onSubmit={{ title: 'Create Lesson', onClick: alter }}
       />
     </div>

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -1,7 +1,4 @@
-import { useMutation } from '@apollo/client'
 import React, { useEffect, useState } from 'react'
-import createNewLesson from '../../../graphql/queries/createLesson'
-import updateLesson from '../../../graphql/queries/updateLesson'
 import * as Sentry from '@sentry/browser'
 import { FormCard } from '../../FormCard'
 import _ from 'lodash'
@@ -10,7 +7,11 @@ import {
   makeGraphqlVariable,
   errorCheckAllFields
 } from '../../../helpers/admin/adminHelpers'
-import { Lesson } from '../../../graphql/index'
+import {
+  Lesson,
+  useCreateLessonMutation,
+  useUpdateLessonMutation
+} from '../../../graphql/index'
 import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
 import { lessonSchema } from '../../../helpers/formValidation'
 import { formChange } from '../../../helpers/formChange'
@@ -32,13 +33,13 @@ type NewLessonProps = {
 
 // Creates card for a lessons's information to update
 const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
-  const [alterLesson, { loading, data, error }] = useMutation(updateLesson)
+  const [alterLesson, { loading, data, error }] = useUpdateLessonMutation()
   const [lessonProperties, setLessonProperties] = useState(
     getPropertyArr(lesson, ['challenges', '__typename'])
   )
   // when data is fully loaded after sending mutation request, update front-end lessons info
   useEffect(() => {
-    !loading && data && setLessons(data.updateLessons)
+    !loading && data && setLessons(data.updateLesson)
   }, [data])
 
   // alter gets called when someone clicks button to update a lesson
@@ -97,7 +98,7 @@ const newLessonAttributes = {
 
 // Renders when someone clicks on `create new button` on the sidebar
 const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
-  const [createLesson, { loading, data, error }] = useMutation(createNewLesson)
+  const [createLesson, { loading, data, error }] = useCreateLessonMutation()
   const [lessonProperties, setLessonProperties] = useState(
     getPropertyArr(newLessonAttributes)
   )

--- a/components/admin/lessons/AdminLessonsSideBar.tsx
+++ b/components/admin/lessons/AdminLessonsSideBar.tsx
@@ -21,6 +21,7 @@ export const AdminLessonsSideBar: React.FC<SideBarLessonProps> = ({
       title: 'Create New Lesson',
       description: '',
       order: -1,
+      slug: '',
       challenges: []
     })
   }
@@ -33,6 +34,7 @@ export const AdminLessonsSideBar: React.FC<SideBarLessonProps> = ({
       title: 'Create New Lesson',
       description: '',
       order: -1,
+      slug: '',
       challenges: []
     })
   }

--- a/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
+++ b/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
@@ -140,13 +140,29 @@ exports[`AdminLessonsInfo component Should create new lesson 1`] = `
             class="d-flex flex-column ml-3 mr-3 mb-4"
           >
             <h5
-              data-testid="h5chatUrl6"
+              data-testid="h5slug6"
+            >
+              Slug
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input6"
+              placeholder=""
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5chatUrl7"
             >
               Chaturl
             </h5>
             <input
               class="form-control"
-              data-testid="input6"
+              data-testid="input7"
               placeholder=""
               type="text"
               value=""
@@ -312,13 +328,29 @@ exports[`AdminLessonsInfo component Should create new lesson 2`] = `
             class="d-flex flex-column ml-3 mr-3 mb-4"
           >
             <h5
-              data-testid="h5chatUrl6"
+              data-testid="h5slug6"
+            >
+              Slug
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input6"
+              placeholder=""
+              type="text"
+              value="js12"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5chatUrl7"
             >
               Chaturl
             </h5>
             <input
               class="form-control"
-              data-testid="input6"
+              data-testid="input7"
               placeholder=""
               type="text"
               value=""
@@ -488,13 +520,29 @@ exports[`AdminLessonsInfo component Should render non-existent lesson 1`] = `
               class="d-flex flex-column ml-3 mr-3 mb-4"
             >
               <h5
-                data-testid="h5chatUrl7"
+                data-testid="h5slug7"
+              >
+                Slug
+              </h5>
+              <input
+                class="form-control"
+                data-testid="input7"
+                placeholder=""
+                type="text"
+                value="js0"
+              />
+            </div>
+            <div
+              class="d-flex flex-column ml-3 mr-3 mb-4"
+            >
+              <h5
+                data-testid="h5chatUrl8"
               >
                 Chaturl
               </h5>
               <input
                 class="form-control"
-                data-testid="input7"
+                data-testid="input8"
                 placeholder=""
                 type="text"
                 value="https://chat.c0d3.com/c0d3/channels/js1-variablesfunction"
@@ -1826,13 +1874,29 @@ exports[`AdminLessonsInfo component Should render undefined lessons 1`] = `
             class="d-flex flex-column ml-3 mr-3 mb-4"
           >
             <h5
-              data-testid="h5chatUrl6"
+              data-testid="h5slug6"
+            >
+              Slug
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input6"
+              placeholder=""
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5chatUrl7"
             >
               Chaturl
             </h5>
             <input
               class="form-control"
-              data-testid="input6"
+              data-testid="input7"
               placeholder=""
               type="text"
               value=""
@@ -2003,13 +2067,29 @@ exports[`AdminLessonsInfo component Should update lesson sucessfully 1`] = `
               class="d-flex flex-column ml-3 mr-3 mb-4"
             >
               <h5
-                data-testid="h5chatUrl7"
+                data-testid="h5slug7"
+              >
+                Slug
+              </h5>
+              <input
+                class="form-control"
+                data-testid="input7"
+                placeholder=""
+                type="text"
+                value="js0"
+              />
+            </div>
+            <div
+              class="d-flex flex-column ml-3 mr-3 mb-4"
+            >
+              <h5
+                data-testid="h5chatUrl8"
               >
                 Chaturl
               </h5>
               <input
                 class="form-control"
-                data-testid="input7"
+                data-testid="input8"
                 placeholder=""
                 type="text"
                 value="https://chat.c0d3.com/c0d3/channels/js1-variablesfunction"

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -76,6 +76,7 @@ export type Lesson = {
   githubUrl?: Maybe<Scalars['String']>
   videoUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
   title: Scalars['String']
   challenges: Array<Challenge>
   users?: Maybe<Array<Maybe<User>>>
@@ -182,6 +183,7 @@ export type MutationCreateLessonArgs = {
   title: Scalars['String']
   chatUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
 }
 
 export type MutationUpdateLessonArgs = {
@@ -193,6 +195,7 @@ export type MutationUpdateLessonArgs = {
   title: Scalars['String']
   chatUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
 }
 
 export type MutationCreateChallengeArgs = {
@@ -443,6 +446,7 @@ export type CreateLessonMutationVariables = Exact<{
   videoUrl?: Maybe<Scalars['String']>
   chatUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
   description: Scalars['String']
   title: Scalars['String']
 }>
@@ -459,6 +463,7 @@ export type CreateLessonMutation = {
         videoUrl?: Maybe<string>
         chatUrl?: Maybe<string>
         order: number
+        slug: string
         description: string
         title: string
         challenges: Array<{
@@ -503,6 +508,7 @@ export type GetAppQuery = {
     githubUrl?: Maybe<string>
     videoUrl?: Maybe<string>
     order: number
+    slug: string
     chatUrl?: Maybe<string>
     challenges: Array<{
       __typename?: 'Challenge'
@@ -851,6 +857,7 @@ export type UpdateLessonMutationVariables = Exact<{
   videoUrl?: Maybe<Scalars['String']>
   chatUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
   description: Scalars['String']
   title: Scalars['String']
 }>
@@ -867,6 +874,7 @@ export type UpdateLessonMutation = {
         videoUrl?: Maybe<string>
         chatUrl?: Maybe<string>
         order: number
+        slug: string
         description: string
         title: string
         challenges: Array<{
@@ -1190,6 +1198,7 @@ export type LessonResolvers<
   githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   order?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   challenges?: Resolver<
     Array<ResolversTypes['Challenge']>,
@@ -1297,7 +1306,10 @@ export type MutationResolvers<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
     ParentType,
     ContextType,
-    RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>
+    RequireFields<
+      MutationCreateLessonArgs,
+      'description' | 'title' | 'order' | 'slug'
+    >
   >
   updateLesson?: Resolver<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
@@ -1305,7 +1317,7 @@ export type MutationResolvers<
     ContextType,
     RequireFields<
       MutationUpdateLessonArgs,
-      'id' | 'description' | 'title' | 'order'
+      'id' | 'description' | 'title' | 'order' | 'slug'
     >
   >
   createChallenge?: Resolver<
@@ -2063,6 +2075,7 @@ export const CreateLessonDocument = gql`
     $videoUrl: String
     $chatUrl: String
     $order: Int!
+    $slug: String!
     $description: String!
     $title: String!
   ) {
@@ -2072,6 +2085,7 @@ export const CreateLessonDocument = gql`
       videoUrl: $videoUrl
       chatUrl: $chatUrl
       order: $order
+      slug: $slug
       description: $description
       title: $title
     ) {
@@ -2081,6 +2095,7 @@ export const CreateLessonDocument = gql`
       videoUrl
       chatUrl
       order
+      slug
       description
       title
       challenges {
@@ -2148,6 +2163,7 @@ export function withCreateLesson<
  *      videoUrl: // value for 'videoUrl'
  *      chatUrl: // value for 'chatUrl'
  *      order: // value for 'order'
+ *      slug: // value for 'slug'
  *      description: // value for 'description'
  *      title: // value for 'title'
  *   },
@@ -2280,6 +2296,7 @@ export const GetAppDocument = gql`
       githubUrl
       videoUrl
       order
+      slug
       challenges {
         id
         title
@@ -3574,6 +3591,7 @@ export const UpdateLessonDocument = gql`
     $videoUrl: String
     $chatUrl: String
     $order: Int!
+    $slug: String!
     $description: String!
     $title: String!
   ) {
@@ -3584,6 +3602,7 @@ export const UpdateLessonDocument = gql`
       chatUrl: $chatUrl
       id: $id
       order: $order
+      slug: $slug
       description: $description
       title: $title
     ) {
@@ -3593,6 +3612,7 @@ export const UpdateLessonDocument = gql`
       videoUrl
       chatUrl
       order
+      slug
       description
       title
       challenges {
@@ -3661,6 +3681,7 @@ export function withUpdateLesson<
  *      videoUrl: // value for 'videoUrl'
  *      chatUrl: // value for 'chatUrl'
  *      order: // value for 'order'
+ *      slug: // value for 'slug'
  *      description: // value for 'description'
  *      title: // value for 'title'
  *   },

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -99,8 +99,8 @@ export type Mutation = {
   acceptSubmission?: Maybe<Submission>
   rejectSubmission?: Maybe<Submission>
   addComment?: Maybe<Comment>
-  createLesson?: Maybe<Array<Maybe<Lesson>>>
-  updateLesson?: Maybe<Array<Maybe<Lesson>>>
+  createLesson: Array<Lesson>
+  updateLesson: Array<Lesson>
   createChallenge?: Maybe<Array<Maybe<Lesson>>>
   updateChallenge?: Maybe<Array<Maybe<Lesson>>>
 }
@@ -453,30 +453,26 @@ export type CreateLessonMutationVariables = Exact<{
 
 export type CreateLessonMutation = {
   __typename?: 'Mutation'
-  createLesson?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: 'Lesson'
-        id: number
-        docUrl?: Maybe<string>
-        githubUrl?: Maybe<string>
-        videoUrl?: Maybe<string>
-        chatUrl?: Maybe<string>
-        order: number
-        slug: string
-        description: string
-        title: string
-        challenges: Array<{
-          __typename?: 'Challenge'
-          id: number
-          description: string
-          lessonId: number
-          title: string
-          order: number
-        }>
-      }>
-    >
-  >
+  createLesson: Array<{
+    __typename?: 'Lesson'
+    id: number
+    docUrl?: Maybe<string>
+    githubUrl?: Maybe<string>
+    videoUrl?: Maybe<string>
+    chatUrl?: Maybe<string>
+    order: number
+    slug: string
+    description: string
+    title: string
+    challenges: Array<{
+      __typename?: 'Challenge'
+      id: number
+      description: string
+      lessonId: number
+      title: string
+      order: number
+    }>
+  }>
 }
 
 export type CreateSubmissionMutationVariables = Exact<{
@@ -864,30 +860,26 @@ export type UpdateLessonMutationVariables = Exact<{
 
 export type UpdateLessonMutation = {
   __typename?: 'Mutation'
-  updateLesson?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: 'Lesson'
-        id: number
-        docUrl?: Maybe<string>
-        githubUrl?: Maybe<string>
-        videoUrl?: Maybe<string>
-        chatUrl?: Maybe<string>
-        order: number
-        slug: string
-        description: string
-        title: string
-        challenges: Array<{
-          __typename?: 'Challenge'
-          id: number
-          description: string
-          lessonId: number
-          title: string
-          order: number
-        }>
-      }>
-    >
-  >
+  updateLesson: Array<{
+    __typename?: 'Lesson'
+    id: number
+    docUrl?: Maybe<string>
+    githubUrl?: Maybe<string>
+    videoUrl?: Maybe<string>
+    chatUrl?: Maybe<string>
+    order: number
+    slug: string
+    description: string
+    title: string
+    challenges: Array<{
+      __typename?: 'Challenge'
+      id: number
+      description: string
+      lessonId: number
+      title: string
+      order: number
+    }>
+  }>
 }
 
 export type ChangePwMutationVariables = Exact<{
@@ -1303,7 +1295,7 @@ export type MutationResolvers<
     RequireFields<MutationAddCommentArgs, 'submissionId' | 'content'>
   >
   createLesson?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    Array<ResolversTypes['Lesson']>,
     ParentType,
     ContextType,
     RequireFields<
@@ -1312,7 +1304,7 @@ export type MutationResolvers<
     >
   >
   updateLesson?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    Array<ResolversTypes['Lesson']>,
     ParentType,
     ContextType,
     RequireFields<

--- a/graphql/queries/createLesson.ts
+++ b/graphql/queries/createLesson.ts
@@ -7,6 +7,7 @@ const CREATE_LESSON = gql`
     $videoUrl: String
     $chatUrl: String
     $order: Int!
+    $slug: String!
     $description: String!
     $title: String!
   ) {
@@ -16,6 +17,7 @@ const CREATE_LESSON = gql`
       videoUrl: $videoUrl
       chatUrl: $chatUrl
       order: $order
+      slug: $slug
       description: $description
       title: $title
     ) {
@@ -25,6 +27,7 @@ const CREATE_LESSON = gql`
       videoUrl
       chatUrl
       order
+      slug
       description
       title
       challenges {

--- a/graphql/queries/getApp.ts
+++ b/graphql/queries/getApp.ts
@@ -10,6 +10,7 @@ const GET_APP = gql`
       githubUrl
       videoUrl
       order
+      slug
       challenges {
         id
         title

--- a/graphql/queries/updateLesson.ts
+++ b/graphql/queries/updateLesson.ts
@@ -8,6 +8,7 @@ const UPDATE_LESSON = gql`
     $videoUrl: String
     $chatUrl: String
     $order: Int!
+    $slug: String!
     $description: String!
     $title: String!
   ) {
@@ -18,6 +19,7 @@ const UPDATE_LESSON = gql`
       chatUrl: $chatUrl
       id: $id
       order: $order
+      slug: $slug
       description: $description
       title: $title
     ) {
@@ -27,6 +29,7 @@ const UPDATE_LESSON = gql`
       videoUrl
       chatUrl
       order
+      slug
       description
       title
       challenges {

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -61,6 +61,7 @@ export default gql`
       title: String!
       chatUrl: String
       order: Int!
+      slug: String!
     ): [Lesson]
     updateLesson(
       id: Int!
@@ -71,6 +72,7 @@ export default gql`
       title: String!
       chatUrl: String
       order: Int!
+      slug: String!
     ): [Lesson]
     createChallenge(
       lessonId: Int!
@@ -169,6 +171,7 @@ export default gql`
     githubUrl: String
     videoUrl: String
     order: Int!
+    slug: String!
     title: String!
     challenges: [Challenge!]!
     users: [User]

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -62,7 +62,7 @@ export default gql`
       chatUrl: String
       order: Int!
       slug: String!
-    ): [Lesson]
+    ): [Lesson!]!
     updateLesson(
       id: Int!
       description: String!
@@ -73,7 +73,7 @@ export default gql`
       chatUrl: String
       order: Int!
       slug: String!
-    ): [Lesson]
+    ): [Lesson!]!
     createChallenge(
       lessonId: Int!
       order: Int!

--- a/helpers/formValidation.tsx
+++ b/helpers/formValidation.tsx
@@ -15,11 +15,16 @@ const alertValidation = Yup.object({
 const lessonSchema = Yup.object({
   title: Yup.string().required('Required').strict(true),
   description: Yup.string().required('Required').strict(true),
+  docUrl: Yup.string(),
+  githubUrl: Yup.string(),
+  videoUrl: Yup.string(),
   order: Yup.number()
     .required('Required')
     .typeError('Numbers only')
     .min(0, 'Positive numbers only')
-    .strict(true)
+    .strict(true),
+  slug: Yup.string().required('Required').strict(true),
+  chatUrl: Yup.string()
 })
 
 const signupValidation = Yup.object({

--- a/helpers/formValidation.tsx
+++ b/helpers/formValidation.tsx
@@ -12,6 +12,16 @@ const alertValidation = Yup.object({
   urlCaption: Yup.string()
 })
 
+const challengeSchema = Yup.object({
+  title: Yup.string().required('Required').strict(true),
+  description: Yup.string().required('Required').strict(true),
+  order: Yup.number()
+    .required('Required')
+    .typeError('Numbers only')
+    .min(0, 'Positive numbers only')
+    .strict(true)
+})
+
 const lessonSchema = Yup.object({
   title: Yup.string().required('Required').strict(true),
   description: Yup.string().required('Required').strict(true),
@@ -93,6 +103,7 @@ const resetPasswordValidation = Yup.object({
 
 export {
   alertValidation,
+  challengeSchema,
   lessonSchema,
   signupValidation,
   loginValidation,

--- a/prisma/migrations/20210816200009_lesson_slug/migration.sql
+++ b/prisma/migrations/20210816200009_lesson_slug/migration.sql
@@ -1,0 +1,12 @@
+-- Create slug field
+ALTER TABLE "lessons" ADD COLUMN "slug" VARCHAR(50);
+
+-- Add slug's to existing lessons
+UPDATE "lessons"
+SET "slug" = 'js' || "lessons".order;
+
+-- Make slug field required
+ALTER TABLE "lessons" ALTER COLUMN "slug" SET NOT NULL;
+
+-- CreateIndex (ensure no deplicate slugs)
+CREATE UNIQUE INDEX "lessons.slug_unique" ON "lessons"("slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Challenge {
 
 model Lesson {
   id          Int          @id @default(autoincrement())
+  slug        String       @unique @db.VarChar(50)
   description String
   docUrl      String?      @db.VarChar(255)
   githubUrl   String?      @db.VarChar(255)

--- a/prisma/seedData.ts
+++ b/prisma/seedData.ts
@@ -6,6 +6,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     title: 'Foundations of JavaScript',
     description: 'A super simple introduction to help you get started!',
     order: 0,
+    slug: 'js0',
     docUrl:
       'https://www.notion.so/garagescript/JS-0-Foundations-a43ca620e54945b2b620bcda5f3cf672',
     challenges: {
@@ -80,6 +81,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'Learn how to solve simple algorithm problems recursively with the following exercises',
     order: 1,
+    slug: 'js1',
     docUrl:
       'https://www.notion.so/garagescript/JS-1-Functions-01dd8400b85f40d083966908acbfa184',
     challenges: {
@@ -166,6 +168,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.',
     order: 2,
+    slug: 'js2',
     docUrl:
       'https://www.notion.so/garagescript/JS-2-Arrays-8601f89c64164f188286df7b1e6d0ad9',
     challenges: {
@@ -246,6 +249,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'These exercises will test your understanding of objects, which includes linked lists and trees',
     order: 3,
+    slug: 'js3',
     docUrl:
       'https://www.notion.so/garagescript/JS-3-Objects-3df846eaf0404fe6b012208773063a04',
     challenges: {
@@ -320,6 +324,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)',
     order: 4,
+    slug: 'js4',
     docUrl:
       'https://www.notion.so/garagescript/JS-4-Front-End-Engineering-c59fbdd58dcc4214956f7856e0892b52',
     challenges: {
@@ -376,6 +381,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'These exercises will help you build a strong understanding of how the web works.',
     order: 5,
+    slug: 'js5',
     docUrl:
       'https://www.notion.so/JS-5-System-Design-Theory-67e7ee647a1c429d8e60e82f13a8d286',
     challenges: {
@@ -443,6 +449,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     title: 'React, GraphQL, SocketIO',
     description: 'React and GraphQL Lessons',
     order: 6,
+    slug: 'js6',
     docUrl: '',
     challenges: {
       createMany: {
@@ -504,6 +511,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'Problems that are commonly asked to test your JavaScript knowledge',
     order: 7,
+    slug: 'js7',
     docUrl:
       'https://docs.google.com/document/d/1ekuu6VbN7qqypm71cVHT-BkdxYSwY0BBHLK8xGXSN1U/edit',
     challenges: {
@@ -583,6 +591,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     title: 'Trees',
     description: 'Tree problems with high difficulty',
     order: 8,
+    slug: 'js8',
     docUrl: '',
     challenges: {
       createMany: {
@@ -669,6 +678,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     title: 'General Algorithms',
     description: 'General Algorithm from interviews',
     order: 9,
+    slug: 'js9',
     docUrl: '',
     challenges: {
       createMany: {

--- a/stories/profile/ProfileStarComments.stories.tsx
+++ b/stories/profile/ProfileStarComments.stories.tsx
@@ -23,6 +23,7 @@ const stars: StarType[] = [
       title: 'Objects',
       description: 'Objects description',
       order: 3,
+      slug: 'js3',
       challenges: []
     },
     comment:
@@ -43,6 +44,7 @@ const stars: StarType[] = [
       title: 'End to End',
       description: 'End to End description',
       order: 5,
+      slug: 'js5',
       challenges: []
     },
     comment: "Objects ain't easy, but thanks to you, they're now lemon squeezy."


### PR DESCRIPTION
## Changes
- Add `slug` field to Lesson database table
- update admin lesson creating / update components to handle new slug field
  - Add error message in response to submit errors (used to catch is unique error)
![slug-field-with-error](https://user-images.githubusercontent.com/17365077/129796766-ff157108-84d6-44c8-b931-ff2aa323b038.png)
(Screenshot of http://localhost:3000/admin/lessons)
## Purpose
Allow us to easily link self hosted lesson material to correct lesson via [folders names](https://github.com/garageScript/c0d3-app/tree/master/pages/curriculum/lessons)

## Test locally 

Since this pr includes a migration the vercel preview branch will not work as our preview branches currently run on the production db.

You can test it locally by pulling down the branch and then switching to it and running `yarn prima migrate dev` \* When you switch back to another branch you will have to run `yarn db:init` to reset your dev db

## Potential Migration issues

- Duplicate Lesson.orders will cause the migration to fail as it uses `js` + `Lesson.order` as the default slug value which must be unique, but order isn't required to be unique

-  ???? Please point out any other potential issues if you see them