### PR TITLE
Changes tests comparing paths to be cross platform Closes #1076

### DIFF
--- a/helpers/static/docs.test.js
+++ b/helpers/static/docs.test.js
@@ -1,5 +1,7 @@
 import { promises as fs } from 'fs'
 import { getDocSlugs, getDocGithubFilePath, getDocContent } from './docs'
+import path from 'path'
+
 jest.mock('fs', () => {
   return {
     promises: {
@@ -39,7 +41,7 @@ describe('Static Docs Helpers', () => {
       fs.readFile.mockResolvedValue(fakeFileContent)
 
       expect(getDocContent(slug)).resolves.toEqual(fakeFileContent)
-      expect(fs.readFile).toBeCalledWith(expect.stringContaining(filePath))
+      expect(fs.readFile).toBeCalledWith(path.join(process.cwd(), filePath))
     })
   })
   describe('getDocGithubFilePath', () => {

--- a/helpers/static/lessons.test.js
+++ b/helpers/static/lessons.test.js
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs'
+
 jest.mock('fs', () => {
   return {
     promises: {
@@ -13,6 +14,8 @@ import {
   getSubLessonGithubFilePath,
   getSubLessonContent
 } from './lessons'
+import path from 'path'
+
 jest.mock('fs')
 
 describe('Static Lessons Helpers', () => {
@@ -104,7 +107,7 @@ describe('Static Lessons Helpers', () => {
         })
       ).resolves.toEqual(fakeFileContent)
 
-      expect(fs.readFile).toBeCalledWith(expect.stringContaining(filePath))
+      expect(fs.readFile).toBeCalledWith(path.join(process.cwd(), filePath))
     })
   })
 })


### PR DESCRIPTION
Closes #1076

As described in 1076, tests comparing file paths using simple string equality/matching don't work across platforms as different platforms can use different characters as file separators. Some of these tests were fixed in #1078 

https://github.com/garageScript/c0d3-app/pull/1078#issuecomment-907332905 these two checks are fixed in this PR.

Instead of comparing with `filePath`, `path.join(process.cwd(), filePath)` is used to evaluate the correct path for the platform and then compared. 