### PR TITLE
Update #843- removes localstorage setting on /curriculum

### DIFF
--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -135,10 +135,7 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
   useEffect(() => {
     if (data && data.session) {
       if (data.session.user && !data.session.user.isConnectedToDiscord) {
-        setShowConnectToDiscordModal(
-          // remove localStorage line when this works in production
-          !!localStorage.getItem('discordmodal') || true
-        )
+        setShowConnectToDiscordModal(true)
       }
       setState({
         session: data.session,


### PR DESCRIPTION
Discord modal and auth flow now works in production