### PR TITLE
Fix failing time related test snapshots

### DIFF
--- a/__tests__/storyshots.test.js
+++ b/__tests__/storyshots.test.js
@@ -1,6 +1,8 @@
 import initStoryshots from '@storybook/addon-storyshots'
 
-/*	
+jest.useFakeTimers('modern').setSystemTime(new Date('2021-10-21').getTime())
+
+/* 
 	This mock is necessary because there is currently a problem
 	with taking storyshots of Modals. See here for more info:
 	https://github.com/storybookjs/storybook/issues/2822


### PR DESCRIPTION
## what

Fix failing `storyshots.test.js` time related screenshots  tests
![storyshotsTimeFail](https://user-images.githubusercontent.com/17365077/138504840-a0fe6815-5edc-4b9e-a24e-afd89456ece0.png)


## why

Today is 10/22/2021 which is just over the 3.5year mark from the tests 4/22/2018. These components round to the nearest year and was displaying 4 years instead of the old 3 years.

## how

Enable mocked system time for the storyshots test suite like our other time related components are tested: `jest.useFakeTimers('modern').setSystemTime(new Date('2021-10-21').getTime())`

\* I just set the date to yesterday knowing all tests were passing then and I wouldn't have to update any snapshots