### PR TITLE
Change google search console verification method

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -44,6 +44,12 @@ function MyApp({ Component, pageProps, err }: IProps) {
           />
           <link rel="shortcut icon" href="/favicon.ico" />
 
+          {/* <!-- Google Search Console --> */}
+          <meta
+            name="google-site-verification"
+            content="g3XwtRaZPgo2DxVzw7ujpH5L0I0jqAmD-D5ojAS3bag"
+          />
+
           {/* <!-- Open Graph / Facebook --> */}
           <meta property="og:type" content="website" />
           <meta property="og:url" content="https://www.c0d3.com/" />

--- a/public/google374fa39cff3d32f3.html
+++ b/public/google374fa39cff3d32f3.html
@@ -1,1 +1,0 @@
-google-site-verification: google374fa39cff3d32f3.html


### PR DESCRIPTION
# Description

Google Search Console Verification take 2!

Trying out the meta tag verification method.

First attempt to verify with pr #1115 did not work (I may have just had to remove the `.html` as the public folder does not behave like a normal server and do that for us)

But a quick google search turned up this: [nextjs discussion that mentions the meta tag method](https://github.com/vercel/next.js/discussions/14806)
