### PR TITLE
Update #843 - test discord modal in production

### DIFF
--- a/helpers/discordAuth.ts
+++ b/helpers/discordAuth.ts
@@ -4,9 +4,9 @@ import { User } from '.prisma/client'
 import fetch from 'node-fetch'
 
 const discordAPI = 'https://discordapp.com/api'
-export const client_id = process.env.NEXT_PUBLIC_DISCORD_KEY
-export const client_secret = process.env.NEXT_PUBLIC_DISCORD_SECRET
-export const redirect_uri = process.env.NEXT_PUBLIC_DISCORD_REDIRECT_URI // {baseurl}/api/auth/callback/discord
+export const client_id = process.env.DISCORD_KEY
+export const client_secret = process.env.DISCORD_SECRET
+export const redirect_uri = process.env.DISCORD_REDIRECT_URI // {baseurl}/api/auth/callback/discord
 
 type AccessTokenResponse = {
   access_token: string

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -136,6 +136,7 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
     if (data && data.session) {
       if (data.session.user && !data.session.user.isConnectedToDiscord) {
         setShowConnectToDiscordModal(
+          // remove localStorage line when this works in production
           !!localStorage.getItem('discordmodal') || true
         )
       }


### PR DESCRIPTION
Connect to Discord auth flow not working in production for some reason. could be a problem with environment variables named incorrectly. This fix allows me to test the merged PR in production.