### PR TITLE
Content/Remove todo challenge cards and fix broken links

### DIFF
--- a/content/lessons/js0/sublesson/functions_and_execution_context.mdx
+++ b/content/lessons/js0/sublesson/functions_and_execution_context.mdx
@@ -379,7 +379,7 @@ snitch = !keeper() // false: now we run the function and get 5; !5 is false
 ## Examples
 
 Functions are the most important concept in JavaScript (more on that
-[later](/curriculum/lessons/js3/objects)), so here are more examples.
+[later](/curriculum/js3/objects)), so here are more examples.
 
 **Note:** You must step through each line like a computer. Keep in mind that
 values of variables change constantly.
@@ -1258,7 +1258,7 @@ Concepts you must know:
 - What `return` does
 
 <ChallengeBar
-  href="/curriculum/5"
+  href="/curriculum/js0"
   description="Complete the rest of JS0 challenges"
   title="Master your skill by solving challenges"
 />

--- a/content/lessons/js0/sublesson/primitive_data_and_operators.mdx
+++ b/content/lessons/js0/sublesson/primitive_data_and_operators.mdx
@@ -687,22 +687,7 @@ a = new EventEmitter()
 </Spoiler>
 
 <ChallengeBar
-  href="/curriculum/5"
+  href="/curriculum/js0"
   description="Complete the first seven of JS0 challenges"
   title="Master your skill by solving challenges"
 />
-
-export default ({ children }) => (
-  <Layout
-    lessonCoverUrl={`js-0-cover.svg`}
-    title="Foundations of JavaScript"
-    lessonUrl="/curriculum/lessons/js0/primitive_data_and_operators"
-    lessonId="5"
-    subLessons={[
-      'Primitive data and operators',
-      'Functions and execution context'
-    ]}
-  >
-    {children}
-  </Layout>
-)

--- a/content/lessons/js1/sublesson/hypertext_markup_language.mdx
+++ b/content/lessons/js1/sublesson/hypertext_markup_language.mdx
@@ -791,9 +791,3 @@ const a = solution(1, 2) // a is a function
 ```
 
 </Spoiler>
-
-<ChallengeBar
-  href="/curriculum/2"
-  description="Complete HTML challenges (TO-DO add HTML challenges)"
-  title="Master your skill by solving challenges"
-/>

--- a/content/lessons/js1/sublesson/recursion_closure_and_async.mdx
+++ b/content/lessons/js1/sublesson/recursion_closure_and_async.mdx
@@ -33,7 +33,7 @@ an example for every exercise for the rest of the book
 # Closure
 
 **Note: It might be helpful to review
-[Execution Context in JS0](/curriculum/lessons/js0/functions_and_execution_context#execution-context)
+[Execution Context in JS0](/curriculum/js0/functions_and_execution_context#execution-context)
 before tackling this section.**
 
 Closure is a concept that allows a JavaScript function to keep track of the
@@ -2099,7 +2099,7 @@ Please solve these challenges with recursive functions instead of using `for` or
 you feel the need to use `for` or `while`, then please use recursion instead.
 
 <ChallengeBar
-  href="/curriculum/2"
-  description="Complete recursion and closure challenges"
+  href="/curriculum/js1"
+  description="Complete JS1 challenges"
   title="Master your skill by solving challenges"
 />

--- a/content/lessons/js2/sublesson/basic_array_functions.mdx
+++ b/content/lessons/js2/sublesson/basic_array_functions.mdx
@@ -1772,7 +1772,7 @@ they use.
 </Spoiler>
 
 <ChallengeBar
-  href="/curriculum/1"
+  href="/curriculum/js2"
   description="Complete the first six JS2 challenges"
   title="Master your skill by solving challenges"
 />

--- a/content/lessons/js2/sublesson/introduction_to_testing_inner_properties.mdx
+++ b/content/lessons/js2/sublesson/introduction_to_testing_inner_properties.mdx
@@ -1337,9 +1337,3 @@ Below are more exercises that you can do for more practice:
    - the `h1` tag will display `"Hello World"`
 
 </Spoiler>
-
-<ChallengeBar
-  href="/curriculum/1"
-  description="Complete HTML and testing challenges (TO-DO add these challenges)"
-  title="Master your skill by solving challenges"
-/>

--- a/content/lessons/js2/sublesson/map_reduce_and_filter_functions.mdx
+++ b/content/lessons/js2/sublesson/map_reduce_and_filter_functions.mdx
@@ -1395,7 +1395,7 @@ Here are the steps to add your own customized function for arrays:
 
 1. Define your function using `function( ... parameters ...) { ... code ...}`.
    - The difference between `function` and `() => {}` is described thoroughly in
-     the [next lesson](/curriculum/lessons/js3/promises#function-vs-fat-arrow).
+     the [next lesson](/curriculum/js3/promises#function-vs-fat-arrow).
 2. Assign your function to `Array.prototype`.
 3. Access array properties using the `this` keyword.
    - Note that `this` is a system keyword. **Do not** name your variables
@@ -1450,7 +1450,7 @@ approach is called **prototype inheritance**. But why?
 
 - **Prototype** - Because you are assigning your function to `Array.prototype`.
   More details covered in the
-  [next lesson](/curriculum/lessons/js3/objects#prototype-inheritance).
+  [next lesson](/curriculum/js3/objects#prototype-inheritance).
 - **Inheritance** - Because in the following example, all existing arrays
   **inherit** the new function.
 
@@ -2020,7 +2020,7 @@ const friends = ['Tony Stark', 'Vision', 'Ultron'].reduce((a, b) => {
 > implement these functions, then you can freely use them in future lessons.
 
 <ChallengeBar
-  href="/curriculum/1"
+  href="/curriculum/js2"
   description="Complete the rest of JS2 challenges"
   title="Master your skill by solving challenges"
 />

--- a/content/lessons/js3/sublesson/objects.mdx
+++ b/content/lessons/js3/sublesson/objects.mdx
@@ -8,7 +8,7 @@ order: 2
 # Objects
 
 Objects are the most important concept in JavaScript. But wait, didn't we
-[already say that functions are the most important concept in JavaScript](/curriculum/lessons/js0/functions_and_execution_context#running-a-function)?!
+[already say that functions are the most important concept in JavaScript](/curriculum/js0/functions_and_execution_context#running-a-function)?!
 Yes we did. But functions are actually objects in JavaScript (and so are
 arrays)! In fact, almost everything in JavaScript is an object.
 
@@ -772,8 +772,8 @@ method available to them.
 
 The `hasOwnProperty` method allows us to check if a particular property exists
 **ONLY** on the object in context and not down the prototype chain of the
-object. Go [here](/curriculum/lessons/js3/objects#prototype-inheritance) to read
-more on prototypes.
+object. Go [here](/curriculum/js3/objects#prototype-inheritance) to read more on
+prototypes.
 
 Let's look at an example to see why we may use this method.
 
@@ -2631,7 +2631,7 @@ not been defined yet.
 </Spoiler>
 
 <ChallengeBar
-  href="/curriculum/4"
+  href="/curriculum/js3"
   description="Complete the first eight JS3 challenges"
   title="Master your skill by solving challenges"
 />

--- a/content/lessons/js3/sublesson/preflight.mdx
+++ b/content/lessons/js3/sublesson/preflight.mdx
@@ -961,17 +961,3 @@ The new function we had to add here was the Filter button's onclick. We chose to
    listener for the add `button`.
 
 </Spoiler>
-
-<hr />
-
-export default ({ children }) => (
-  <Layout
-    lessonCoverUrl={`js-3-cover.svg`}
-    title="Objects"
-    lessonUrl="/curriculum/lessons/js3/objects"
-    lessonId="4"
-    subLessons={['Preflight', 'Objects', 'Promises']}
-  >
-    {children}
-  </Layout>
-)

--- a/content/lessons/js3/sublesson/promises.mdx
+++ b/content/lessons/js3/sublesson/promises.mdx
@@ -2217,7 +2217,7 @@ parameters.
 </Spoiler>
 
 <ChallengeBar
-  href="/curriculum/4"
+  href="/curriculum/js3"
   description="Complete the last two JS3 challenges"
   title="Master your skill by solving challenges"
 />

--- a/content/lessons/js4/sublesson/classes.mdx
+++ b/content/lessons/js4/sublesson/classes.mdx
@@ -1627,9 +1627,3 @@ YOLO [documentation](https://learn.ml5js.org/docs/#/reference/yolo)
 <Spoiler name = "EMPTY ANSWER">
 
 </Spoiler>
-
-<ChallengeBar
-  href="/curriculum/24"
-  description="Complete class related challenges (add class related challenges)"
-  title="Master your skill by solving challenges"
-/>

--- a/content/lessons/js4/sublesson/css.mdx
+++ b/content/lessons/js4/sublesson/css.mdx
@@ -1356,7 +1356,7 @@ Assets:
 </Spoiler>
 
 <ChallengeBar
-  href="/curriculum/24"
-  description="Complete css chalenges (all current ones)"
+  href="/curriculum/js4"
+  description="Complete JS4 chalenges"
   title="Master your skill by solving challenges"
 />

--- a/content/lessons/js4/sublesson/interactive_elements.mdx
+++ b/content/lessons/js4/sublesson/interactive_elements.mdx
@@ -2049,9 +2049,3 @@ const blocks3 = document.querySelectorAll('.div4')
 
 You'll see why this is essential in the next section, when we learn how to apply
 styles to elements based on their class(es)
-
-<ChallengeBar
-  href="/curriculum/24"
-  description="Add a few testing challenges?"
-  title="Master your skill by solving challenges"
-/>

--- a/content/lessons/js5/sublesson/server.mdx
+++ b/content/lessons/js5/sublesson/server.mdx
@@ -1316,7 +1316,7 @@ your application with the world!
 />
 
 <ChallengeBar
-  href="/curriculum/3"
-  description="Complete End to End challenges"
+  href="/curriculum/js5"
+  description="Complete JS5 challenges"
   title="Master your skill by solving challenges"
 />


### PR DESCRIPTION
# Description
Some house keeping before going live with the self hosted lessons.
- Removed todo challenge cards (created issue #1077 so they get addressed in the future)
- Fixed broken links (old lesson paths were `curriculum/<lessonSlug>/lesson/<subLessonSlug>` new url drops the `lesson` part)