### PR TITLE
Add google search console verification file

### DIFF
--- a/public/google374fa39cff3d32f3.html
+++ b/public/google374fa39cff3d32f3.html
@@ -1,0 +1,1 @@
+google-site-verification: google374fa39cff3d32f3.html


### PR DESCRIPTION
# Description

Registering a Google Search Console domain requires a verification step.

Adding this single html file to our public folder should do the trick.
https://c0d3-app-t2sxi406q-c0d3.vercel.app/google374fa39cff3d32f3.html

More Info:
https://support.google.com/webmasters/answer/9008080#html_verification&zippy=%2Chtml-file-upload