### PR TITLE
Fix failing url path tests on windows machines

### DIFF
--- a/helpers/static/docs.ts
+++ b/helpers/static/docs.ts
@@ -17,7 +17,7 @@ export const getDocSlugs = async () =>
   })
 
 export const getDocGithubFilePath = (docSlug: string) =>
-  path.join(DOCS_GITHUB_PATH, docSlug + '.mdx')
+  `${DOCS_GITHUB_PATH}/${docSlug}.mdx`
 
 export const getDocContent = (docSlug: string) => {
   const filePath = path.join(DOCS_PATH, docSlug + '.mdx')

--- a/helpers/static/lessons.ts
+++ b/helpers/static/lessons.ts
@@ -64,12 +64,7 @@ export const getSubLessonGithubFilePath = ({
   lessonSlug,
   subLessonSlug
 }: Slugs) =>
-  path.join(
-    LESSONS_GITHUB_PATH,
-    lessonSlug,
-    'sublesson',
-    `${subLessonSlug}.mdx`
-  )
+  `${LESSONS_GITHUB_PATH}/${lessonSlug}/sublesson/${subLessonSlug}.mdx`
 
 export const getSubLessonContent = ({ lessonSlug, subLessonSlug }: Slugs) =>
   fs.readFile(


### PR DESCRIPTION
# Description
Fixed failing windows tests that were documented in issue #1076

# Change
Changed from using the `path.join` utility to a simple template literal string. In this case we wanted a url path and not a file path. Since all the variables have already been sanitized with ` name === encodeURI(name)` in the other helper functions I believe this is the ideal solution. 

\*There are other utilities like [URL.pathToFileUrl](https://nodejs.org/api/url.html#url_url_pathtofileurl_path) but I believe that is overkill in this situation. 