### PR TITLE
Update#843 - Fixes utility functions in discordAuth.ts 

### DIFF
--- a/__tests__/pages/discord.test.js
+++ b/__tests__/pages/discord.test.js
@@ -6,8 +6,8 @@ jest.mock('../../helpers/middleware/logger')
 
 import nextConnect from 'next-connect'
 import {
-  getTokenFromAuthCode,
-  getUserInfoFromRefreshToken
+  getDiscordUserInfo,
+  setTokenFromAuthCode
 } from '../../helpers/discordAuth'
 
 const mockDiscordUserInfo = {
@@ -52,31 +52,18 @@ describe('discord redirect with auth code query parameter', () => {
   })
 
   it('return discord user info if valid refresh token', async () => {
-    getTokenFromAuthCode.mockResolvedValue({
-      refresh_token: 'fakeRefreshToken'
+    setTokenFromAuthCode.mockResolvedValue({
+      id: 123
     })
-    getUserInfoFromRefreshToken.mockResolvedValue(mockDiscordUserInfo)
+    getDiscordUserInfo.mockResolvedValue(mockDiscordUserInfo)
     await getHandler[1](
-      { query: { code: 'fakeAuthCode' }, user: { userId: '123' } },
+      { query: { code: 'fakeAuthCode' }, user: { id: 123 } },
       {
         json: userInfo => {
           expect(userInfo).toBe(mockDiscordUserInfo)
         }
       }
     )
-    expect(getTokenFromAuthCode).toBeCalledWith('fakeAuthCode')
-  })
-
-  it('should throw error if auth token invalid', async () => {
-    getTokenFromAuthCode.mockRejectedValue({})
-    await getHandler[1](
-      { query: { code: 'fakeAuthCode' }, user: { userId: '123' } },
-      mockErrorResponse
-    )
-
-    expect(mockErrorResponse.status).toHaveBeenCalledWith(400)
-    expect(mockErrorResponse.json).toHaveBeenCalledWith({
-      error: 'invalid auth code'
-    })
+    expect(setTokenFromAuthCode).toBeCalledWith(123, 'fakeAuthCode')
   })
 })

--- a/graphql/queryResolvers/session.ts
+++ b/graphql/queryResolvers/session.ts
@@ -14,7 +14,7 @@ export const session = async (_parent: void, _args: void, context: Context) => {
   // FYI: The reason we are querying with parallelized promises:
   // https://github.com/garageScript/c0d3-app/wiki/Sequelize-Query-Performance
   const [session, starsGiven] = await Promise.all([
-    userInfo(_parent, { username: user.username }, context),
+    userInfo(_parent, { username: user.username }),
     prisma.star.findMany({
       where: {
         studentId: user.id

--- a/helpers/controllers/userInfoController.test.js
+++ b/helpers/controllers/userInfoController.test.js
@@ -2,7 +2,7 @@ jest.mock('../discordAuth')
 import { SubmissionStatus } from '../../graphql'
 import prismaMock from '../../__tests__/utils/prismaMock'
 import { userInfo } from './userInfoController'
-import { getUserInfoFromRefreshToken } from '../discordAuth'
+import { getDiscordUserInfo } from '../discordAuth'
 
 const user = {
   id: '10',
@@ -37,14 +37,6 @@ describe('userInfo controller tests', () => {
       'Invalid user object'
     )
   })
-  test('should not call getUserInfoFromRefreshToken if user has no refresh token', async () => {
-    prismaMock.user.findFirst.mockResolvedValue(user)
-    prismaMock.userLesson.findMany.mockResolvedValue([userLesson])
-    prismaMock.submission.findMany.mockResolvedValue([submission])
-    prismaMock.star.findMany.mockResolvedValue([star])
-    await userInfo({}, { username: 'testing2020' }, mockCtx)
-    expect(getUserInfoFromRefreshToken.mock.calls.length).toBe(0)
-  })
   test('should return correct user info, submissions and user lesson', async () => {
     prismaMock.user.findFirst.mockResolvedValue({
       ...user,
@@ -53,7 +45,7 @@ describe('userInfo controller tests', () => {
     prismaMock.userLesson.findMany.mockResolvedValue([userLesson])
     prismaMock.submission.findMany.mockResolvedValue([submission])
     prismaMock.star.findMany.mockResolvedValue([star])
-    getUserInfoFromRefreshToken.mockResolvedValue({
+    getDiscordUserInfo.mockResolvedValue({
       userId: 'fakeId',
       username: 'fakeDiscordUser',
       avatarUrl: 'fakeUrl'
@@ -96,35 +88,6 @@ describe('userInfo controller tests', () => {
         discordUserId: 'fakeId',
         discordUsername: 'fakeDiscordUser',
         discordAvatarUrl: 'fakeUrl'
-      },
-      lessonStatus: [
-        {
-          ...userLesson,
-          starsReceived: []
-        }
-      ],
-      submissions: [submission]
-    })
-  })
-  test('should return empty values for discord username and avatar url if refresh token invalid', async () => {
-    prismaMock.user.findFirst.mockResolvedValue({
-      ...user,
-      discordRefreshToken: 'invalidToken'
-    })
-    prismaMock.userLesson.findMany.mockResolvedValue([userLesson])
-    prismaMock.submission.findMany.mockResolvedValue([submission])
-    prismaMock.star.findMany.mockResolvedValue([])
-    getUserInfoFromRefreshToken.mockImplementation(() => {
-      throw new Error('refresh token invalid for userId 123')
-    })
-    const returnValue = await userInfo({}, { username: user.username }, mockCtx)
-    expect(returnValue).toEqual({
-      user: {
-        ...user,
-        discordRefreshToken: 'invalidToken',
-        discordUserId: '',
-        discordUsername: '',
-        discordAvatarUrl: ''
       },
       lessonStatus: [
         {

--- a/helpers/controllers/userInfoController.ts
+++ b/helpers/controllers/userInfoController.ts
@@ -2,7 +2,7 @@ import type { Star } from '.prisma/client'
 import { UserInfoQueryVariables } from '../../graphql'
 import { Context } from '../../@types/helpers'
 import prisma from '../../prisma'
-import { getUserInfoFromRefreshToken } from '../../helpers/discordAuth'
+import { getDiscordUserInfo } from '../../helpers/discordAuth'
 
 type StarMap = {
   [lessonId: number]: Star[]
@@ -10,8 +10,7 @@ type StarMap = {
 
 export const userInfo = async (
   _parent: void,
-  { username }: UserInfoQueryVariables,
-  { req }: Context
+  { username }: UserInfoQueryVariables
 ) => {
   if (!username) {
     throw new Error('Invalid username')
@@ -26,22 +25,11 @@ export const userInfo = async (
     throw new Error('Invalid user object')
   }
 
-  let discordUserId = '',
-    discordUsername = '',
-    discordAvatarUrl = ''
-  if (user.discordRefreshToken) {
-    try {
-      const { userId, username, avatarUrl } = await getUserInfoFromRefreshToken(
-        user.id,
-        user.discordRefreshToken
-      )
-      discordUserId = userId
-      discordUsername = username
-      discordAvatarUrl = avatarUrl
-    } catch (error) {
-      req.error(error)
-    }
-  }
+  const {
+    userId: discordUserId,
+    username: discordUsername,
+    avatarUrl: discordAvatarUrl
+  } = await getDiscordUserInfo(user)
 
   const [userLessons, submissions, stars] = await prisma.$transaction([
     prisma.userLesson.findMany({

--- a/helpers/controllers/userInfoController.ts
+++ b/helpers/controllers/userInfoController.ts
@@ -1,6 +1,5 @@
 import type { Star } from '.prisma/client'
 import { UserInfoQueryVariables } from '../../graphql'
-import { Context } from '../../@types/helpers'
 import prisma from '../../prisma'
 import { getDiscordUserInfo } from '../../helpers/discordAuth'
 

--- a/helpers/discordAuth.test.js
+++ b/helpers/discordAuth.test.js
@@ -42,11 +42,15 @@ describe('getUserInfoFromRefreshToken function', () => {
     jest.clearAllMocks()
     prisma.user.update = jest.fn()
   })
+
+  global.Date.now = jest.fn(() => 200)
+
   it('should call the correct functions and update refresh token in database and return the correct object if refresh token valid', async () => {
     fetch.mockResolvedValueOnce({
       json: () => ({
         refresh_token: 'fakeRefreshToken',
-        access_token: 'fakeAccessToken'
+        access_token: 'fakeAccessToken',
+        expires_in: 10
       })
     })
     fetch.mockResolvedValueOnce({
@@ -56,6 +60,7 @@ describe('getUserInfoFromRefreshToken function', () => {
         avatar: 'ea8f5f59aff14450e892321ba128745d'
       })
     })
+
     const result = await getUserInfoFromRefreshToken(123, 'mockRefreshToken')
 
     expect(fetch.mock.calls.length).toBe(2)
@@ -94,7 +99,9 @@ describe('getUserInfoFromRefreshToken function', () => {
         id: 123
       },
       data: {
-        discordRefreshToken: 'fakeRefreshToken'
+        discordRefreshToken: 'fakeRefreshToken',
+        discordAccessToken: 'fakeAccessToken',
+        discordAccessTokenExpires: new Date(200 + 10 * 1000)
       }
     })
 
@@ -128,7 +135,9 @@ describe('getUserInfoFromRefreshToken function', () => {
         id: 123
       },
       data: {
-        discordRefreshToken: ''
+        discordRefreshToken: '',
+        discordAccessToken: '',
+        discordAccessTokenExpires: new Date(200)
       }
     })
   })

--- a/helpers/discordAuth.test.js
+++ b/helpers/discordAuth.test.js
@@ -8,14 +8,35 @@ import {
   client_id,
   client_secret,
   redirect_uri,
-  getTokenFromAuthCode,
-  getUserInfoFromRefreshToken
+  setTokenFromAuthCode,
+  getDiscordUserInfo
 } from './discordAuth'
+import { executionAsyncId } from 'async_hooks'
 
-describe('getTokenFromAuthCode function', () => {
-  test('fetch should be called once', async () => {
-    fetch.mockResolvedValue({ json: () => {} })
-    const mockRefreshToken = await getTokenFromAuthCode('123')
+const emptyUserInfoResult = {
+  userId: '',
+  username: '',
+  avatarUrl: '',
+  refreshToken: ''
+}
+
+describe('setTokenFromAuthCode function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    prisma.user.update = jest.fn()
+  })
+
+  global.Date.now = jest.fn(() => 200)
+
+  it('should call fetch once and update user in database', async () => {
+    fetch.mockResolvedValue({
+      json: () => ({
+        access_token: '',
+        refresh_token: '',
+        expires_in: 0
+      })
+    })
+    await setTokenFromAuthCode(123, 'fakeAuthCode')
 
     expect(fetch.mock.calls[0][0]).toBe(
       'https://discordapp.com/api/oauth2/token'
@@ -29,107 +50,11 @@ describe('getTokenFromAuthCode function', () => {
         grant_type: 'authorization_code',
         client_id,
         client_secret,
-        code: '123',
+        code: 'fakeAuthCode',
         redirect_uri,
         scope: 'email guilds.join gdm.join identify'
       })
     })
-  })
-})
-
-describe('getUserInfoFromRefreshToken function', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    prisma.user.update = jest.fn()
-  })
-
-  global.Date.now = jest.fn(() => 200)
-
-  it('should call the correct functions and update refresh token in database and return the correct object if refresh token valid', async () => {
-    fetch.mockResolvedValueOnce({
-      json: () => ({
-        refresh_token: 'fakeRefreshToken',
-        access_token: 'fakeAccessToken',
-        expires_in: 10
-      })
-    })
-    fetch.mockResolvedValueOnce({
-      json: () => ({
-        id: 'discord123',
-        username: 'discord-fakeuser',
-        avatar: 'ea8f5f59aff14450e892321ba128745d'
-      })
-    })
-
-    const result = await getUserInfoFromRefreshToken(123, 'mockRefreshToken')
-
-    expect(fetch.mock.calls.length).toBe(2)
-
-    // first fetch function call
-    expect(fetch.mock.calls[0][0]).toBe(
-      'https://discordapp.com/api/oauth2/token'
-    )
-    expect(fetch.mock.calls[0][1]).toEqual({
-      method: 'POST',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded;charset=utf-8'
-      },
-      body: new URLSearchParams({
-        client_id,
-        client_secret,
-        grant_type: 'refresh_token',
-        refresh_token: 'mockRefreshToken'
-      })
-    })
-
-    // second fetch function call
-    expect(fetch.mock.calls[1][0]).toBe('https://discordapp.com/api/users/@me')
-    expect(fetch.mock.calls[1][1]).toEqual({
-      method: 'GET',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded;charset=utf-8',
-        Authorization: 'Bearer fakeAccessToken'
-      }
-    })
-
-    // database call
-    expect(prisma.user.update.mock.calls.length).toBe(1)
-    expect(prisma.user.update.mock.calls[0][0]).toEqual({
-      where: {
-        id: 123
-      },
-      data: {
-        discordRefreshToken: 'fakeRefreshToken',
-        discordAccessToken: 'fakeAccessToken',
-        discordAccessTokenExpires: new Date(200 + 10 * 1000)
-      }
-    })
-
-    expect(result).toEqual({
-      userId: 'discord123',
-      username: 'discord-fakeuser',
-      avatarUrl:
-        'https://cdn.discordapp.com/avatars/discord123/ea8f5f59aff14450e892321ba128745d.png',
-      refreshToken: 'fakeRefreshToken'
-    })
-  })
-
-  it('should throw error and update database with empty string if refresh token invalid', async () => {
-    fetch.mockResolvedValueOnce({
-      json: () => ({})
-    })
-    try {
-      const result = await getUserInfoFromRefreshToken(
-        123,
-        'invalidRefreshToken'
-      )
-      expect(false).toEqual(true) // force test to fail
-    } catch (error) {
-      expect(error.message).toBe('refresh token invalid for userId 123')
-    }
-
-    expect(fetch.mock.calls.length).toBe(1)
-    expect(prisma.user.update.mock.calls.length).toBe(1)
     expect(prisma.user.update.mock.calls[0][0]).toEqual({
       where: {
         id: 123
@@ -139,6 +64,144 @@ describe('getUserInfoFromRefreshToken function', () => {
         discordAccessToken: '',
         discordAccessTokenExpires: new Date(200)
       }
+    })
+  })
+})
+
+describe('getDiscordUserInfo function', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    prisma.user.update = jest.fn()
+  })
+
+  global.Date.now = jest.fn(() => 200)
+
+  it('should return object with falsy values if user has no refresh token', async () => {
+    const mockUser = {
+      discordAccessToken: '',
+      discordAccessTokenExpires: '',
+      discordRefreshToken: ''
+    }
+    const result = await getDiscordUserInfo(mockUser)
+    expect(result).toEqual(emptyUserInfoResult)
+  })
+
+  it('should fetch new tokens if user has no access token, then update user in database', async () => {
+    const mockUser = {
+      id: 123,
+      discordAccessToken: '',
+      discordAccessTokenExpires: 'tokenExpiration',
+      discordRefreshToken: 'refreshToken'
+    }
+    fetch.mockResolvedValue({
+      json: () => ({
+        refresh_token: 'updatedRefreshToken',
+        access_token: 'updatedAccessToken',
+        expires_in: 10
+      })
+    })
+    await getDiscordUserInfo(mockUser)
+    expect(prisma.user.update.mock.calls[0][0]).toEqual({
+      where: {
+        id: 123
+      },
+      data: {
+        discordRefreshToken: 'updatedRefreshToken',
+        discordAccessToken: 'updatedAccessToken',
+        discordAccessTokenExpires: new Date(200 + 10 * 1000)
+      }
+    })
+  })
+
+  it('should fetch new tokens if access token is expired, then update user in database', async () => {
+    const mockUser = {
+      id: 123,
+      discordAccessToken: 'expiredAccessToken',
+      discordAccessTokenExpires: new Date(0),
+      discordRefreshToken: 'refreshToken'
+    }
+    fetch.mockResolvedValue({
+      json: () => ({
+        refresh_token: 'updatedRefreshToken',
+        access_token: 'updatedAccessToken',
+        expires_in: 10
+      })
+    })
+    await getDiscordUserInfo(mockUser)
+    expect(prisma.user.update.mock.calls[0][0]).toEqual({
+      where: {
+        id: 123
+      },
+      data: {
+        discordRefreshToken: 'updatedRefreshToken',
+        discordAccessToken: 'updatedAccessToken',
+        discordAccessTokenExpires: new Date(200 + 10 * 1000)
+      }
+    })
+  })
+
+  it('should return empty values if refresh token is invalid and update user in database', async () => {
+    const mockUser = {
+      id: 123,
+      discordAccessToken: 'invalidAccessToken',
+      discordAccessTokenExpires: 0,
+      discordRefreshToken: 'invalidRefreshToken'
+    }
+    fetch.mockResolvedValue({
+      json: () => ({
+        refresh_token: '',
+        access_token: '',
+        expires_in: 0
+      })
+    })
+    const result = await getDiscordUserInfo(mockUser)
+    expect(fetch.mock.calls.length).toBe(1)
+    expect(prisma.user.update.mock.calls[0][0]).toEqual({
+      where: {
+        id: 123
+      },
+      data: {
+        discordRefreshToken: '',
+        discordAccessToken: '',
+        discordAccessTokenExpires: new Date(200)
+      }
+    })
+    expect(result).toEqual(emptyUserInfoResult)
+  })
+
+  it('should call the correct functions and update refresh token in database and return the correct object if access token is valid', async () => {
+    const mockUser = {
+      id: 123,
+      discordAccessToken: 'validFreshAccessToken',
+      discordAccessTokenExpires: Date.now(),
+      discordRefreshToken: 'validRefreshToken'
+    }
+    fetch.mockResolvedValue({
+      json: () => ({
+        id: 'discord123',
+        username: 'discord-fakeuser',
+        avatar: 'ea8f5f59aff14450e892321ba128745d'
+      })
+    })
+    const result = await getDiscordUserInfo(mockUser)
+
+    expect(fetch.mock.calls.length).toBe(1)
+
+    expect(fetch.mock.calls[0][0]).toBe('https://discordapp.com/api/users/@me')
+    expect(fetch.mock.calls[0][1]).toEqual({
+      method: 'GET',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+        Authorization: 'Bearer validFreshAccessToken'
+      }
+    })
+
+    expect(result).toEqual({
+      userId: 'discord123',
+      username: 'discord-fakeuser',
+      avatarUrl:
+        'https://cdn.discordapp.com/avatars/discord123/ea8f5f59aff14450e892321ba128745d.png',
+      refreshToken: 'validRefreshToken'
     })
   })
 })

--- a/pages/api/auth/callback/discord.ts
+++ b/pages/api/auth/callback/discord.ts
@@ -1,6 +1,6 @@
 import {
-  getTokenFromAuthCode,
-  getUserInfoFromRefreshToken
+  setTokenFromAuthCode,
+  getDiscordUserInfo
 } from '../../../../helpers/discordAuth'
 import { NextApiResponse } from 'next'
 import { LoggedRequest } from '../../../../@types/helpers'
@@ -23,14 +23,11 @@ const discordOAuthHandler = async (
   const { code } = req.query
 
   try {
-    const { refresh_token } = await getTokenFromAuthCode(code as string)
-    const userInfo = await getUserInfoFromRefreshToken(
-      req.user.id,
-      refresh_token
-    )
+    const user = await setTokenFromAuthCode(req.user.id, code as string)
+    const userInfo = await getDiscordUserInfo(user)
     return res.json(userInfo)
   } catch (error) {
-    res.status(400).json({ error: 'invalid auth code' })
+    res.status(400).json({ error })
   }
 }
 

--- a/pages/api/auth/callback/discord.ts
+++ b/pages/api/auth/callback/discord.ts
@@ -22,13 +22,9 @@ const discordOAuthHandler = async (
 
   const { code } = req.query
 
-  try {
-    const user = await setTokenFromAuthCode(req.user.id, code as string)
-    const userInfo = await getDiscordUserInfo(user)
-    return res.json(userInfo)
-  } catch (error) {
-    res.status(400).json({ error })
-  }
+  const user = await setTokenFromAuthCode(req.user.id, code as string)
+  const userInfo = await getDiscordUserInfo(user)
+  return res.json(userInfo)
 }
 
 handler

--- a/prisma/migrations/20210905112311_added_acces_token_and_expiration/migration.sql
+++ b/prisma/migrations/20210905112311_added_acces_token_and_expiration/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "discordAccessToken" VARCHAR(255),
+ADD COLUMN     "discordAccessTokenExpires" TIMESTAMPTZ(6);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -128,27 +128,29 @@ model UserLesson {
 }
 
 model User {
-  id                     Int          @id @default(autoincrement())
-  name                   String       @db.VarChar(255)
-  username               String       @db.VarChar(255)
-  password               String?      @db.VarChar(255)
-  email                  String       @db.VarChar(255)
-  gsId                   Int?
-  isOnline               Boolean?
-  createdAt              DateTime     @default(now()) @db.Timestamptz(6)
-  updatedAt              DateTime     @updatedAt @db.Timestamptz(6)
-  isAdmin                Boolean      @default(false)
-  forgotToken            String?      @db.VarChar(255)
-  cliToken               String?      @db.VarChar(255)
-  emailVerificationToken String?      @db.VarChar(255)
-  tokenExpiration        DateTime?    @db.Timestamptz(6)
-  discordRefreshToken    String?      @db.VarChar(255)
-  starsMentor            Star[]       @relation("starMentor")
-  starsGiven             Star[]       @relation("starStudent")
-  submissionsReviewed    Submission[] @relation("userReviewedSubmissions")
-  submissions            Submission[] @relation("userSubmissions")
-  userLessons            UserLesson[]
-  comments               Comment[]
+  id                        Int          @id @default(autoincrement())
+  name                      String       @db.VarChar(255)
+  username                  String       @db.VarChar(255)
+  password                  String?      @db.VarChar(255)
+  email                     String       @db.VarChar(255)
+  gsId                      Int?
+  isOnline                  Boolean?
+  createdAt                 DateTime     @default(now()) @db.Timestamptz(6)
+  updatedAt                 DateTime     @updatedAt @db.Timestamptz(6)
+  isAdmin                   Boolean      @default(false)
+  forgotToken               String?      @db.VarChar(255)
+  cliToken                  String?      @db.VarChar(255)
+  emailVerificationToken    String?      @db.VarChar(255)
+  tokenExpiration           DateTime?    @db.Timestamptz(6)
+  discordRefreshToken       String?      @db.VarChar(255)
+  discordAccessToken        String?      @db.VarChar(255)
+  discordAccessTokenExpires DateTime?    @db.Timestamptz(6)
+  starsMentor               Star[]       @relation("starMentor")
+  starsGiven                Star[]       @relation("starStudent")
+  submissionsReviewed       Submission[] @relation("userReviewedSubmissions")
+  submissions               Submission[] @relation("userSubmissions")
+  userLessons               UserLesson[]
+  comments                  Comment[]
 
   @@map("users")
 }


### PR DESCRIPTION
This PR adds two new User columns: the discord access token and its expiration date.

previously, our app was making two calls to userInfoController every time the user navigates. each call took a refresh token, got a new refresh token from it and updated it in database. however, the first call didn't update User's the refresh token in time for the second call, so the 'old' refresh token was coming up invalid.

discordAuth now has a new function getDiscordUserInfo, which takes in a User object (from prisma.user) and returns a discordUserInfo object. The improvement is that it just uses the stored access token to fetch discord user info, without going through the whole refresh token exchange step (unless the access token is expired).

two other files - userInfoController.ts and discord.ts used those utility functions, and therefore had to be updated with their tests.

