### PR TITLE
Refactor/mdinput tabs

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1307,28 +1307,49 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
               }
             }
           >
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#292929",
-                }
-              }
+            <div
+              className="nav nav-tabs"
+              onKeyDown={[Function]}
             >
-              Write
-            </button>
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#8e8e8e",
-                }
-              }
-            >
-              Preview
-            </button>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#292929",
+                    }
+                  }
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#8e8e8e",
+                    }
+                  }
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               className="textarea"
               data-testid="textbox"
@@ -1826,28 +1847,49 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
               }
             }
           >
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#292929",
-                }
-              }
+            <div
+              className="nav nav-tabs"
+              onKeyDown={[Function]}
             >
-              Write
-            </button>
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#8e8e8e",
-                }
-              }
-            >
-              Preview
-            </button>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#292929",
+                    }
+                  }
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#8e8e8e",
+                    }
+                  }
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               className="textarea"
               data-testid="textbox"
@@ -4617,28 +4659,49 @@ exports[`Storyshots Components/FormCard Basic 1`] = `
               }
             }
           >
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#292929",
-                }
-              }
+            <div
+              className="nav nav-tabs"
+              onKeyDown={[Function]}
             >
-              Write
-            </button>
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#8e8e8e",
-                }
-              }
-            >
-              Preview
-            </button>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#292929",
+                    }
+                  }
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#8e8e8e",
+                    }
+                  }
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               className="textarea"
               data-testid="textbox"
@@ -4833,28 +4896,49 @@ exports[`Storyshots Components/FormCard With Border 1`] = `
               }
             }
           >
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#292929",
-                }
-              }
+            <div
+              className="nav nav-tabs"
+              onKeyDown={[Function]}
             >
-              Write
-            </button>
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#8e8e8e",
-                }
-              }
-            >
-              Preview
-            </button>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#292929",
+                    }
+                  }
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#8e8e8e",
+                    }
+                  }
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               className="textarea"
               data-testid="textbox"
@@ -4979,28 +5063,49 @@ exports[`Storyshots Components/FormCard With Title 1`] = `
               }
             }
           >
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#292929",
-                }
-              }
+            <div
+              className="nav nav-tabs"
+              onKeyDown={[Function]}
             >
-              Write
-            </button>
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#8e8e8e",
-                }
-              }
-            >
-              Preview
-            </button>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#292929",
+                    }
+                  }
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#8e8e8e",
+                    }
+                  }
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               className="textarea"
               data-testid="textbox"
@@ -5125,28 +5230,49 @@ exports[`Storyshots Components/FormCard With Validation 1`] = `
               }
             }
           >
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#292929",
-                }
-              }
+            <div
+              className="nav nav-tabs"
+              onKeyDown={[Function]}
             >
-              Write
-            </button>
-            <button
-              className="btn"
-              onClick={[Function]}
-              style={
-                Object {
-                  "color": "#8e8e8e",
-                }
-              }
-            >
-              Preview
-            </button>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#292929",
+                    }
+                  }
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                className="nav-item"
+              >
+                <a
+                  className="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  style={
+                    Object {
+                      "color": "#8e8e8e",
+                    }
+                  }
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               className="textarea"
               data-testid="textbox"
@@ -6725,28 +6851,49 @@ exports[`Storyshots Components/MdInput Basic 1`] = `
     }
   }
 >
-  <button
-    className="btn"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#292929",
-      }
-    }
+  <div
+    className="nav nav-tabs"
+    onKeyDown={[Function]}
   >
-    Write
-  </button>
-  <button
-    className="btn"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#8e8e8e",
-      }
-    }
-  >
-    Preview
-  </button>
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link active"
+        data-rb-event-key="Write"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#292929",
+          }
+        }
+      >
+        Write
+      </a>
+    </div>
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link"
+        data-rb-event-key="Preview"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#8e8e8e",
+          }
+        }
+      >
+        Preview
+      </a>
+    </div>
+  </div>
   <textarea
     className="textarea"
     data-testid="textbox"
@@ -6766,28 +6913,49 @@ exports[`Storyshots Components/MdInput White 1`] = `
     }
   }
 >
-  <button
-    className="btn"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#292929",
-      }
-    }
+  <div
+    className="nav nav-tabs"
+    onKeyDown={[Function]}
   >
-    Write
-  </button>
-  <button
-    className="btn"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#8e8e8e",
-      }
-    }
-  >
-    Preview
-  </button>
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link active"
+        data-rb-event-key="Write"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#292929",
+          }
+        }
+      >
+        Write
+      </a>
+    </div>
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link"
+        data-rb-event-key="Preview"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#8e8e8e",
+          }
+        }
+      >
+        Preview
+      </a>
+    </div>
+  </div>
   <textarea
     className="textarea"
     data-testid="textbox"
@@ -6807,28 +6975,49 @@ exports[`Storyshots Components/MdInput With Preset Value 1`] = `
     }
   }
 >
-  <button
-    className="btn"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#292929",
-      }
-    }
+  <div
+    className="nav nav-tabs"
+    onKeyDown={[Function]}
   >
-    Write
-  </button>
-  <button
-    className="btn"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#8e8e8e",
-      }
-    }
-  >
-    Preview
-  </button>
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link active"
+        data-rb-event-key="Write"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#292929",
+          }
+        }
+      >
+        Write
+      </a>
+    </div>
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link"
+        data-rb-event-key="Preview"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#8e8e8e",
+          }
+        }
+      >
+        Preview
+      </a>
+    </div>
+  </div>
   <textarea
     className="textarea"
     data-testid="textbox"
@@ -6849,28 +7038,49 @@ exports[`Storyshots Components/MdInput With Submission Buttons 1`] = `
       }
     }
   >
-    <button
-      className="btn"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "#292929",
-        }
-      }
+    <div
+      className="nav nav-tabs"
+      onKeyDown={[Function]}
     >
-      Write
-    </button>
-    <button
-      className="btn"
-      onClick={[Function]}
-      style={
-        Object {
-          "color": "#8e8e8e",
-        }
-      }
-    >
-      Preview
-    </button>
+      <div
+        className="nav-item"
+      >
+        <a
+          className="nav-link active"
+          data-rb-event-key="Write"
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          style={
+            Object {
+              "color": "#292929",
+            }
+          }
+        >
+          Write
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          className="nav-link"
+          data-rb-event-key="Preview"
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          style={
+            Object {
+              "color": "#8e8e8e",
+            }
+          }
+        >
+          Preview
+        </a>
+      </div>
+    </div>
     <textarea
       className="textarea"
       data-testid="textbox"
@@ -9410,28 +9620,49 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
         }
       }
     >
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#292929",
-          }
-        }
+      <div
+        className="nav nav-tabs"
+        onKeyDown={[Function]}
       >
-        Write
-      </button>
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#8e8e8e",
-          }
-        }
-      >
-        Preview
-      </button>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link active"
+            data-rb-event-key="Write"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#292929",
+              }
+            }
+          >
+            Write
+          </a>
+        </div>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link"
+            data-rb-event-key="Preview"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#8e8e8e",
+              }
+            }
+          >
+            Preview
+          </a>
+        </div>
+      </div>
       <textarea
         className="textarea"
         data-testid="textbox"
@@ -10447,28 +10678,49 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
         }
       }
     >
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#292929",
-          }
-        }
+      <div
+        className="nav nav-tabs"
+        onKeyDown={[Function]}
       >
-        Write
-      </button>
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#8e8e8e",
-          }
-        }
-      >
-        Preview
-      </button>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link active"
+            data-rb-event-key="Write"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#292929",
+              }
+            }
+          >
+            Write
+          </a>
+        </div>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link"
+            data-rb-event-key="Preview"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#8e8e8e",
+              }
+            }
+          >
+            Preview
+          </a>
+        </div>
+      </div>
       <textarea
         className="textarea"
         data-testid="textbox"
@@ -11482,28 +11734,49 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
         }
       }
     >
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#292929",
-          }
-        }
+      <div
+        className="nav nav-tabs"
+        onKeyDown={[Function]}
       >
-        Write
-      </button>
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#8e8e8e",
-          }
-        }
-      >
-        Preview
-      </button>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link active"
+            data-rb-event-key="Write"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#292929",
+              }
+            }
+          >
+            Write
+          </a>
+        </div>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link"
+            data-rb-event-key="Preview"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#8e8e8e",
+              }
+            }
+          >
+            Preview
+          </a>
+        </div>
+      </div>
       <textarea
         className="textarea"
         data-testid="textbox"
@@ -12517,28 +12790,49 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
         }
       }
     >
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#292929",
-          }
-        }
+      <div
+        className="nav nav-tabs"
+        onKeyDown={[Function]}
       >
-        Write
-      </button>
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#8e8e8e",
-          }
-        }
-      >
-        Preview
-      </button>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link active"
+            data-rb-event-key="Write"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#292929",
+              }
+            }
+          >
+            Write
+          </a>
+        </div>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link"
+            data-rb-event-key="Preview"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#8e8e8e",
+              }
+            }
+          >
+            Preview
+          </a>
+        </div>
+      </div>
       <textarea
         className="textarea"
         data-testid="textbox"
@@ -13552,28 +13846,49 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
         }
       }
     >
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#292929",
-          }
-        }
+      <div
+        className="nav nav-tabs"
+        onKeyDown={[Function]}
       >
-        Write
-      </button>
-      <button
-        className="btn"
-        onClick={[Function]}
-        style={
-          Object {
-            "color": "#8e8e8e",
-          }
-        }
-      >
-        Preview
-      </button>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link active"
+            data-rb-event-key="Write"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#292929",
+              }
+            }
+          >
+            Write
+          </a>
+        </div>
+        <div
+          className="nav-item"
+        >
+          <a
+            className="nav-link"
+            data-rb-event-key="Preview"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            style={
+              Object {
+                "color": "#8e8e8e",
+              }
+            }
+          >
+            Preview
+          </a>
+        </div>
+      </div>
       <textarea
         className="textarea"
         data-testid="textbox"

--- a/__tests__/pages/admin/__snapshots__/lessons.test.js.snap
+++ b/__tests__/pages/admin/__snapshots__/lessons.test.js.snap
@@ -304,18 +304,36 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 1`] 
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -487,18 +505,36 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 1`] 
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -590,18 +626,36 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 1`] 
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -696,18 +750,36 @@ solution(4,1) // Should return 5
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -802,18 +874,36 @@ solution(4,1,9) // Should return 14
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -908,18 +998,36 @@ solution(4) // Should return false
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -1014,18 +1122,36 @@ solution(4,1) // Should return 4
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -1121,18 +1247,36 @@ solution(4,5,1) // Should return 5
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -1227,18 +1371,36 @@ solution(4,1) // Should return true
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -1333,18 +1495,36 @@ solution(4,1) // Should return false
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -1438,18 +1618,36 @@ const a = solution(5,6) // a is a function, and a() will return 11
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -1545,18 +1743,36 @@ const a = solution(1,2); // a is a function
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -1918,18 +2134,36 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 2`] 
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2101,18 +2335,36 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 2`] 
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2204,18 +2456,36 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 2`] 
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2308,18 +2578,36 @@ solution(['123', 'abc'], {123: 'hi', 345: 'world', abc: 'world'});
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2427,18 +2715,36 @@ solution(99,2)
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2540,18 +2846,36 @@ console.log(resp({iron: 'man', billy: 'joel'}))
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2644,18 +2968,36 @@ solution([1,2,22,333,23], 24)   // returns true
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2763,18 +3105,36 @@ solution ({
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2868,18 +3228,36 @@ solution([1, 1, 1, 1, 2, 3, 3])  // should return [1, 3]
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -2981,18 +3359,36 @@ console.log(result)
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -3103,18 +3499,36 @@ levellevellevel
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"
@@ -3214,18 +3628,36 @@ Example: Put this tag into an html file to display a picture of the cat.
                   <div
                     style="background-color: white;"
                   >
-                    <button
-                      class="btn"
-                      style="color: rgb(41, 41, 41);"
+                    <div
+                      class="nav nav-tabs"
                     >
-                      Write
-                    </button>
-                    <button
-                      class="btn"
-                      style="color: rgb(142, 142, 142);"
-                    >
-                      Preview
-                    </button>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link active"
+                          data-rb-event-key="Write"
+                          href="#"
+                          role="button"
+                          style="color: rgb(41, 41, 41);"
+                        >
+                          Write
+                        </a>
+                      </div>
+                      <div
+                        class="nav-item"
+                      >
+                        <a
+                          class="nav-link"
+                          data-rb-event-key="Preview"
+                          href="#"
+                          role="button"
+                          style="color: rgb(142, 142, 142);"
+                        >
+                          Preview
+                        </a>
+                      </div>
+                    </div>
                     <textarea
                       class="textarea"
                       data-testid="textbox"

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -2987,18 +2987,36 @@ exports[`Lesson Page Should render new submissions 1`] = `
                             <div
                               style="background-color: white;"
                             >
-                              <button
-                                class="btn"
-                                style="color: rgb(41, 41, 41);"
+                              <div
+                                class="nav nav-tabs"
                               >
-                                Write
-                              </button>
-                              <button
-                                class="btn"
-                                style="color: rgb(142, 142, 142);"
-                              >
-                                Preview
-                              </button>
+                                <div
+                                  class="nav-item"
+                                >
+                                  <a
+                                    class="nav-link active"
+                                    data-rb-event-key="Write"
+                                    href="#"
+                                    role="button"
+                                    style="color: rgb(41, 41, 41);"
+                                  >
+                                    Write
+                                  </a>
+                                </div>
+                                <div
+                                  class="nav-item"
+                                >
+                                  <a
+                                    class="nav-link"
+                                    data-rb-event-key="Preview"
+                                    href="#"
+                                    role="button"
+                                    style="color: rgb(142, 142, 142);"
+                                  >
+                                    Preview
+                                  </a>
+                                </div>
+                              </div>
                               <textarea
                                 class="textarea"
                                 data-testid="textbox"
@@ -3098,18 +3116,36 @@ exports[`Lesson Page Should render new submissions 1`] = `
                             <div
                               style="background-color: white;"
                             >
-                              <button
-                                class="btn"
-                                style="color: rgb(41, 41, 41);"
+                              <div
+                                class="nav nav-tabs"
                               >
-                                Write
-                              </button>
-                              <button
-                                class="btn"
-                                style="color: rgb(142, 142, 142);"
-                              >
-                                Preview
-                              </button>
+                                <div
+                                  class="nav-item"
+                                >
+                                  <a
+                                    class="nav-link active"
+                                    data-rb-event-key="Write"
+                                    href="#"
+                                    role="button"
+                                    style="color: rgb(41, 41, 41);"
+                                  >
+                                    Write
+                                  </a>
+                                </div>
+                                <div
+                                  class="nav-item"
+                                >
+                                  <a
+                                    class="nav-link"
+                                    data-rb-event-key="Preview"
+                                    href="#"
+                                    role="button"
+                                    style="color: rgb(142, 142, 142);"
+                                  >
+                                    Preview
+                                  </a>
+                                </div>
+                              </div>
                               <textarea
                                 class="textarea"
                                 data-testid="textbox"
@@ -5652,18 +5688,36 @@ exports[`Lesson Page Should render new submissions 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"

--- a/components/MdInput.test.js
+++ b/components/MdInput.test.js
@@ -28,8 +28,21 @@ describe('MdInput Component', () => {
     expect(container).toMatchSnapshot()
   })
 
-  test('Should switch to Preview mode when user clicks Preview button', () => {
+  test("Should display 'Nothing to preview' when switching to Preview mode with no input", () => {
     const { container } = render(<MdInput />)
+
+    userEvent.click(screen.getByRole('button', { name: 'Preview' }))
+
+    expect(screen.getByRole('textbox')).toHaveClass('d-none')
+    expect(screen.getByText('Nothing to preview')).toBeInTheDocument()
+  })
+
+  test('Should display markdown preview text when switch to Preview mode with input', () => {
+    const { container } = render(<TestComponent />)
+
+    const textbox = screen.getByRole('textbox')
+    userEvent.click(textbox)
+    userEvent.type(textbox, 'Some **Text**')
 
     userEvent.click(screen.getByRole('button', { name: 'Preview' }))
 

--- a/components/MdInput.tsx
+++ b/components/MdInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import Markdown from 'markdown-to-jsx'
-import { Button } from './theme/Button'
+import { colors } from './theme/colors'
+import { Nav } from 'react-bootstrap'
 import noop from '../helpers/noop'
 import styles from '../scss/mdInput.module.scss'
 
@@ -63,16 +64,46 @@ export const MdInput: React.FC<MdInputProps> = ({
 
   return (
     <div style={{ backgroundColor: bgColor }}>
-      <Button color={writeBtnColor} onClick={() => setPreview(false)}>
-        Write
-      </Button>
-      <Button color={previewBtnColor} onClick={() => setPreview(true)}>
-        Preview
-      </Button>
+      <Nav
+        variant="tabs"
+        defaultActiveKey="Write"
+        activeKey={preview ? 'Preview' : 'Write'}
+        onSelect={selectedKey => setPreview(selectedKey === 'Preview')}
+      >
+        <Nav.Item>
+          <Nav.Link style={{ color: colors[writeBtnColor] }} eventKey="Write">
+            Write
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link
+            style={{ color: colors[previewBtnColor] }}
+            eventKey="Preview"
+          >
+            Preview
+          </Nav.Link>
+        </Nav.Item>
+      </Nav>
       {preview && (
-        <Markdown data-testid="markdown" className={`${styles['preview']}`}>
-          {value}
-        </Markdown>
+        <>
+          {value ? (
+            <Markdown
+              data-testid="markdown"
+              style={{
+                minHeight:
+                  Math.min(textareaRef.current?.clientHeight || Infinity, 500) +
+                  'px'
+              }}
+              className={`${styles['preview']}`}
+            >
+              {value}
+            </Markdown>
+          ) : (
+            // Using textArea class so minHeight stays in sync
+            <div className={styles['textarea']}>Nothing to preview</div>
+          )}
+          <hr />
+        </>
       )}
       <textarea
         onMouseDown={() => {

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -2429,18 +2429,36 @@ exports[`Curriculum challenge page Should be able to select another challenge 1`
                         <div
                           style="background-color: white;"
                         >
-                          <button
-                            class="btn"
-                            style="color: rgb(41, 41, 41);"
+                          <div
+                            class="nav nav-tabs"
                           >
-                            Write
-                          </button>
-                          <button
-                            class="btn"
-                            style="color: rgb(142, 142, 142);"
-                          >
-                            Preview
-                          </button>
+                            <div
+                              class="nav-item"
+                            >
+                              <a
+                                class="nav-link active"
+                                data-rb-event-key="Write"
+                                href="#"
+                                role="button"
+                                style="color: rgb(41, 41, 41);"
+                              >
+                                Write
+                              </a>
+                            </div>
+                            <div
+                              class="nav-item"
+                            >
+                              <a
+                                class="nav-link"
+                                data-rb-event-key="Preview"
+                                href="#"
+                                role="button"
+                                style="color: rgb(142, 142, 142);"
+                              >
+                                Preview
+                              </a>
+                            </div>
+                          </div>
                           <textarea
                             class="textarea"
                             data-testid="textbox"
@@ -2540,18 +2558,36 @@ exports[`Curriculum challenge page Should be able to select another challenge 1`
                         <div
                           style="background-color: white;"
                         >
-                          <button
-                            class="btn"
-                            style="color: rgb(41, 41, 41);"
+                          <div
+                            class="nav nav-tabs"
                           >
-                            Write
-                          </button>
-                          <button
-                            class="btn"
-                            style="color: rgb(142, 142, 142);"
-                          >
-                            Preview
-                          </button>
+                            <div
+                              class="nav-item"
+                            >
+                              <a
+                                class="nav-link active"
+                                data-rb-event-key="Write"
+                                href="#"
+                                role="button"
+                                style="color: rgb(41, 41, 41);"
+                              >
+                                Write
+                              </a>
+                            </div>
+                            <div
+                              class="nav-item"
+                            >
+                              <a
+                                class="nav-link"
+                                data-rb-event-key="Preview"
+                                href="#"
+                                role="button"
+                                style="color: rgb(142, 142, 142);"
+                              >
+                                Preview
+                              </a>
+                            </div>
+                          </div>
                           <textarea
                             class="textarea"
                             data-testid="textbox"
@@ -5119,18 +5155,36 @@ exports[`Curriculum challenge page Should be able to select another challenge 1`
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -7336,18 +7390,36 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -12351,18 +12423,36 @@ exports[`Curriculum challenge page Should select previous iterations 1`] = `
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -254,18 +254,36 @@ exports[`DiffView component Should add comment box 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2695,18 +2713,36 @@ exports[`DiffView component Should render diff with comments 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2806,18 +2842,36 @@ exports[`DiffView component Should render diff with comments 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"

--- a/components/__snapshots__/FormCard.test.js.snap
+++ b/components/__snapshots__/FormCard.test.js.snap
@@ -25,18 +25,36 @@ exports[`FormCard Component Should call function with updated array as parameter
           <div
             style="background-color: white;"
           >
-            <button
-              class="btn"
-              style="color: rgb(41, 41, 41);"
+            <div
+              class="nav nav-tabs"
             >
-              Write
-            </button>
-            <button
-              class="btn"
-              style="color: rgb(142, 142, 142);"
-            >
-              Preview
-            </button>
+              <div
+                class="nav-item"
+              >
+                <a
+                  class="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  role="button"
+                  style="color: rgb(41, 41, 41);"
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                class="nav-item"
+              >
+                <a
+                  class="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  role="button"
+                  style="color: rgb(142, 142, 142);"
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               class="textarea"
               data-testid="textbox"
@@ -129,18 +147,36 @@ exports[`FormCard Component Should render MdInput component when type is MD_INPU
           <div
             style="background-color: white;"
           >
-            <button
-              class="btn"
-              style="color: rgb(41, 41, 41);"
+            <div
+              class="nav nav-tabs"
             >
-              Write
-            </button>
-            <button
-              class="btn"
-              style="color: rgb(142, 142, 142);"
-            >
-              Preview
-            </button>
+              <div
+                class="nav-item"
+              >
+                <a
+                  class="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  role="button"
+                  style="color: rgb(41, 41, 41);"
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                class="nav-item"
+              >
+                <a
+                  class="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  role="button"
+                  style="color: rgb(142, 142, 142);"
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               class="textarea"
               data-testid="textbox"
@@ -265,18 +301,36 @@ exports[`FormCard Component Should update testing onChange variable when person 
           <div
             style="background-color: white;"
           >
-            <button
-              class="btn"
-              style="color: rgb(41, 41, 41);"
+            <div
+              class="nav nav-tabs"
             >
-              Write
-            </button>
-            <button
-              class="btn"
-              style="color: rgb(142, 142, 142);"
-            >
-              Preview
-            </button>
+              <div
+                class="nav-item"
+              >
+                <a
+                  class="nav-link active"
+                  data-rb-event-key="Write"
+                  href="#"
+                  role="button"
+                  style="color: rgb(41, 41, 41);"
+                >
+                  Write
+                </a>
+              </div>
+              <div
+                class="nav-item"
+              >
+                <a
+                  class="nav-link"
+                  data-rb-event-key="Preview"
+                  href="#"
+                  role="button"
+                  style="color: rgb(142, 142, 142);"
+                >
+                  Preview
+                </a>
+              </div>
+            </div>
             <textarea
               class="textarea"
               data-testid="textbox"

--- a/components/__snapshots__/MdInput.test.js.snap
+++ b/components/__snapshots__/MdInput.test.js.snap
@@ -1,20 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MdInput Component Should display markdown preview text when switch to Preview mode with input 1`] = `
+<div>
+  <div>
+    <div
+      class="nav nav-tabs"
+    >
+      <div
+        class="nav-item"
+      >
+        <a
+          class="nav-link"
+          data-rb-event-key="Write"
+          href="#"
+          role="button"
+          style="color: rgb(142, 142, 142);"
+        >
+          Write
+        </a>
+      </div>
+      <div
+        class="nav-item"
+      >
+        <a
+          class="nav-link active"
+          data-rb-event-key="Preview"
+          href="#"
+          role="button"
+          style="color: rgb(41, 41, 41);"
+        >
+          Preview
+        </a>
+      </div>
+    </div>
+    <span
+      class="preview"
+      data-testid="markdown"
+      style="min-height: 500px;"
+    >
+      Some 
+      <strong>
+        Text
+      </strong>
+    </span>
+    <hr />
+    <textarea
+      class="textarea d-none"
+      data-testid="textbox"
+      placeholder="Type something..."
+      style="height: 2px;"
+    >
+      Some **Text**
+    </textarea>
+  </div>
+</div>
+`;
+
 exports[`MdInput Component Should render text onto textbox when user types 1`] = `
 <div>
   <div>
-    <button
-      class="btn"
-      style="color: rgb(41, 41, 41);"
+    <div
+      class="nav nav-tabs"
     >
-      Write
-    </button>
-    <button
-      class="btn"
-      style="color: rgb(142, 142, 142);"
-    >
-      Preview
-    </button>
+      <div
+        class="nav-item"
+      >
+        <a
+          class="nav-link active"
+          data-rb-event-key="Write"
+          href="#"
+          role="button"
+          style="color: rgb(41, 41, 41);"
+        >
+          Write
+        </a>
+      </div>
+      <div
+        class="nav-item"
+      >
+        <a
+          class="nav-link"
+          data-rb-event-key="Preview"
+          href="#"
+          role="button"
+          style="color: rgb(142, 142, 142);"
+        >
+          Preview
+        </a>
+      </div>
+    </div>
     <textarea
       class="textarea"
       data-testid="textbox"
@@ -27,49 +101,39 @@ exports[`MdInput Component Should render text onto textbox when user types 1`] =
 </div>
 `;
 
-exports[`MdInput Component Should switch to Preview mode when user clicks Preview button 1`] = `
-<div>
-  <div>
-    <button
-      class="btn"
-      style="color: rgb(142, 142, 142);"
-    >
-      Write
-    </button>
-    <button
-      class="btn"
-      style="color: rgb(41, 41, 41);"
-    >
-      Preview
-    </button>
-    <span
-      class="preview"
-      data-testid="markdown"
-    />
-    <textarea
-      class="textarea d-none"
-      data-testid="textbox"
-      placeholder="Type something..."
-    />
-  </div>
-</div>
-`;
-
 exports[`MdInput Component Should switch to Write mode when user clicks Write button 1`] = `
 <div>
   <div>
-    <button
-      class="btn"
-      style="color: rgb(41, 41, 41);"
+    <div
+      class="nav nav-tabs"
     >
-      Write
-    </button>
-    <button
-      class="btn"
-      style="color: rgb(142, 142, 142);"
-    >
-      Preview
-    </button>
+      <div
+        class="nav-item"
+      >
+        <a
+          class="nav-link active"
+          data-rb-event-key="Write"
+          href="#"
+          role="button"
+          style="color: rgb(41, 41, 41);"
+        >
+          Write
+        </a>
+      </div>
+      <div
+        class="nav-item"
+      >
+        <a
+          class="nav-link"
+          data-rb-event-key="Preview"
+          href="#"
+          role="button"
+          style="color: rgb(142, 142, 142);"
+        >
+          Preview
+        </a>
+      </div>
+    </div>
     <textarea
       class="textarea"
       data-testid="textbox"

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -480,18 +480,36 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
       <div
         style="background-color: white;"
       >
-        <button
-          class="btn"
-          style="color: rgb(41, 41, 41);"
+        <div
+          class="nav nav-tabs"
         >
-          Write
-        </button>
-        <button
-          class="btn"
-          style="color: rgb(142, 142, 142);"
-        >
-          Preview
-        </button>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link active"
+              data-rb-event-key="Write"
+              href="#"
+              role="button"
+              style="color: rgb(41, 41, 41);"
+            >
+              Write
+            </a>
+          </div>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link"
+              data-rb-event-key="Preview"
+              href="#"
+              role="button"
+              style="color: rgb(142, 142, 142);"
+            >
+              Preview
+            </a>
+          </div>
+        </div>
         <textarea
           class="textarea"
           data-testid="textbox"
@@ -1063,18 +1081,36 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
       <div
         style="background-color: white;"
       >
-        <button
-          class="btn"
-          style="color: rgb(41, 41, 41);"
+        <div
+          class="nav nav-tabs"
         >
-          Write
-        </button>
-        <button
-          class="btn"
-          style="color: rgb(142, 142, 142);"
-        >
-          Preview
-        </button>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link active"
+              data-rb-event-key="Write"
+              href="#"
+              role="button"
+              style="color: rgb(41, 41, 41);"
+            >
+              Write
+            </a>
+          </div>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link"
+              data-rb-event-key="Preview"
+              href="#"
+              role="button"
+              style="color: rgb(142, 142, 142);"
+            >
+              Preview
+            </a>
+          </div>
+        </div>
         <textarea
           class="textarea"
           data-testid="textbox"
@@ -2396,18 +2432,36 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
       <div
         style="background-color: white;"
       >
-        <button
-          class="btn"
-          style="color: rgb(41, 41, 41);"
+        <div
+          class="nav nav-tabs"
         >
-          Write
-        </button>
-        <button
-          class="btn"
-          style="color: rgb(142, 142, 142);"
-        >
-          Preview
-        </button>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link active"
+              data-rb-event-key="Write"
+              href="#"
+              role="button"
+              style="color: rgb(41, 41, 41);"
+            >
+              Write
+            </a>
+          </div>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link"
+              data-rb-event-key="Preview"
+              href="#"
+              role="button"
+              style="color: rgb(142, 142, 142);"
+            >
+              Preview
+            </a>
+          </div>
+        </div>
         <textarea
           class="textarea"
           data-testid="textbox"
@@ -3728,18 +3782,36 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
       <div
         style="background-color: white;"
       >
-        <button
-          class="btn"
-          style="color: rgb(41, 41, 41);"
+        <div
+          class="nav nav-tabs"
         >
-          Write
-        </button>
-        <button
-          class="btn"
-          style="color: rgb(142, 142, 142);"
-        >
-          Preview
-        </button>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link active"
+              data-rb-event-key="Write"
+              href="#"
+              role="button"
+              style="color: rgb(41, 41, 41);"
+            >
+              Write
+            </a>
+          </div>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link"
+              data-rb-event-key="Preview"
+              href="#"
+              role="button"
+              style="color: rgb(142, 142, 142);"
+            >
+              Preview
+            </a>
+          </div>
+        </div>
         <textarea
           class="textarea"
           data-testid="textbox"
@@ -3883,18 +3955,36 @@ exports[`ReviewCard Component Should render single path submission 1`] = `
       <div
         style="background-color: white;"
       >
-        <button
-          class="btn"
-          style="color: rgb(41, 41, 41);"
+        <div
+          class="nav nav-tabs"
         >
-          Write
-        </button>
-        <button
-          class="btn"
-          style="color: rgb(142, 142, 142);"
-        >
-          Preview
-        </button>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link active"
+              data-rb-event-key="Write"
+              href="#"
+              role="button"
+              style="color: rgb(41, 41, 41);"
+            >
+              Write
+            </a>
+          </div>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link"
+              data-rb-event-key="Preview"
+              href="#"
+              role="button"
+              style="color: rgb(142, 142, 142);"
+            >
+              Preview
+            </a>
+          </div>
+        </div>
         <textarea
           class="textarea"
           data-testid="textbox"
@@ -5215,18 +5305,36 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
       <div
         style="background-color: white;"
       >
-        <button
-          class="btn"
-          style="color: rgb(41, 41, 41);"
+        <div
+          class="nav nav-tabs"
         >
-          Write
-        </button>
-        <button
-          class="btn"
-          style="color: rgb(142, 142, 142);"
-        >
-          Preview
-        </button>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link active"
+              data-rb-event-key="Write"
+              href="#"
+              role="button"
+              style="color: rgb(41, 41, 41);"
+            >
+              Write
+            </a>
+          </div>
+          <div
+            class="nav-item"
+          >
+            <a
+              class="nav-link"
+              data-rb-event-key="Preview"
+              href="#"
+              role="button"
+              style="color: rgb(142, 142, 142);"
+            >
+              Preview
+            </a>
+          </div>
+        </div>
         <textarea
           class="textarea"
           data-testid="textbox"

--- a/components/admin/lessons/__snapshots__/AdminLessonChallenges.test.js.snap
+++ b/components/admin/lessons/__snapshots__/AdminLessonChallenges.test.js.snap
@@ -53,18 +53,36 @@ exports[`AdminLessonChallenges component Should create challenge 1`] = `
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -161,18 +179,36 @@ exports[`AdminLessonChallenges component Should refuse creating  new challenge w
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -271,18 +307,36 @@ exports[`AdminLessonChallenges component Should refuse updating challenge with i
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -376,18 +430,36 @@ exports[`AdminLessonChallenges component Should refuse updating challenge with i
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -465,18 +537,36 @@ exports[`AdminLessonChallenges component Should render a challenge without title
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -580,18 +670,36 @@ exports[`AdminLessonChallenges component Should update challenge 1`] = `
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -686,18 +794,36 @@ solution(4,1) // Should return 5
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -797,18 +923,36 @@ exports[`AdminLessonChallenges component Should update challenge 2`] = `
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -897,18 +1041,36 @@ exports[`AdminLessonChallenges component Should update challenge 2`] = `
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"

--- a/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
+++ b/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
@@ -53,18 +53,36 @@ exports[`AdminLessonsInfo component Should create new lesson 1`] = `
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -238,18 +256,36 @@ exports[`AdminLessonsInfo component Should create new lesson 2`] = `
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -431,18 +467,36 @@ exports[`AdminLessonsInfo component Should render non-existent lesson 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -614,18 +668,36 @@ exports[`AdminLessonsInfo component Should render non-existent lesson 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -717,18 +789,36 @@ exports[`AdminLessonsInfo component Should render non-existent lesson 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -823,18 +913,36 @@ solution(4,1) // Should return 5
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -929,18 +1037,36 @@ solution(4,1,9) // Should return 14
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -1035,18 +1161,36 @@ solution(4) // Should return false
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -1141,18 +1285,36 @@ solution(4,1) // Should return 4
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -1248,18 +1410,36 @@ solution(4,5,1) // Should return 5
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -1354,18 +1534,36 @@ solution(4,1) // Should return true
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -1460,18 +1658,36 @@ solution(4,1) // Should return false
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -1565,18 +1781,36 @@ const a = solution(5,6) // a is a function, and a() will return 11
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -1672,18 +1906,36 @@ const a = solution(1,2); // a is a function
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -1787,18 +2039,36 @@ exports[`AdminLessonsInfo component Should render undefined lessons 1`] = `
             <div
               style="background-color: white;"
             >
-              <button
-                class="btn"
-                style="color: rgb(41, 41, 41);"
+              <div
+                class="nav nav-tabs"
               >
-                Write
-              </button>
-              <button
-                class="btn"
-                style="color: rgb(142, 142, 142);"
-              >
-                Preview
-              </button>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link active"
+                    data-rb-event-key="Write"
+                    href="#"
+                    role="button"
+                    style="color: rgb(41, 41, 41);"
+                  >
+                    Write
+                  </a>
+                </div>
+                <div
+                  class="nav-item"
+                >
+                  <a
+                    class="nav-link"
+                    data-rb-event-key="Preview"
+                    href="#"
+                    role="button"
+                    style="color: rgb(142, 142, 142);"
+                  >
+                    Preview
+                  </a>
+                </div>
+              </div>
               <textarea
                 class="textarea"
                 data-testid="textbox"
@@ -1977,18 +2247,36 @@ exports[`AdminLessonsInfo component Should update lesson sucessfully 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2161,18 +2449,36 @@ exports[`AdminLessonsInfo component Should update lesson sucessfully 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2264,18 +2570,36 @@ exports[`AdminLessonsInfo component Should update lesson sucessfully 1`] = `
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2370,18 +2694,36 @@ solution(4,1) // Should return 5
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2476,18 +2818,36 @@ solution(4,1,9) // Should return 14
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2582,18 +2942,36 @@ solution(4) // Should return false
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2688,18 +3066,36 @@ solution(4,1) // Should return 4
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2795,18 +3191,36 @@ solution(4,5,1) // Should return 5
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -2901,18 +3315,36 @@ solution(4,1) // Should return true
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -3007,18 +3439,36 @@ solution(4,1) // Should return false
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -3112,18 +3562,36 @@ const a = solution(5,6) // a is a function, and a() will return 11
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"
@@ -3219,18 +3687,36 @@ const a = solution(1,2); // a is a function
               <div
                 style="background-color: white;"
               >
-                <button
-                  class="btn"
-                  style="color: rgb(41, 41, 41);"
+                <div
+                  class="nav nav-tabs"
                 >
-                  Write
-                </button>
-                <button
-                  class="btn"
-                  style="color: rgb(142, 142, 142);"
-                >
-                  Preview
-                </button>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link active"
+                      data-rb-event-key="Write"
+                      href="#"
+                      role="button"
+                      style="color: rgb(41, 41, 41);"
+                    >
+                      Write
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="nav-link"
+                      data-rb-event-key="Preview"
+                      href="#"
+                      role="button"
+                      style="color: rgb(142, 142, 142);"
+                    >
+                      Preview
+                    </a>
+                  </div>
+                </div>
                 <textarea
                   class="textarea"
                   data-testid="textbox"


### PR DESCRIPTION
# Description

- Convert MdInput preview/write buttons into react-bootstrap Nav elements with tab style.
- Add placeholder text for preview state with no input "Nothing to preview"
- Add minHeight to preview mode to reduce layout shift when switching to preview mode.


This might not seem like an obvious gain but the Tab style looks much nicer with markdown-toolbar that is still a work in progress.

## Screenshots

New tab nav buttons with `write` active

![typeSomething](https://user-images.githubusercontent.com/17365077/131933562-39cb329b-ce55-4c3e-ac43-1f95f1d03a90.png)
<hr />

New "Nothing to preview" placeholder with minHeight

![nothingToPreview](https://user-images.githubusercontent.com/17365077/131933568-3c77dc62-c37d-40c1-b334-4dba69f00d77.png)

<hr />

Preview mode with short input still keeps the textbox minHeight to prevent layout shift

![somethingShort](https://user-images.githubusercontent.com/17365077/131933574-5ab517c5-6cbb-4a93-8628-1fd5e95e2ec6.png)
