### PR TITLE
Feature/lesson page use slug

### DIFF
--- a/__dummy__/lessonData.ts
+++ b/__dummy__/lessonData.ts
@@ -11,6 +11,7 @@ const dummyLessonsData: Lesson[] = [
     videoUrl:
       'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
     order: 0,
+    slug: 'js0',
     challenges: [
       {
         id: 107,
@@ -106,6 +107,7 @@ const dummyLessonsData: Lesson[] = [
     videoUrl:
       'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
     order: 1,
+    slug: 'js1',
     challenges: [
       {
         id: 146,
@@ -218,6 +220,7 @@ const dummyLessonsData: Lesson[] = [
     videoUrl:
       'https://www.youtube.com/watch?v=rem796-hPY8&index=3&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7',
     order: 2,
+    slug: 'js2',
     challenges: [
       {
         id: 84,
@@ -322,6 +325,7 @@ const dummyLessonsData: Lesson[] = [
     videoUrl:
       'https://www.youtube.com/watch?v=Npn275pNXYw&index=4&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7',
     order: 3,
+    slug: 'js3',
     challenges: [
       {
         id: 91,
@@ -416,6 +420,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 4,
+    slug: 'js4',
     challenges: [
       {
         id: 177,
@@ -486,6 +491,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 5,
+    slug: 'js5',
     challenges: [
       {
         id: 73,
@@ -570,6 +576,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 6,
+    slug: 'js6',
     challenges: [
       {
         id: 192,
@@ -648,6 +655,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 7,
+    slug: 'js7',
     challenges: [
       {
         id: 180,
@@ -748,6 +756,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 8,
+    slug: 'js8',
     challenges: [
       {
         id: 160,
@@ -858,6 +867,7 @@ const dummyLessonsData: Lesson[] = [
     githubUrl: '',
     videoUrl: '',
     order: 9,
+    slug: 'js9',
     challenges: [
       {
         id: 167,

--- a/__dummy__/starsData.ts
+++ b/__dummy__/starsData.ts
@@ -13,6 +13,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Foundations of JavaScript',
       order: 0,
+      slug: 'js0',
       id: 5,
       description: 'A super simple introduction to help you get started!',
       challenges: []
@@ -32,6 +33,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Variables & Functions',
       order: 1,
+      slug: 'js1',
       id: 2,
       description:
         'Learn how to solve simple algorithm problems recursively with the following exercises. ',
@@ -52,6 +54,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Arrays',
       order: 2,
+      slug: 'js2',
       id: 1,
       description:
         'These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.',
@@ -72,6 +75,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Objects',
       order: 3,
+      slug: 'js3',
       id: 4,
       description:
         'These exercises will test your understanding of objects, which includes linked lists and trees',
@@ -92,6 +96,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Front End Engineering',
       order: 4,
+      slug: 'js4',
       id: 24,
       description:
         'Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)',
@@ -112,6 +117,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'End To End',
       order: 5,
+      slug: 'js5',
       id: 3,
       description:
         'These exercises will help you build a strong understanding of how the web works.',
@@ -132,6 +138,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'React, GraphQL, SocketIO',
       order: 6,
+      slug: 'js6',
       id: 29,
       description: 'React and GraphQL Lessons',
       challenges: []
@@ -151,6 +158,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Foundations of JavaScript',
       order: 0,
+      slug: 'js0',
       id: 5,
       description: 'A super simple introduction to help you get started!',
       challenges: []
@@ -171,6 +179,8 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Variables & Functions',
       order: 1,
+      slug: 'js1',
+
       id: 2,
       description:
         'Learn how to solve simple algorithm problems recursively with the following exercises. ',
@@ -191,6 +201,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Arrays',
       order: 2,
+      slug: 'js2',
       id: 1,
       description:
         'These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.',
@@ -211,6 +222,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Objects',
       order: 3,
+      slug: 'js3',
       id: 4,
       description:
         'These exercises will test your understanding of objects, which includes linked lists and trees',
@@ -231,6 +243,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'Front End Engineering',
       order: 4,
+      slug: 'js4',
       id: 24,
       description:
         'Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)',
@@ -251,6 +264,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'End To End',
       order: 5,
+      slug: 'js5',
       id: 3,
       description:
         'These exercises will help you build a strong understanding of how the web works.',
@@ -271,6 +285,7 @@ const dummyStarData: Star[] = [
     lesson: {
       title: 'React, GraphQL, SocketIO',
       order: 6,
+      slug: 'js6',
       id: 29,
       description: 'React and GraphQL Lessons',
       challenges: []

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5833,7 +5833,7 @@ exports[`Storyshots Components/LessonCard Basic 1`] = `
         >
           <a
             className=""
-            href="/curriculum/4"
+            href="https://c0d3.com/student/24"
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
@@ -5896,7 +5896,7 @@ exports[`Storyshots Components/LessonCard Basic 1`] = `
         >
           <a
             className=""
-            href="/curriculum/4"
+            href="https://c0d3.com/student/24"
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
@@ -5951,7 +5951,7 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
         >
           <a
             className=""
-            href="/curriculum/4"
+            href="https://c0d3.com/student/24"
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
@@ -6021,6 +6021,8 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
     <a
       className="btn btn-sm bg-primary text-white float-right mb-2 mr-2mr-0"
       href="https://c0d3.com/teacher/5"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
     >
       Review 
       <div
@@ -6052,7 +6054,7 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
         >
           <a
             className=""
-            href="/curriculum/4"
+            href="https://c0d3.com/student/24"
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
@@ -6114,6 +6116,8 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
       <a
         className="btn btn-sm bg-primary text-white float-right mb-2 mr-2"
         href="https://c0d3.com/teacher/5"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
       >
         Review 
         <div
@@ -6145,7 +6149,7 @@ exports[`Storyshots Components/LessonCard With In Progress 1`] = `
         >
           <a
             className=""
-            href="/curriculum/4"
+            href="https://c0d3.com/student/24"
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
@@ -6208,7 +6212,7 @@ exports[`Storyshots Components/LessonCard With In Progress 1`] = `
         >
           <a
             className=""
-            href="/curriculum/4"
+            href="https://c0d3.com/student/24"
             onClick={[Function]}
             onMouseEnter={[Function]}
           >
@@ -6311,7 +6315,7 @@ exports[`Storyshots Components/LessonTitleCard Basic 1`] = `
       </a>
       <a
         className="btn border-right rounded-0 px-4 py-3"
-        href="/curriculum/5"
+        href="/curriculum/js0"
         onClick={[Function]}
         onMouseEnter={[Function]}
       >
@@ -6368,7 +6372,7 @@ exports[`Storyshots Components/LessonTitleCard Passed Lesson 1`] = `
       </a>
       <a
         className="btn border-right rounded-0 px-4 py-3"
-        href="/curriculum/5"
+        href="/curriculum/js0"
         onClick={[Function]}
         onMouseEnter={[Function]}
       >
@@ -6376,7 +6380,7 @@ exports[`Storyshots Components/LessonTitleCard Passed Lesson 1`] = `
       </a>
       <a
         className="btn border-right rounded-0 px-4 py-3"
-        href="/review/5"
+        href="/review/js0"
         onClick={[Function]}
         onMouseEnter={[Function]}
       >
@@ -14570,7 +14574,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -14633,7 +14637,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -14685,7 +14689,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -14748,7 +14752,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -14800,7 +14804,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -14863,7 +14867,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -14915,7 +14919,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -14978,7 +14982,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15030,7 +15034,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15093,7 +15097,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15145,7 +15149,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15208,7 +15212,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15260,7 +15264,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15323,7 +15327,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15375,7 +15379,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15438,7 +15442,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15490,7 +15494,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15553,7 +15557,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15605,7 +15609,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -15668,7 +15672,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16090,7 +16094,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16153,7 +16157,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16205,7 +16209,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16268,7 +16272,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16320,7 +16324,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16383,7 +16387,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16435,7 +16439,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16498,7 +16502,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16550,7 +16554,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16613,7 +16617,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16665,7 +16669,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16728,7 +16732,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16780,7 +16784,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16843,7 +16847,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16895,7 +16899,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -16958,7 +16962,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17010,7 +17014,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17073,7 +17077,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17125,7 +17129,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17188,7 +17192,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17610,7 +17614,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17673,7 +17677,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17725,7 +17729,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17788,7 +17792,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17840,7 +17844,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17903,7 +17907,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -17955,7 +17959,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18018,7 +18022,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18070,7 +18074,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18133,7 +18137,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18185,7 +18189,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18248,7 +18252,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18300,7 +18304,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18363,7 +18367,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18415,7 +18419,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18478,7 +18482,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18530,7 +18534,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18593,7 +18597,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18645,7 +18649,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -18708,7 +18712,7 @@ Array [
                 >
                   <a
                     className=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
@@ -23545,7 +23549,7 @@ Array [
             </a>
             <a
               className="btn border-right rounded-0 px-4 py-3"
-              href="/curriculum/1"
+              href="/curriculum/undefined"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -159,7 +159,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                   >
                     Foundations of JavaScript
                   </a>
@@ -218,7 +218,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                   >
                     Foundations of JavaScript
                   </a>
@@ -268,7 +268,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                   >
                     Variables & Functions
                   </a>
@@ -327,7 +327,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                   >
                     Variables & Functions
                   </a>
@@ -377,7 +377,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                   >
                     Arrays
                   </a>
@@ -436,7 +436,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                   >
                     Arrays
                   </a>
@@ -486,7 +486,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                   >
                     Objects
                   </a>
@@ -545,7 +545,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                   >
                     Objects
                   </a>
@@ -595,7 +595,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                   >
                     Front End Engineering
                   </a>
@@ -654,7 +654,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                   >
                     Front End Engineering
                   </a>
@@ -704,7 +704,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                   >
                     End To End
                   </a>
@@ -763,7 +763,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                   >
                     End To End
                   </a>
@@ -813,7 +813,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                   >
                     React, GraphQL, SocketIO
                   </a>
@@ -872,7 +872,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                   >
                     React, GraphQL, SocketIO
                   </a>
@@ -922,7 +922,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                   >
                     JavaScript Algorithms
                   </a>
@@ -981,7 +981,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                   >
                     JavaScript Algorithms
                   </a>
@@ -1031,7 +1031,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                   >
                     Trees
                   </a>
@@ -1090,7 +1090,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                   >
                     Trees
                   </a>
@@ -1140,7 +1140,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                   >
                     General Algorithms
                   </a>
@@ -1199,7 +1199,7 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                   >
                     General Algorithms
                   </a>
@@ -1739,7 +1739,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                   >
                     Foundations of JavaScript
                   </a>
@@ -1798,7 +1798,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                   >
                     Foundations of JavaScript
                   </a>
@@ -1843,7 +1843,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
             </a>
             <a
               class="lesson-card__button btn bg-primary my-1 text-white border border-white"
-              href="/curriculum/5"
+              href="/curriculum/js0"
             >
               View Challenges
             </a>
@@ -1866,7 +1866,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                   >
                     Variables & Functions
                   </a>
@@ -1925,7 +1925,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                   >
                     Variables & Functions
                   </a>
@@ -1975,7 +1975,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                   >
                     Arrays
                   </a>
@@ -2034,7 +2034,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                   >
                     Arrays
                   </a>
@@ -2084,7 +2084,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                   >
                     Objects
                   </a>
@@ -2143,7 +2143,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                   >
                     Objects
                   </a>
@@ -2193,7 +2193,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                   >
                     Front End Engineering
                   </a>
@@ -2252,7 +2252,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                   >
                     Front End Engineering
                   </a>
@@ -2302,7 +2302,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                   >
                     End To End
                   </a>
@@ -2361,7 +2361,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                   >
                     End To End
                   </a>
@@ -2411,7 +2411,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                   >
                     React, GraphQL, SocketIO
                   </a>
@@ -2470,7 +2470,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                   >
                     React, GraphQL, SocketIO
                   </a>
@@ -2520,7 +2520,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                   >
                     JavaScript Algorithms
                   </a>
@@ -2579,7 +2579,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                   >
                     JavaScript Algorithms
                   </a>
@@ -2629,7 +2629,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                   >
                     Trees
                   </a>
@@ -2688,7 +2688,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                   >
                     Trees
                   </a>
@@ -2738,7 +2738,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                   >
                     General Algorithms
                   </a>
@@ -2797,7 +2797,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                   >
                     General Algorithms
                   </a>
@@ -3405,7 +3405,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                   >
                     Foundations of JavaScript
                   </a>
@@ -3471,7 +3471,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
             </p>
             <a
               class="btn btn-sm bg-primary text-white float-right mb-2 mr-2mr-0"
-              href="/review/5"
+              href="/review/js0"
             >
               Review 
               <span>
@@ -3501,7 +3501,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/5"
+                    href="/curriculum/js0"
                   >
                     Foundations of JavaScript
                   </a>
@@ -3560,7 +3560,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               </div>
               <a
                 class="btn btn-sm bg-primary text-white float-right mb-2 mr-2"
-                href="/review/5"
+                href="/review/js0"
               >
                 Review 
                 <span>
@@ -3588,7 +3588,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                   >
                     Variables & Functions
                   </a>
@@ -3654,7 +3654,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
             </p>
             <a
               class="btn btn-sm bg-primary text-white float-right mb-2 mr-2mr-0"
-              href="/review/2"
+              href="/review/js1"
             >
               Review 
               <span>
@@ -3684,7 +3684,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/2"
+                    href="/curriculum/js1"
                   >
                     Variables & Functions
                   </a>
@@ -3743,7 +3743,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               </div>
               <a
                 class="btn btn-sm bg-primary text-white float-right mb-2 mr-2"
-                href="/review/2"
+                href="/review/js1"
               >
                 Review 
                 <span>
@@ -3771,7 +3771,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                   >
                     Arrays
                   </a>
@@ -3837,7 +3837,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
             </p>
             <a
               class="btn btn-sm bg-primary text-white float-right mb-2 mr-2mr-0"
-              href="/review/1"
+              href="/review/js2"
             >
               Review 
               <span>
@@ -3867,7 +3867,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/1"
+                    href="/curriculum/js2"
                   >
                     Arrays
                   </a>
@@ -3926,7 +3926,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
               </div>
               <a
                 class="btn btn-sm bg-primary text-white float-right mb-2 mr-2"
-                href="/review/1"
+                href="/review/js2"
               >
                 Review 
                 <span>
@@ -3954,7 +3954,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                   >
                     Objects
                   </a>
@@ -4013,7 +4013,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/4"
+                    href="/curriculum/js3"
                   >
                     Objects
                   </a>
@@ -4058,7 +4058,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
             </a>
             <a
               class="lesson-card__button btn bg-primary my-1 text-white border border-white"
-              href="/curriculum/4"
+              href="/curriculum/js3"
             >
               View Challenges
             </a>
@@ -4081,7 +4081,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                   >
                     Front End Engineering
                   </a>
@@ -4140,7 +4140,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/24"
+                    href="/curriculum/js4"
                   >
                     Front End Engineering
                   </a>
@@ -4190,7 +4190,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                   >
                     End To End
                   </a>
@@ -4249,7 +4249,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/3"
+                    href="/curriculum/js5"
                   >
                     End To End
                   </a>
@@ -4299,7 +4299,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                   >
                     React, GraphQL, SocketIO
                   </a>
@@ -4358,7 +4358,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/29"
+                    href="/curriculum/js6"
                   >
                     React, GraphQL, SocketIO
                   </a>
@@ -4408,7 +4408,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                   >
                     JavaScript Algorithms
                   </a>
@@ -4467,7 +4467,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/28"
+                    href="/curriculum/js7"
                   >
                     JavaScript Algorithms
                   </a>
@@ -4517,7 +4517,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                   >
                     Trees
                   </a>
@@ -4576,7 +4576,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/25"
+                    href="/curriculum/js8"
                   >
                     Trees
                   </a>
@@ -4626,7 +4626,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                   >
                     General Algorithms
                   </a>
@@ -4685,7 +4685,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                 >
                   <a
                     class=""
-                    href="/curriculum/27"
+                    href="/curriculum/js9"
                   >
                     General Algorithms
                   </a>

--- a/__tests__/pages/admin/__snapshots__/lessons.test.js.snap
+++ b/__tests__/pages/admin/__snapshots__/lessons.test.js.snap
@@ -393,13 +393,29 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 1`] 
                   class="d-flex flex-column ml-3 mr-3 mb-4"
                 >
                   <h5
-                    data-testid="h5chatUrl7"
+                    data-testid="h5slug7"
+                  >
+                    Slug
+                  </h5>
+                  <input
+                    class="form-control"
+                    data-testid="input7"
+                    placeholder=""
+                    type="text"
+                    value="js0"
+                  />
+                </div>
+                <div
+                  class="d-flex flex-column ml-3 mr-3 mb-4"
+                >
+                  <h5
+                    data-testid="h5chatUrl8"
                   >
                     Chaturl
                   </h5>
                   <input
                     class="form-control"
-                    data-testid="input7"
+                    data-testid="input8"
                     placeholder=""
                     type="text"
                     value="https://chat.c0d3.com/c0d3/channels/js1-variablesfunction"
@@ -1991,13 +2007,29 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 2`] 
                   class="d-flex flex-column ml-3 mr-3 mb-4"
                 >
                   <h5
-                    data-testid="h5chatUrl7"
+                    data-testid="h5slug7"
+                  >
+                    Slug
+                  </h5>
+                  <input
+                    class="form-control"
+                    data-testid="input7"
+                    placeholder=""
+                    type="text"
+                    value="js3"
+                  />
+                </div>
+                <div
+                  class="d-flex flex-column ml-3 mr-3 mb-4"
+                >
+                  <h5
+                    data-testid="h5chatUrl8"
                   >
                     Chaturl
                   </h5>
                   <input
                     class="form-control"
-                    data-testid="input7"
+                    data-testid="input8"
                     placeholder=""
                     type="text"
                     value="https://chat.c0d3.com/c0d3/channels/js5-htmlcssjs"

--- a/__tests__/pages/curriculum/[lesson].test.js
+++ b/__tests__/pages/curriculum/[lesson].test.js
@@ -76,7 +76,7 @@ const session = {
 }
 describe('Lesson Page', () => {
   const { query } = useRouter()
-  query['lesson'] = 2
+  query['lesson'] = 'js1'
   test('Should render correctly with valid lesson route', async () => {
     const mocks = [
       {
@@ -105,7 +105,7 @@ describe('Lesson Page', () => {
   })
 
   test('Should render correctly with invalid lesson route', async () => {
-    query['lesson'] = 100
+    query['lesson'] = 'js100'
     const mocks = [
       {
         request: { query: GET_APP },
@@ -129,7 +129,7 @@ describe('Lesson Page', () => {
     await waitFor(() => expect(container).toMatchSnapshot())
   })
   test("Should correctly render challenges page for students who hadn't passed previous lessons", async () => {
-    query['lesson'] = 25
+    query['lesson'] = 'js8'
     const mocks = [
       {
         request: { query: GET_APP },
@@ -179,7 +179,7 @@ describe('Lesson Page', () => {
     await waitFor(() => expect(container).toMatchSnapshot())
   })
   test('Should render with nulled submissions', async () => {
-    query['lesson'] = 2
+    query['lesson'] = 'js1'
     const mocks = [
       {
         request: { query: GET_APP },

--- a/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/curriculum/__snapshots__/[lesson].test.js.snap
@@ -179,7 +179,7 @@ exports[`Lesson Page Should correctly render challenges page for students who ha
               >
                 <a
                   class="btn border-right rounded-0 px-4 py-3"
-                  href="/curriculum/25"
+                  href="/curriculum/js8"
                 >
                   CHALLENGES
                 </a>
@@ -825,7 +825,7 @@ exports[`Lesson Page Should render correctly with valid lesson route 1`] = `
                 </a>
                 <a
                   class="btn border-right rounded-0 px-4 py-3"
-                  href="/curriculum/2"
+                  href="/curriculum/js1"
                 >
                   CHALLENGES
                 </a>

--- a/__tests__/pages/profile/username.test.js
+++ b/__tests__/pages/profile/username.test.js
@@ -340,6 +340,7 @@ describe('user profile test', () => {
         videoUrl:
           'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
         order: null,
+        slug: null,
         challenges: [null, null, null],
         chatUrl: 'https://chat.c0d3.com/c0d3/channels/js1-variablesfunction'
       }

--- a/__tests__/pages/review/[lesson].test.js
+++ b/__tests__/pages/review/[lesson].test.js
@@ -82,7 +82,7 @@ const getPreviousSubmissionsMock = {
 const mocks = [getAppMock, getSubmissionsMock, getPreviousSubmissionsMock]
 describe('Lesson Page', () => {
   const { query, push, asPath } = useRouter()
-  query['lesson'] = '2'
+  query['lesson'] = 'js1'
   test('Should render new submissions', async () => {
     const { container } = render(
       <MockedProvider mocks={mocks} addTypename={false}>

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -377,13 +377,13 @@ exports[`Lesson Page Should render empty submissions 1`] = `
               </a>
               <a
                 class="btn border-right rounded-0 px-4 py-3"
-                href="/curriculum/2"
+                href="/curriculum/js1"
               >
                 CHALLENGES
               </a>
               <a
                 class="btn border-right rounded-0 px-4 py-3"
-                href="/review/2"
+                href="/review/js1"
               >
                 REVIEW
               </a>
@@ -588,13 +588,13 @@ exports[`Lesson Page Should render new submissions 1`] = `
               </a>
               <a
                 class="btn border-right rounded-0 px-4 py-3"
-                href="/curriculum/2"
+                href="/curriculum/js1"
               >
                 CHALLENGES
               </a>
               <a
                 class="btn border-right rounded-0 px-4 py-3"
-                href="/review/2"
+                href="/review/js1"
               >
                 REVIEW
               </a>

--- a/components/FormCard.test.js
+++ b/components/FormCard.test.js
@@ -88,6 +88,19 @@ describe('FormCard Component', () => {
     expect(container).toMatchSnapshot()
   })
 
+  test('Should display submit error message', () => {
+    const mockError = 'Helpful Error Message Here :)'
+    const { queryByText } = render(
+      <FormCard
+        onChange={() => {}}
+        values={[{ title: '' }]}
+        submitError={mockError}
+        onSubmit={mockBtn}
+      />
+    )
+    expect(queryByText(mockError)).toBeTruthy()
+  })
+
   test('Should render nothing if id is a title', () => {
     mockValues = [{ title: 'id' }]
     const { container } = render(

--- a/components/FormCard.test.js
+++ b/components/FormCard.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { FormCard } from './FormCard'
-
+import '@testing-library/jest-dom'
 let testBtnOnClick = ''
 
 const mockBtn = {
@@ -98,7 +98,7 @@ describe('FormCard Component', () => {
         onSubmit={mockBtn}
       />
     )
-    expect(queryByText(mockError)).toBeTruthy()
+    expect(queryByText(mockError)).toBeVisible()
   })
 
   test('Should render nothing if id is a title', () => {

--- a/components/FormCard.tsx
+++ b/components/FormCard.tsx
@@ -26,6 +26,7 @@ type Btn = {
 type FormCardProps = {
   values: Option[]
   onSubmit: Btn
+  submitError?: string
   capitalizeTitle?: boolean
   onChange: Function
   title?: string
@@ -95,6 +96,7 @@ const OptionInfo: React.FC<OptionInfoProps> = ({
 export const FormCard: React.FC<FormCardProps> = ({
   values,
   onSubmit,
+  submitError,
   capitalizeTitle = true,
   title,
   onChange,
@@ -121,6 +123,7 @@ export const FormCard: React.FC<FormCardProps> = ({
           )}
         </div>
         <div className="text-left">{optionsList}</div>
+        {submitError && <h6 className="text-danger">{submitError}</h6>}
         <div className="text-center mb-4">
           <Button onClick={btnOnClick} type="primary" color="white">
             {onSubmit.title}

--- a/components/LessonCard.test.js
+++ b/components/LessonCard.test.js
@@ -6,12 +6,18 @@ import { render } from '@testing-library/react'
 import { SubmissionStatus } from '../graphql'
 
 describe('Lesson Card Complete State', () => {
+  const props = {
+    challengesUrl: 'challengeUrl',
+    reviewUrl: 'reviewUrl'
+  }
   test('Should render lessonCard with null if no data', async () => {
     useQuery.mockReturnValue({
       data: null
     })
 
-    const { container } = render(<LessonCard currentState="completed" />)
+    const { container } = render(
+      <LessonCard {...props} currentState="completed" />
+    )
     expect(container).toMatchSnapshot()
   })
   test('Should render lessonCard with loading...', async () => {
@@ -19,7 +25,9 @@ describe('Lesson Card Complete State', () => {
       loading: true
     })
 
-    const { container } = render(<LessonCard currentState="completed" />)
+    const { container } = render(
+      <LessonCard {...props} currentState="completed" />
+    )
     expect(container).toMatchSnapshot()
   })
   test('Should render lessonCard with submission count', async () => {
@@ -39,18 +47,24 @@ describe('Lesson Card Complete State', () => {
       }
     })
 
-    const { container } = render(<LessonCard currentState="completed" />)
+    const { container } = render(
+      <LessonCard {...props} currentState="completed" />
+    )
     expect(container).toMatchSnapshot()
   })
 })
 
 describe('Lesson Card', () => {
+  const props = {
+    challengesUrl: 'challengeUrl',
+    reviewUrl: 'reviewUrl'
+  }
   test('Should render loading card when loading', async () => {
     useQuery.mockReturnValue({
       loading: true
     })
 
-    const { container } = render(<LessonCard />)
+    const { container } = render(<LessonCard {...props} />)
     expect(container).toMatchSnapshot()
   })
   test('Should render ellpsis when no data is present', async () => {
@@ -58,7 +72,7 @@ describe('Lesson Card', () => {
       loading: false
     })
 
-    const { container } = render(<LessonCard />)
+    const { container } = render(<LessonCard {...props} />)
     expect(container).toMatchSnapshot()
   })
   test('Should render lessonCard with no submission count', async () => {
@@ -68,15 +82,17 @@ describe('Lesson Card', () => {
       }
     })
 
-    const { container } = render(<LessonCard />)
+    const { container } = render(<LessonCard {...props} />)
     expect(container).toMatchSnapshot()
   })
   test('Should render lessonCard with inProgress currentState prop', async () => {
-    const { container } = render(<LessonCard currentState="inProgress" />)
+    const { container } = render(
+      <LessonCard {...props} currentState="inProgress" />
+    )
     expect(container).toMatchSnapshot()
   })
   test('Should render lessonCard with lessonId prop', async () => {
-    const { container } = render(<LessonCard lessonId={4} />)
+    const { container } = render(<LessonCard {...props} lessonId={4} />)
     expect(container).toMatchSnapshot()
   })
 })

--- a/components/LessonCard.tsx
+++ b/components/LessonCard.tsx
@@ -11,11 +11,13 @@ import NavLink from './NavLink'
 import Image from 'next/image'
 import styles from '../scss/lessonCard.module.scss'
 import { SubmissionStatus } from '../graphql'
+import Link from 'next/link'
 
 const ReviewCount: React.FC<ReviewCountProps> = props => {
   const { loading, data } = useQuery(GET_SUBMISSIONS, {
     variables: { lessonId: props.lessonId },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'cache-first'
   })
 
   if (loading) {
@@ -47,10 +49,13 @@ const ReviewButton: React.FC<ReviewButtonProps> = props => {
   if (!props.isCompleted) {
     return null
   }
+
   return (
-    <a href={props.reviewUrl} className={style}>
-      Review <ReviewCount lessonId={props.lessonId} /> Submissions
-    </a>
+    <Link href={props.reviewUrl}>
+      <a className={style}>
+        Review <ReviewCount lessonId={props.lessonId} /> Submissions
+      </a>
+    </Link>
   )
 }
 
@@ -64,12 +69,7 @@ const LessonCard: React.FC<Props> = props => {
       <h4 className={`${styles['lesson-card__title']} font-weight-bold mt-3 `}>
         <div className="d-flex justify-content-center">
           <div className="align-self-center">
-            <NavLink
-              as={`/curriculum/${props.lessonId}`}
-              path="/curriculum/[lesson]"
-            >
-              {props.title}
-            </NavLink>
+            <NavLink path={props.challengesUrl}>{props.title}</NavLink>
           </div>
           {props.currentState === 'completed' && (
             <span
@@ -130,12 +130,7 @@ const LessonCard: React.FC<Props> = props => {
           <h4
             className={`${styles['lesson-card__title']} font-weight-bold mt-3`}
           >
-            <NavLink
-              as={`/curriculum/${props.lessonId}`}
-              path="/curriculum/[lesson]"
-            >
-              {props.title}
-            </NavLink>
+            <NavLink path={props.challengesUrl}>{props.title}</NavLink>
           </h4>
           {props.currentState === 'completed' && (
             <span

--- a/components/LessonTitleCard.test.js
+++ b/components/LessonTitleCard.test.js
@@ -1,59 +1,48 @@
 import React from 'react'
 import LessonTitleCard from './LessonTitleCard'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useRouter } from 'next/router'
 
 describe('LessonTitleCard Component', () => {
-  const props = {
-    lessonCoverUrl: 'coverUrl',
-    lessonUrl: 'lessonUrl',
-    lessonTitle: 'Test Lesson',
-    lessonId: '0',
-    isPassed: true
-  }
-
-  test('Go back should call router.back()', async () => {
-    const { back } = useRouter()
-    const { container } = render(<LessonTitleCard {...props} />)
-    await waitFor(() => fireEvent.click(screen.getByText('Go Back')))
-    expect(back).toHaveBeenCalled()
-    expect(container).toMatchSnapshot()
-  })
-})
-
-describe('LessonTitleCard component on Curriculum Page', () => {
   const setShow = jest.fn()
   const props = {
     lessonCoverUrl: 'coverUrl',
     lessonUrl: 'lessonUrl',
     lessonTitle: 'Test Lesson',
     lessonId: '0',
-    isPassed: true,
-    setShow,
-    show: false
+    lessonSlug: 'js0',
+    isPassed: true
   }
-  test('Should show challenges on click on mobile devices', async () => {
-    global.window.innerWidth = 500
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('Go back should call router.back()', async () => {
+    const { back } = useRouter()
     const { container } = render(<LessonTitleCard {...props} />)
-    await waitFor(() => fireEvent.click(screen.getByText('SHOW CHALLENGES')))
+    expect(back).not.toHaveBeenCalled()
+    userEvent.click(screen.getByText('Go Back'))
+    expect(back).toHaveBeenCalled()
+  })
+
+  test('should display "show challenges" button on small screens and call "setShow" when clicked', async () => {
+    global.window.innerWidth = 500
+    const { container } = render(
+      <LessonTitleCard {...props} setShow={setShow} show={false} />
+    )
+    userEvent.click(screen.getByText('SHOW CHALLENGES'))
     expect(setShow).toBeCalledWith(true)
     expect(container).toMatchSnapshot()
   })
-  test('Should render default layout for wider screens', async () => {
+
+  test('should display "challenges" button on wider screens', async () => {
     global.window.innerWidth = 1080
-    const { container } = render(<LessonTitleCard {...props} />)
+    const { container } = render(
+      <LessonTitleCard {...props} setShow={setShow} show={false} />
+    )
     expect(container).toMatchSnapshot()
   })
-})
-
-describe('LessonTitleCard component on Review Page', () => {
-  const props = {
-    lessonCoverUrl: 'coverUrl',
-    lessonUrl: 'lessonUrl',
-    lessonTitle: 'Test Lesson',
-    lessonId: '0',
-    isPassed: true
-  }
 
   test('Renders default layout', async () => {
     let { container } = render(<LessonTitleCard {...props} />)

--- a/components/LessonTitleCard.tsx
+++ b/components/LessonTitleCard.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 import NavLink from './NavLink'
 import styles from '../scss/lessonTitleCard.module.scss'
 import { useRouter } from 'next/router'
+import useHasMounted from '../helpers/useHasMounted'
 
 export type LessonTitleProps = {
   lessonCoverUrl: string
   lessonUrl: string
+  lessonSlug: string
   lessonTitle: string
   lessonId: number
   isPassed: boolean
@@ -14,6 +16,7 @@ export type LessonTitleProps = {
 }
 
 const LessonTitleCard: React.FC<LessonTitleProps> = props => {
+  const hasMounted = useHasMounted()
   const router = useRouter()
 
   return (
@@ -53,9 +56,7 @@ const LessonTitleCard: React.FC<LessonTitleProps> = props => {
             LESSON
           </NavLink>
           {/* 768 px is md bootstrap breakpoint */}
-          {typeof window !== 'undefined' &&
-          window.innerWidth <= 768 &&
-          props.setShow ? (
+          {hasMounted && window.innerWidth <= 768 && props.setShow ? (
             <div
               onClick={() => props.setShow!(!props.show)}
               className="btn border-right rounded-0 px-4 py-3"
@@ -64,7 +65,7 @@ const LessonTitleCard: React.FC<LessonTitleProps> = props => {
             </div>
           ) : (
             <NavLink
-              path={`/curriculum/${props.lessonId}`}
+              path={`/curriculum/${props.lessonSlug}`}
               className="btn border-right rounded-0 px-4 py-3"
             >
               CHALLENGES
@@ -72,7 +73,7 @@ const LessonTitleCard: React.FC<LessonTitleProps> = props => {
           )}
           {props.isPassed && (
             <NavLink
-              path={`/review/${props.lessonId}`}
+              path={`/review/${props.lessonSlug}`}
               className="btn border-right rounded-0 px-4 py-3"
             >
               REVIEW

--- a/components/__snapshots__/LessonCard.test.js.snap
+++ b/components/__snapshots__/LessonCard.test.js.snap
@@ -19,7 +19,7 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </div>
           <span
@@ -79,6 +79,7 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
       />
       <a
         class="btn btn-sm bg-primary text-white float-right mb-2 mr-2mr-0"
+        href="/reviewUrl"
       >
         Review 
         <div
@@ -108,7 +109,7 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </h4>
           <span
@@ -162,6 +163,7 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
         </div>
         <a
           class="btn btn-sm bg-primary text-white float-right mb-2 mr-2"
+          href="/reviewUrl"
         >
           Review 
           <div
@@ -195,7 +197,7 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </div>
           <span
@@ -255,6 +257,7 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
       />
       <a
         class="btn btn-sm bg-primary text-white float-right mb-2 mr-2mr-0"
+        href="/reviewUrl"
       >
         Review 
         <span>
@@ -283,7 +286,7 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </h4>
           <span
@@ -337,6 +340,7 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
         </div>
         <a
           class="btn btn-sm bg-primary text-white float-right mb-2 mr-2"
+          href="/reviewUrl"
         >
           Review 
           <span>
@@ -369,7 +373,7 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </div>
           <span
@@ -429,6 +433,7 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
       />
       <a
         class="btn btn-sm bg-primary text-white float-right mb-2 mr-2mr-0"
+        href="/reviewUrl"
       >
         Review 
         <span>
@@ -457,7 +462,7 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </h4>
           <span
@@ -511,6 +516,7 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
         </div>
         <a
           class="btn btn-sm bg-primary text-white float-right mb-2 mr-2"
+          href="/reviewUrl"
         >
           Review 
           <span>
@@ -543,7 +549,7 @@ exports[`Lesson Card Should render ellpsis when no data is present 1`] = `
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </div>
         </div>
@@ -595,7 +601,7 @@ exports[`Lesson Card Should render ellpsis when no data is present 1`] = `
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </h4>
         </div>
@@ -645,7 +651,7 @@ exports[`Lesson Card Should render lessonCard with inProgress currentState prop 
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </div>
         </div>
@@ -697,7 +703,7 @@ exports[`Lesson Card Should render lessonCard with inProgress currentState prop 
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </h4>
         </div>
@@ -726,7 +732,14 @@ exports[`Lesson Card Should render lessonCard with inProgress currentState prop 
     </div>
     <div
       class="p-2 bg-primary"
-    />
+    >
+      <a
+        class="lesson-card__button btn bg-primary my-1 text-white border border-white"
+        href="/challengeUrl"
+      >
+        View Challenges
+      </a>
+    </div>
   </div>
 </div>
 `;
@@ -750,7 +763,7 @@ exports[`Lesson Card Should render lessonCard with lessonId prop 1`] = `
           >
             <a
               class=""
-              href="/curriculum/4"
+              href="/challengeUrl"
             />
           </div>
         </div>
@@ -802,7 +815,7 @@ exports[`Lesson Card Should render lessonCard with lessonId prop 1`] = `
           >
             <a
               class=""
-              href="/curriculum/4"
+              href="/challengeUrl"
             />
           </h4>
         </div>
@@ -852,7 +865,7 @@ exports[`Lesson Card Should render lessonCard with no submission count 1`] = `
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </div>
         </div>
@@ -904,7 +917,7 @@ exports[`Lesson Card Should render lessonCard with no submission count 1`] = `
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </h4>
         </div>
@@ -954,7 +967,7 @@ exports[`Lesson Card Should render loading card when loading 1`] = `
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </div>
         </div>
@@ -1006,7 +1019,7 @@ exports[`Lesson Card Should render loading card when loading 1`] = `
           >
             <a
               class=""
-              href="/curriculum/undefined"
+              href="/challengeUrl"
             />
           </h4>
         </div>

--- a/components/__snapshots__/LessonTitleCard.test.js.snap
+++ b/components/__snapshots__/LessonTitleCard.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LessonTitleCard Component Go back should call router.back() 1`] = `
+exports[`LessonTitleCard Component Renders default layout 1`] = `
 <div>
   <div
     class="card shadow-sm mt-3 col-12 px-0 pt-3 border-0"
@@ -46,13 +46,13 @@ exports[`LessonTitleCard Component Go back should call router.back() 1`] = `
         </a>
         <a
           class="btn border-right rounded-0 px-4 py-3"
-          href="/curriculum/0"
+          href="/curriculum/js0"
         >
           CHALLENGES
         </a>
         <a
           class="btn border-right rounded-0 px-4 py-3"
-          href="/review/0"
+          href="/review/js0"
         >
           REVIEW
         </a>
@@ -62,7 +62,7 @@ exports[`LessonTitleCard Component Go back should call router.back() 1`] = `
 </div>
 `;
 
-exports[`LessonTitleCard component on Curriculum Page Should render default layout for wider screens 1`] = `
+exports[`LessonTitleCard Component should display "challenges" button on wider screens with "setShow" prop 1`] = `
 <div>
   <div
     class="card shadow-sm mt-3 col-12 px-0 pt-3 border-0"
@@ -108,13 +108,13 @@ exports[`LessonTitleCard component on Curriculum Page Should render default layo
         </a>
         <a
           class="btn border-right rounded-0 px-4 py-3"
-          href="/curriculum/0"
+          href="/curriculum/js0"
         >
           CHALLENGES
         </a>
         <a
           class="btn border-right rounded-0 px-4 py-3"
-          href="/review/0"
+          href="/review/js0"
         >
           REVIEW
         </a>
@@ -124,7 +124,7 @@ exports[`LessonTitleCard component on Curriculum Page Should render default layo
 </div>
 `;
 
-exports[`LessonTitleCard component on Curriculum Page Should show challenges on click on mobile devices 1`] = `
+exports[`LessonTitleCard Component should display "show challenges" button on small screens with "setShow" prop 1`] = `
 <div>
   <div
     class="card shadow-sm mt-3 col-12 px-0 pt-3 border-0"
@@ -175,69 +175,7 @@ exports[`LessonTitleCard component on Curriculum Page Should show challenges on 
         </div>
         <a
           class="btn border-right rounded-0 px-4 py-3"
-          href="/review/0"
-        >
-          REVIEW
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`LessonTitleCard component on Review Page Renders default layout 1`] = `
-<div>
-  <div
-    class="card shadow-sm mt-3 col-12 px-0 pt-3 border-0"
-  >
-    <div
-      class="card-body p-0"
-    >
-      <div
-        class="d-flex mb-3 px-3"
-      >
-        <img
-          alt="lesson-cover"
-          class="lessonTitleCard__lesson-cover mr-3"
-          src="/assets/curriculum/coverUrl"
-        />
-        <div>
-          <p
-            class="m-0"
-          >
-            <a
-              href="#"
-            >
-              Go Back
-            </a>
-          </p>
-          <h1
-            class="lessonTitleCard__lesson-title"
-          >
-            Test Lesson
-          </h1>
-        </div>
-      </div>
-      <div
-        class="card-footer bg-white p-0"
-      >
-        <a
-          class="btn border-right rounded-0 px-4 py-3"
-          href="lessonUrl"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          LESSON
-        </a>
-        <a
-          class="btn border-right rounded-0 px-4 py-3"
-          href="/curriculum/0"
-        >
-          CHALLENGES
-        </a>
-        <a
-          class="btn border-right rounded-0 px-4 py-3"
-          href="/review/0"
+          href="/review/js0"
         >
           REVIEW
         </a>

--- a/components/__snapshots__/LessonTitleCard.test.js.snap
+++ b/components/__snapshots__/LessonTitleCard.test.js.snap
@@ -62,7 +62,7 @@ exports[`LessonTitleCard Component Renders default layout 1`] = `
 </div>
 `;
 
-exports[`LessonTitleCard Component should display "challenges" button on wider screens with "setShow" prop 1`] = `
+exports[`LessonTitleCard Component should display "challenges" button on wider screens 1`] = `
 <div>
   <div
     class="card shadow-sm mt-3 col-12 px-0 pt-3 border-0"
@@ -124,7 +124,7 @@ exports[`LessonTitleCard Component should display "challenges" button on wider s
 </div>
 `;
 
-exports[`LessonTitleCard Component should display "show challenges" button on small screens with "setShow" prop 1`] = `
+exports[`LessonTitleCard Component should display "show challenges" button on small screens and call "setShow" when clicked 1`] = `
 <div>
   <div
     class="card shadow-sm mt-3 col-12 px-0 pt-3 border-0"

--- a/components/admin/lessons/AdminLessonChallenges.tsx
+++ b/components/admin/lessons/AdminLessonChallenges.tsx
@@ -10,7 +10,7 @@ import {
   makeGraphqlVariable,
   errorCheckAllFields
 } from '../../../helpers/admin/adminHelpers'
-import { lessonSchema } from '../../../helpers/formValidation'
+import { challengeSchema } from '../../../helpers/formValidation'
 import { formChange } from '../../../helpers/formChange'
 
 const challengeAttributes = {
@@ -51,7 +51,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
   // alter gets called when someone clicks button to create a lesson
   const alter = async () => {
     const newProperties = [...challengeProperties]
-    const valid = await errorCheckAllFields(newProperties, lessonSchema)
+    const valid = await errorCheckAllFields(newProperties, challengeSchema)
     if (!valid) {
       setChallengeProperties(newProperties)
       return
@@ -74,7 +74,7 @@ export const NewChallenge: React.FC<NewChallengeProps> = ({
       propertyIndex,
       challengeProperties,
       setChallengeProperties,
-      lessonSchema
+      challengeSchema
     )
   }
 
@@ -109,7 +109,7 @@ const LessonChallenge: React.FC<LessonChallengeProps> = ({
       propertyIndex,
       challengeProperties,
       setChallengeProperties,
-      lessonSchema
+      challengeSchema
     )
   }
 
@@ -117,7 +117,7 @@ const LessonChallenge: React.FC<LessonChallengeProps> = ({
     title: 'Update Challenge',
     onClick: async () => {
       const newProperties = [...challengeProperties]
-      const valid = await errorCheckAllFields(newProperties, lessonSchema)
+      const valid = await errorCheckAllFields(newProperties, challengeSchema)
       if (!valid) {
         setChallengeProperties(newProperties)
         return

--- a/components/admin/lessons/AdminLessonInfo.test.js
+++ b/components/admin/lessons/AdminLessonInfo.test.js
@@ -22,6 +22,7 @@ const updateLessonMock = {
       videoUrl:
         'https://www.youtube.com/watch?v=H-eqRQo8KoI&list=PLKmS5c0UNZmewGBWlz0l9GZwh3bV8Rlc7&index=1',
       order: 10,
+      slug: 'js0',
       chatUrl: 'https://chat.c0d3.com/c0d3/channels/js1-variablesfunction'
     }
   },

--- a/components/admin/lessons/AdminLessonInfo.test.js
+++ b/components/admin/lessons/AdminLessonInfo.test.js
@@ -39,6 +39,7 @@ const createLessonMock = {
       githubUrl: '',
       videoUrl: '',
       order: 12,
+      slug: 'js12',
       chatUrl: ''
     }
   },
@@ -79,6 +80,8 @@ describe('AdminLessonsInfo component', () => {
     )
     //new lesson order
     await userEvent.type(screen.getByTestId('input5'), '12', { delay: 1 })
+    //new lesson slug
+    await userEvent.type(screen.getByTestId('input6'), 'js12', { delay: 1 })
     await waitFor(() =>
       userEvent.click(screen.getByRole('button', { name: 'Create Lesson' }))
     )
@@ -185,6 +188,7 @@ describe('AdminLessonsInfo component', () => {
       { delay: 1 }
     )
     await userEvent.type(screen.getByTestId('input5'), '12', { delay: 1 })
+    await userEvent.type(screen.getByTestId('input6'), 'js12', { delay: 1 })
     await waitFor(() =>
       userEvent.click(screen.getByRole('button', { name: 'Create Lesson' }))
     )

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -90,6 +90,7 @@ const newLessonAttributes = {
   githubUrl: '',
   videoUrl: '',
   order: '',
+  slug: '',
   chatUrl: ''
 }
 

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -32,7 +32,7 @@ type NewLessonProps = {
 
 // Creates card for a lessons's information to update
 const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
-  const [alterLesson, { loading, data }] = useMutation(updateLesson)
+  const [alterLesson, { loading, data, error }] = useMutation(updateLesson)
   const [lessonProperties, setLessonProperties] = useState(
     getPropertyArr(lesson, ['challenges', '__typename'])
   )
@@ -75,6 +75,7 @@ const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
         <FormCard
           onChange={handleChange}
           values={lessonProperties}
+          submitError={error?.message}
           onSubmit={{ title: 'Update Lesson', onClick: alter }}
           title={lesson && lesson.title + ''}
         />
@@ -96,7 +97,7 @@ const newLessonAttributes = {
 
 // Renders when someone clicks on `create new button` on the sidebar
 const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
-  const [createLesson, { loading, data }] = useMutation(createNewLesson)
+  const [createLesson, { loading, data, error }] = useMutation(createNewLesson)
   const [lessonProperties, setLessonProperties] = useState(
     getPropertyArr(newLessonAttributes)
   )
@@ -142,6 +143,7 @@ const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
       <FormCard
         onChange={handleChange}
         values={lessonProperties}
+        submitError={error?.message}
         onSubmit={{ title: 'Create Lesson', onClick: alter }}
       />
     </div>

--- a/components/admin/lessons/AdminLessonInfo.tsx
+++ b/components/admin/lessons/AdminLessonInfo.tsx
@@ -1,7 +1,4 @@
-import { useMutation } from '@apollo/client'
 import React, { useEffect, useState } from 'react'
-import createNewLesson from '../../../graphql/queries/createLesson'
-import updateLesson from '../../../graphql/queries/updateLesson'
 import * as Sentry from '@sentry/browser'
 import { FormCard } from '../../FormCard'
 import _ from 'lodash'
@@ -10,7 +7,11 @@ import {
   makeGraphqlVariable,
   errorCheckAllFields
 } from '../../../helpers/admin/adminHelpers'
-import { Lesson } from '../../../graphql/index'
+import {
+  Lesson,
+  useCreateLessonMutation,
+  useUpdateLessonMutation
+} from '../../../graphql/index'
 import { AdminLessonChallenges, NewChallenge } from './AdminLessonChallenges'
 import { lessonSchema } from '../../../helpers/formValidation'
 import { formChange } from '../../../helpers/formChange'
@@ -32,13 +33,13 @@ type NewLessonProps = {
 
 // Creates card for a lessons's information to update
 const EditLesson: React.FC<EditLessonProps> = ({ setLessons, lesson }) => {
-  const [alterLesson, { loading, data, error }] = useMutation(updateLesson)
+  const [alterLesson, { loading, data, error }] = useUpdateLessonMutation()
   const [lessonProperties, setLessonProperties] = useState(
     getPropertyArr(lesson, ['challenges', '__typename'])
   )
   // when data is fully loaded after sending mutation request, update front-end lessons info
   useEffect(() => {
-    !loading && data && setLessons(data.updateLessons)
+    !loading && data && setLessons(data.updateLesson)
   }, [data])
 
   // alter gets called when someone clicks button to update a lesson
@@ -97,7 +98,7 @@ const newLessonAttributes = {
 
 // Renders when someone clicks on `create new button` on the sidebar
 const NewLesson: React.FC<NewLessonProps> = ({ setLessons }) => {
-  const [createLesson, { loading, data, error }] = useMutation(createNewLesson)
+  const [createLesson, { loading, data, error }] = useCreateLessonMutation()
   const [lessonProperties, setLessonProperties] = useState(
     getPropertyArr(newLessonAttributes)
   )

--- a/components/admin/lessons/AdminLessonsSideBar.tsx
+++ b/components/admin/lessons/AdminLessonsSideBar.tsx
@@ -21,6 +21,7 @@ export const AdminLessonsSideBar: React.FC<SideBarLessonProps> = ({
       title: 'Create New Lesson',
       description: '',
       order: -1,
+      slug: '',
       challenges: []
     })
   }
@@ -33,6 +34,7 @@ export const AdminLessonsSideBar: React.FC<SideBarLessonProps> = ({
       title: 'Create New Lesson',
       description: '',
       order: -1,
+      slug: '',
       challenges: []
     })
   }

--- a/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
+++ b/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
@@ -140,13 +140,29 @@ exports[`AdminLessonsInfo component Should create new lesson 1`] = `
             class="d-flex flex-column ml-3 mr-3 mb-4"
           >
             <h5
-              data-testid="h5chatUrl6"
+              data-testid="h5slug6"
+            >
+              Slug
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input6"
+              placeholder=""
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5chatUrl7"
             >
               Chaturl
             </h5>
             <input
               class="form-control"
-              data-testid="input6"
+              data-testid="input7"
               placeholder=""
               type="text"
               value=""
@@ -312,13 +328,29 @@ exports[`AdminLessonsInfo component Should create new lesson 2`] = `
             class="d-flex flex-column ml-3 mr-3 mb-4"
           >
             <h5
-              data-testid="h5chatUrl6"
+              data-testid="h5slug6"
+            >
+              Slug
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input6"
+              placeholder=""
+              type="text"
+              value="js12"
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5chatUrl7"
             >
               Chaturl
             </h5>
             <input
               class="form-control"
-              data-testid="input6"
+              data-testid="input7"
               placeholder=""
               type="text"
               value=""
@@ -488,13 +520,29 @@ exports[`AdminLessonsInfo component Should render non-existent lesson 1`] = `
               class="d-flex flex-column ml-3 mr-3 mb-4"
             >
               <h5
-                data-testid="h5chatUrl7"
+                data-testid="h5slug7"
+              >
+                Slug
+              </h5>
+              <input
+                class="form-control"
+                data-testid="input7"
+                placeholder=""
+                type="text"
+                value="js0"
+              />
+            </div>
+            <div
+              class="d-flex flex-column ml-3 mr-3 mb-4"
+            >
+              <h5
+                data-testid="h5chatUrl8"
               >
                 Chaturl
               </h5>
               <input
                 class="form-control"
-                data-testid="input7"
+                data-testid="input8"
                 placeholder=""
                 type="text"
                 value="https://chat.c0d3.com/c0d3/channels/js1-variablesfunction"
@@ -1826,13 +1874,29 @@ exports[`AdminLessonsInfo component Should render undefined lessons 1`] = `
             class="d-flex flex-column ml-3 mr-3 mb-4"
           >
             <h5
-              data-testid="h5chatUrl6"
+              data-testid="h5slug6"
+            >
+              Slug
+            </h5>
+            <input
+              class="form-control"
+              data-testid="input6"
+              placeholder=""
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="d-flex flex-column ml-3 mr-3 mb-4"
+          >
+            <h5
+              data-testid="h5chatUrl7"
             >
               Chaturl
             </h5>
             <input
               class="form-control"
-              data-testid="input6"
+              data-testid="input7"
               placeholder=""
               type="text"
               value=""
@@ -2003,13 +2067,29 @@ exports[`AdminLessonsInfo component Should update lesson sucessfully 1`] = `
               class="d-flex flex-column ml-3 mr-3 mb-4"
             >
               <h5
-                data-testid="h5chatUrl7"
+                data-testid="h5slug7"
+              >
+                Slug
+              </h5>
+              <input
+                class="form-control"
+                data-testid="input7"
+                placeholder=""
+                type="text"
+                value="js0"
+              />
+            </div>
+            <div
+              class="d-flex flex-column ml-3 mr-3 mb-4"
+            >
+              <h5
+                data-testid="h5chatUrl8"
               >
                 Chaturl
               </h5>
               <input
                 class="form-control"
-                data-testid="input7"
+                data-testid="input8"
                 placeholder=""
                 type="text"
                 value="https://chat.c0d3.com/c0d3/channels/js1-variablesfunction"

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -76,6 +76,7 @@ export type Lesson = {
   githubUrl?: Maybe<Scalars['String']>
   videoUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
   title: Scalars['String']
   challenges: Array<Challenge>
   users?: Maybe<Array<Maybe<User>>>
@@ -182,6 +183,7 @@ export type MutationCreateLessonArgs = {
   title: Scalars['String']
   chatUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
 }
 
 export type MutationUpdateLessonArgs = {
@@ -193,6 +195,7 @@ export type MutationUpdateLessonArgs = {
   title: Scalars['String']
   chatUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
 }
 
 export type MutationCreateChallengeArgs = {
@@ -443,6 +446,7 @@ export type CreateLessonMutationVariables = Exact<{
   videoUrl?: Maybe<Scalars['String']>
   chatUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
   description: Scalars['String']
   title: Scalars['String']
 }>
@@ -459,6 +463,7 @@ export type CreateLessonMutation = {
         videoUrl?: Maybe<string>
         chatUrl?: Maybe<string>
         order: number
+        slug: string
         description: string
         title: string
         challenges: Array<{
@@ -503,6 +508,7 @@ export type GetAppQuery = {
     githubUrl?: Maybe<string>
     videoUrl?: Maybe<string>
     order: number
+    slug: string
     chatUrl?: Maybe<string>
     challenges: Array<{
       __typename?: 'Challenge'
@@ -851,6 +857,7 @@ export type UpdateLessonMutationVariables = Exact<{
   videoUrl?: Maybe<Scalars['String']>
   chatUrl?: Maybe<Scalars['String']>
   order: Scalars['Int']
+  slug: Scalars['String']
   description: Scalars['String']
   title: Scalars['String']
 }>
@@ -867,6 +874,7 @@ export type UpdateLessonMutation = {
         videoUrl?: Maybe<string>
         chatUrl?: Maybe<string>
         order: number
+        slug: string
         description: string
         title: string
         challenges: Array<{
@@ -1190,6 +1198,7 @@ export type LessonResolvers<
   githubUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   videoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   order?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   challenges?: Resolver<
     Array<ResolversTypes['Challenge']>,
@@ -1297,7 +1306,10 @@ export type MutationResolvers<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
     ParentType,
     ContextType,
-    RequireFields<MutationCreateLessonArgs, 'description' | 'title' | 'order'>
+    RequireFields<
+      MutationCreateLessonArgs,
+      'description' | 'title' | 'order' | 'slug'
+    >
   >
   updateLesson?: Resolver<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
@@ -1305,7 +1317,7 @@ export type MutationResolvers<
     ContextType,
     RequireFields<
       MutationUpdateLessonArgs,
-      'id' | 'description' | 'title' | 'order'
+      'id' | 'description' | 'title' | 'order' | 'slug'
     >
   >
   createChallenge?: Resolver<
@@ -2063,6 +2075,7 @@ export const CreateLessonDocument = gql`
     $videoUrl: String
     $chatUrl: String
     $order: Int!
+    $slug: String!
     $description: String!
     $title: String!
   ) {
@@ -2072,6 +2085,7 @@ export const CreateLessonDocument = gql`
       videoUrl: $videoUrl
       chatUrl: $chatUrl
       order: $order
+      slug: $slug
       description: $description
       title: $title
     ) {
@@ -2081,6 +2095,7 @@ export const CreateLessonDocument = gql`
       videoUrl
       chatUrl
       order
+      slug
       description
       title
       challenges {
@@ -2148,6 +2163,7 @@ export function withCreateLesson<
  *      videoUrl: // value for 'videoUrl'
  *      chatUrl: // value for 'chatUrl'
  *      order: // value for 'order'
+ *      slug: // value for 'slug'
  *      description: // value for 'description'
  *      title: // value for 'title'
  *   },
@@ -2280,6 +2296,7 @@ export const GetAppDocument = gql`
       githubUrl
       videoUrl
       order
+      slug
       challenges {
         id
         title
@@ -3574,6 +3591,7 @@ export const UpdateLessonDocument = gql`
     $videoUrl: String
     $chatUrl: String
     $order: Int!
+    $slug: String!
     $description: String!
     $title: String!
   ) {
@@ -3584,6 +3602,7 @@ export const UpdateLessonDocument = gql`
       chatUrl: $chatUrl
       id: $id
       order: $order
+      slug: $slug
       description: $description
       title: $title
     ) {
@@ -3593,6 +3612,7 @@ export const UpdateLessonDocument = gql`
       videoUrl
       chatUrl
       order
+      slug
       description
       title
       challenges {
@@ -3661,6 +3681,7 @@ export function withUpdateLesson<
  *      videoUrl: // value for 'videoUrl'
  *      chatUrl: // value for 'chatUrl'
  *      order: // value for 'order'
+ *      slug: // value for 'slug'
  *      description: // value for 'description'
  *      title: // value for 'title'
  *   },

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -99,8 +99,8 @@ export type Mutation = {
   acceptSubmission?: Maybe<Submission>
   rejectSubmission?: Maybe<Submission>
   addComment?: Maybe<Comment>
-  createLesson?: Maybe<Array<Maybe<Lesson>>>
-  updateLesson?: Maybe<Array<Maybe<Lesson>>>
+  createLesson: Array<Lesson>
+  updateLesson: Array<Lesson>
   createChallenge?: Maybe<Array<Maybe<Lesson>>>
   updateChallenge?: Maybe<Array<Maybe<Lesson>>>
 }
@@ -453,30 +453,26 @@ export type CreateLessonMutationVariables = Exact<{
 
 export type CreateLessonMutation = {
   __typename?: 'Mutation'
-  createLesson?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: 'Lesson'
-        id: number
-        docUrl?: Maybe<string>
-        githubUrl?: Maybe<string>
-        videoUrl?: Maybe<string>
-        chatUrl?: Maybe<string>
-        order: number
-        slug: string
-        description: string
-        title: string
-        challenges: Array<{
-          __typename?: 'Challenge'
-          id: number
-          description: string
-          lessonId: number
-          title: string
-          order: number
-        }>
-      }>
-    >
-  >
+  createLesson: Array<{
+    __typename?: 'Lesson'
+    id: number
+    docUrl?: Maybe<string>
+    githubUrl?: Maybe<string>
+    videoUrl?: Maybe<string>
+    chatUrl?: Maybe<string>
+    order: number
+    slug: string
+    description: string
+    title: string
+    challenges: Array<{
+      __typename?: 'Challenge'
+      id: number
+      description: string
+      lessonId: number
+      title: string
+      order: number
+    }>
+  }>
 }
 
 export type CreateSubmissionMutationVariables = Exact<{
@@ -864,30 +860,26 @@ export type UpdateLessonMutationVariables = Exact<{
 
 export type UpdateLessonMutation = {
   __typename?: 'Mutation'
-  updateLesson?: Maybe<
-    Array<
-      Maybe<{
-        __typename?: 'Lesson'
-        id: number
-        docUrl?: Maybe<string>
-        githubUrl?: Maybe<string>
-        videoUrl?: Maybe<string>
-        chatUrl?: Maybe<string>
-        order: number
-        slug: string
-        description: string
-        title: string
-        challenges: Array<{
-          __typename?: 'Challenge'
-          id: number
-          description: string
-          lessonId: number
-          title: string
-          order: number
-        }>
-      }>
-    >
-  >
+  updateLesson: Array<{
+    __typename?: 'Lesson'
+    id: number
+    docUrl?: Maybe<string>
+    githubUrl?: Maybe<string>
+    videoUrl?: Maybe<string>
+    chatUrl?: Maybe<string>
+    order: number
+    slug: string
+    description: string
+    title: string
+    challenges: Array<{
+      __typename?: 'Challenge'
+      id: number
+      description: string
+      lessonId: number
+      title: string
+      order: number
+    }>
+  }>
 }
 
 export type ChangePwMutationVariables = Exact<{
@@ -1303,7 +1295,7 @@ export type MutationResolvers<
     RequireFields<MutationAddCommentArgs, 'submissionId' | 'content'>
   >
   createLesson?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    Array<ResolversTypes['Lesson']>,
     ParentType,
     ContextType,
     RequireFields<
@@ -1312,7 +1304,7 @@ export type MutationResolvers<
     >
   >
   updateLesson?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
+    Array<ResolversTypes['Lesson']>,
     ParentType,
     ContextType,
     RequireFields<

--- a/graphql/queries/createLesson.ts
+++ b/graphql/queries/createLesson.ts
@@ -7,6 +7,7 @@ const CREATE_LESSON = gql`
     $videoUrl: String
     $chatUrl: String
     $order: Int!
+    $slug: String!
     $description: String!
     $title: String!
   ) {
@@ -16,6 +17,7 @@ const CREATE_LESSON = gql`
       videoUrl: $videoUrl
       chatUrl: $chatUrl
       order: $order
+      slug: $slug
       description: $description
       title: $title
     ) {
@@ -25,6 +27,7 @@ const CREATE_LESSON = gql`
       videoUrl
       chatUrl
       order
+      slug
       description
       title
       challenges {

--- a/graphql/queries/getApp.ts
+++ b/graphql/queries/getApp.ts
@@ -10,6 +10,7 @@ const GET_APP = gql`
       githubUrl
       videoUrl
       order
+      slug
       challenges {
         id
         title

--- a/graphql/queries/updateLesson.ts
+++ b/graphql/queries/updateLesson.ts
@@ -8,6 +8,7 @@ const UPDATE_LESSON = gql`
     $videoUrl: String
     $chatUrl: String
     $order: Int!
+    $slug: String!
     $description: String!
     $title: String!
   ) {
@@ -18,6 +19,7 @@ const UPDATE_LESSON = gql`
       chatUrl: $chatUrl
       id: $id
       order: $order
+      slug: $slug
       description: $description
       title: $title
     ) {
@@ -27,6 +29,7 @@ const UPDATE_LESSON = gql`
       videoUrl
       chatUrl
       order
+      slug
       description
       title
       challenges {

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -61,6 +61,7 @@ export default gql`
       title: String!
       chatUrl: String
       order: Int!
+      slug: String!
     ): [Lesson]
     updateLesson(
       id: Int!
@@ -71,6 +72,7 @@ export default gql`
       title: String!
       chatUrl: String
       order: Int!
+      slug: String!
     ): [Lesson]
     createChallenge(
       lessonId: Int!
@@ -169,6 +171,7 @@ export default gql`
     githubUrl: String
     videoUrl: String
     order: Int!
+    slug: String!
     title: String!
     challenges: [Challenge!]!
     users: [User]

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -62,7 +62,7 @@ export default gql`
       chatUrl: String
       order: Int!
       slug: String!
-    ): [Lesson]
+    ): [Lesson!]!
     updateLesson(
       id: Int!
       description: String!
@@ -73,7 +73,7 @@ export default gql`
       chatUrl: String
       order: Int!
       slug: String!
-    ): [Lesson]
+    ): [Lesson!]!
     createChallenge(
       lessonId: Int!
       order: Int!

--- a/helpers/formValidation.tsx
+++ b/helpers/formValidation.tsx
@@ -15,11 +15,16 @@ const alertValidation = Yup.object({
 const lessonSchema = Yup.object({
   title: Yup.string().required('Required').strict(true),
   description: Yup.string().required('Required').strict(true),
+  docUrl: Yup.string(),
+  githubUrl: Yup.string(),
+  videoUrl: Yup.string(),
   order: Yup.number()
     .required('Required')
     .typeError('Numbers only')
     .min(0, 'Positive numbers only')
-    .strict(true)
+    .strict(true),
+  slug: Yup.string().required('Required').strict(true),
+  chatUrl: Yup.string()
 })
 
 const signupValidation = Yup.object({

--- a/helpers/formValidation.tsx
+++ b/helpers/formValidation.tsx
@@ -12,6 +12,16 @@ const alertValidation = Yup.object({
   urlCaption: Yup.string()
 })
 
+const challengeSchema = Yup.object({
+  title: Yup.string().required('Required').strict(true),
+  description: Yup.string().required('Required').strict(true),
+  order: Yup.number()
+    .required('Required')
+    .typeError('Numbers only')
+    .min(0, 'Positive numbers only')
+    .strict(true)
+})
+
 const lessonSchema = Yup.object({
   title: Yup.string().required('Required').strict(true),
   description: Yup.string().required('Required').strict(true),
@@ -93,6 +103,7 @@ const resetPasswordValidation = Yup.object({
 
 export {
   alertValidation,
+  challengeSchema,
   lessonSchema,
   signupValidation,
   loginValidation,

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -139,7 +139,7 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
   }, [data])
   const lessonStatusMap = generateMap(state.session)
   const lessonsToRender: React.ReactElement[] = lessons.map((lesson, idx) => {
-    const { id, title, description, challenges, docUrl } = lesson
+    const { id, title, description, challenges, docUrl, slug } = lesson
     const status = lessonStatusMap[id]
     const passed = Boolean(status?.passedAt)
     let lessonState = ''
@@ -155,8 +155,8 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
         challengeCount={challenges.length}
         description={description}
         currentState={lessonState}
-        reviewUrl={`/review/${id}`}
-        challengesUrl={`/curriculum/${id}`}
+        reviewUrl={`/review/${slug}`}
+        challengesUrl={`/curriculum/${slug}`}
         docUrl={docUrl ?? ''}
       />
     )

--- a/pages/curriculum/[lesson].tsx
+++ b/pages/curriculum/[lesson].tsx
@@ -29,11 +29,11 @@ const Challenges: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
   const router = useRouter()
   if (!router.isReady) return <LoadingSpinner />
 
-  const currentlessonId = Number(router.query.lesson)
+  const slug = router.query.lesson as string
   if (!lessons || !alerts)
     return <Error code={StatusCode.INTERNAL_SERVER_ERROR} message="Bad data" />
 
-  const currentLesson = lessons.find(lesson => lesson.id === currentlessonId)
+  const currentLesson = lessons.find(lesson => lesson.slug === slug)
   if (!currentLesson)
     return <Error code={StatusCode.NOT_FOUND} message="Lesson not found" />
 
@@ -46,10 +46,10 @@ const Challenges: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
   ) as UserLesson[]
 
   const currentLessonStatus =
-    lessonStatus.find(userLesson => userLesson.lessonId === currentlessonId) ||
+    lessonStatus.find(userLesson => userLesson.lessonId === currentLesson.id) ||
     ({
       passedAt: null,
-      lessonId: currentlessonId
+      lessonId: currentLesson.id
     } as UserLesson)
   return (
     <div>
@@ -61,7 +61,8 @@ const Challenges: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
                 lessonCoverUrl={`js-${currentLesson.order}-cover.svg`}
                 lessonUrl={currentLesson.docUrl!}
                 lessonTitle={currentLesson.title}
-                lessonId={currentlessonId}
+                lessonId={currentLesson.id}
+                lessonSlug={slug}
                 isPassed={Boolean(currentLessonStatus.passedAt)}
                 setShow={setShow}
                 show={show}

--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -43,12 +43,13 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
     variables: { lessonId: currentLesson?.id },
     skip: !currentLesson
   })
-  if (!currentLesson) {
-    return <Error code={StatusCode.NOT_FOUND} message="Page not found" />
-  }
   if (loading) {
     return <LoadingSpinner />
   }
+  if (!currentLesson) {
+    return <Error code={StatusCode.NOT_FOUND} message="Page not found" />
+  }
+
   if (!session?.user) {
     router.push({
       pathname: '/login',
@@ -95,7 +96,8 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
 
 export default withQueryLoader<GetAppQuery>(
   {
-    query: GET_APP
+    query: GET_APP,
+    getParams: () => ({ ssr: false })
   },
   Review
 )

--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -34,13 +34,18 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
   const { lessons, session } = queryData
   const router = useRouter()
   const context = useContext(GlobalContext)
-  const currentlessonId = Number(router.query.lesson)
+  const slug = router.query.lesson as string
+  const currentLesson = lessons.find(lesson => lesson.slug === slug)
   useEffect(() => {
     session && context.setContext(session)
   }, [session])
   const { loading, data } = useQuery(GET_SUBMISSIONS, {
-    variables: { lessonId: currentlessonId }
+    variables: { lessonId: currentLesson?.id },
+    skip: !currentLesson
   })
+  if (!currentLesson) {
+    return <Error code={StatusCode.NOT_FOUND} message="Page not found" />
+  }
   if (loading) {
     return <LoadingSpinner />
   }
@@ -51,10 +56,7 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
     })
     return <LoadingSpinner />
   }
-  const currentLesson = lessons.find(lesson => lesson.id === currentlessonId)
-  if (!currentLesson) {
-    return <Error code={StatusCode.NOT_FOUND} message="Page not found" />
-  }
+
   if (
     !session.lessonStatus.find(
       status => status.lessonId === currentLesson.id && status.passedAt
@@ -78,7 +80,8 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
             lessonCoverUrl={`js-${currentLesson.order}-cover.svg`}
             lessonUrl={currentLesson.docUrl!}
             lessonTitle={currentLesson.title!}
-            lessonId={currentlessonId}
+            lessonId={currentLesson.id}
+            lessonSlug={slug}
             isPassed={true}
           />
           {currentLesson && (

--- a/prisma/migrations/20210816200009_lesson_slug/migration.sql
+++ b/prisma/migrations/20210816200009_lesson_slug/migration.sql
@@ -1,0 +1,12 @@
+-- Create slug field
+ALTER TABLE "lessons" ADD COLUMN "slug" VARCHAR(50);
+
+-- Add slug's to existing lessons
+UPDATE "lessons"
+SET "slug" = 'js' || "lessons".order;
+
+-- Make slug field required
+ALTER TABLE "lessons" ALTER COLUMN "slug" SET NOT NULL;
+
+-- CreateIndex (ensure no deplicate slugs)
+CREATE UNIQUE INDEX "lessons.slug_unique" ON "lessons"("slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Challenge {
 
 model Lesson {
   id          Int          @id @default(autoincrement())
+  slug        String       @unique @db.VarChar(50)
   description String
   docUrl      String?      @db.VarChar(255)
   githubUrl   String?      @db.VarChar(255)

--- a/prisma/seedData.ts
+++ b/prisma/seedData.ts
@@ -6,6 +6,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     title: 'Foundations of JavaScript',
     description: 'A super simple introduction to help you get started!',
     order: 0,
+    slug: 'js0',
     docUrl:
       'https://www.notion.so/garagescript/JS-0-Foundations-a43ca620e54945b2b620bcda5f3cf672',
     challenges: {
@@ -80,6 +81,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'Learn how to solve simple algorithm problems recursively with the following exercises',
     order: 1,
+    slug: 'js1',
     docUrl:
       'https://www.notion.so/garagescript/JS-1-Functions-01dd8400b85f40d083966908acbfa184',
     challenges: {
@@ -166,6 +168,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'These exercises will help you gain a better understanding of what it means for a data structure to be non-primitive.',
     order: 2,
+    slug: 'js2',
     docUrl:
       'https://www.notion.so/garagescript/JS-2-Arrays-8601f89c64164f188286df7b1e6d0ad9',
     challenges: {
@@ -246,6 +249,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'These exercises will test your understanding of objects, which includes linked lists and trees',
     order: 3,
+    slug: 'js3',
     docUrl:
       'https://www.notion.so/garagescript/JS-3-Objects-3df846eaf0404fe6b012208773063a04',
     challenges: {
@@ -320,6 +324,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'Create challenging front-end mini-projects and build an understanding of Web Development. Covers the last fundamental JavaScript concept: (Complex Objects)',
     order: 4,
+    slug: 'js4',
     docUrl:
       'https://www.notion.so/garagescript/JS-4-Front-End-Engineering-c59fbdd58dcc4214956f7856e0892b52',
     challenges: {
@@ -376,6 +381,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'These exercises will help you build a strong understanding of how the web works.',
     order: 5,
+    slug: 'js5',
     docUrl:
       'https://www.notion.so/JS-5-System-Design-Theory-67e7ee647a1c429d8e60e82f13a8d286',
     challenges: {
@@ -443,6 +449,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     title: 'React, GraphQL, SocketIO',
     description: 'React and GraphQL Lessons',
     order: 6,
+    slug: 'js6',
     docUrl: '',
     challenges: {
       createMany: {
@@ -504,6 +511,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     description:
       'Problems that are commonly asked to test your JavaScript knowledge',
     order: 7,
+    slug: 'js7',
     docUrl:
       'https://docs.google.com/document/d/1ekuu6VbN7qqypm71cVHT-BkdxYSwY0BBHLK8xGXSN1U/edit',
     challenges: {
@@ -583,6 +591,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     title: 'Trees',
     description: 'Tree problems with high difficulty',
     order: 8,
+    slug: 'js8',
     docUrl: '',
     challenges: {
       createMany: {
@@ -669,6 +678,7 @@ export const lessonsData = Prisma.validator<Prisma.LessonCreateInput[]>()([
     title: 'General Algorithms',
     description: 'General Algorithm from interviews',
     order: 9,
+    slug: 'js9',
     docUrl: '',
     challenges: {
       createMany: {

--- a/stories/components/LessonTitleCard.stories.tsx
+++ b/stories/components/LessonTitleCard.stories.tsx
@@ -11,6 +11,7 @@ export const Basic: React.FC = () => (
     lessonCoverUrl="js-0-cover.svg"
     lessonUrl="#"
     lessonTitle="Foundations"
+    lessonSlug="js0"
     isPassed={false}
     lessonId={5}
   />
@@ -21,6 +22,7 @@ export const PassedLesson: React.FC = () => (
     lessonCoverUrl="js-0-cover.svg"
     lessonUrl="#"
     lessonTitle="Foundations"
+    lessonSlug="js0"
     isPassed={true}
     lessonId={5}
   />

--- a/stories/profile/ProfileStarComments.stories.tsx
+++ b/stories/profile/ProfileStarComments.stories.tsx
@@ -23,6 +23,7 @@ const stars: StarType[] = [
       title: 'Objects',
       description: 'Objects description',
       order: 3,
+      slug: 'js3',
       challenges: []
     },
     comment:
@@ -43,6 +44,7 @@ const stars: StarType[] = [
       title: 'End to End',
       description: 'End to End description',
       order: 5,
+      slug: 'js5',
       challenges: []
     },
     comment: "Objects ain't easy, but thanks to you, they're now lemon squeezy."


### PR DESCRIPTION
Wire `curriculum/[lesson]` & `review/[lesson]` to use the new slug field added in pr #1039

Preview Links: 
https://c0d3-app-n7gycibgm-c0d3.vercel.app/review/js0
https://c0d3-app-n7gycibgm-c0d3.vercel.app/curriculum/js0

Other issues included in this pr:
- Fixed issues with the `LessonCard` review count button
  - Was set to `network-only` fetch so it didn't show stale data but was causing multiple hits to the graphql api when component would rerender, now only hits once on first mount. <br> _\*You can view this bug in production by navigating to https://c0d3.com with your network tab open. if you are logged in it will redirect you to the curriculum page before the getApp fetch has finished and then start the review fetches with will then rerun when the initial fetch finishes (you may have to clear your cache to see it, and easiest to see when you filter graphql requests only)_
  - Converted to next/link to prevent the need to refetch the entire app when clicking the review button.
- Refactored `LessonTitleCard` test file to only be concerned about the component and not the pages it's used in