### PR TITLE
update #843 - adds userId to error message for invalid refresh token

### DIFF
--- a/helpers/discordAuth.test.js
+++ b/helpers/discordAuth.test.js
@@ -115,7 +115,7 @@ describe('getUserInfoFromRefreshToken function', () => {
       )
       expect(false).toEqual(true) // force test to fail
     } catch (error) {
-      expect(error.message).toBe('refresh token invalid')
+      expect(error.message).toBe('refresh token invalid for userId 123')
     }
 
     expect(fetch.mock.calls.length).toBe(1)

--- a/helpers/discordAuth.ts
+++ b/helpers/discordAuth.ts
@@ -103,7 +103,7 @@ export const getUserInfoFromRefreshToken = async (
   // if updatedRefreshToken is undefined, empty string is stored in db to remove invalid refresh tokens
   await updateUserRefreshToken(userId, updatedRefreshToken)
 
-  if (!updatedRefreshToken) throw new Error('refresh token invalid')
+  if (!updatedRefreshToken) throw new Error(`refresh token invalid for userId ${userId}`)
 
   const { id, username, avatar } = await getUserInfo(tokenResponse.access_token)
 

--- a/helpers/discordAuth.ts
+++ b/helpers/discordAuth.ts
@@ -103,7 +103,8 @@ export const getUserInfoFromRefreshToken = async (
   // if updatedRefreshToken is undefined, empty string is stored in db to remove invalid refresh tokens
   await updateUserRefreshToken(userId, updatedRefreshToken)
 
-  if (!updatedRefreshToken) throw new Error(`refresh token invalid for userId ${userId}`)
+  if (!updatedRefreshToken)
+    throw new Error(`refresh token invalid for userId ${userId}`)
 
   const { id, username, avatar } = await getUserInfo(tokenResponse.access_token)
 


### PR DESCRIPTION
Currently an invalid refresh token stored in the User table will throw an 'invalid refresh token' error - this PR adds the user ID for a more descriptive error message