### PR TITLE
Update #843 - allows user to opt out of Discord

### DIFF
--- a/__tests__/pages/curriculum.test.js
+++ b/__tests__/pages/curriculum.test.js
@@ -180,7 +180,7 @@ describe('Curriculum Page', () => {
     )
     expect(arrow.className.includes('left'))
   })
-  test('Should load Connect to Discord modal if user not connected to discord', async () => {
+  test('Should load Connect to Discord modal if user not connected to discord and close modal if user declines', async () => {
     const mocks = [
       {
         request: { query: GET_APP },
@@ -205,6 +205,12 @@ describe('Curriculum Page', () => {
 
     await waitFor(() =>
       expect(screen.getByText('Connect to Discord')).toBeTruthy()
+    )
+
+    // user clicks no thanks or escapes modal
+    await waitFor(() => fireEvent.click(screen.getByText(/No thanks/)))
+    await waitFor(() =>
+      expect(screen.queryByText('Connect to Discord')).toBeFalsy()
     )
   })
   test('should not show Connect to Discord modal if user is connected', async () => {

--- a/__tests__/pages/curriculum.test.js
+++ b/__tests__/pages/curriculum.test.js
@@ -207,4 +207,31 @@ describe('Curriculum Page', () => {
       expect(screen.getByText('Connect to Discord')).toBeTruthy()
     )
   })
+  test('should not show Connect to Discord modal if user is connected', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            lessons: dummyLessonData,
+            session: {
+              ...dummySessionData,
+              user: { ...dummySessionData.user, isConnectedToDiscord: true }
+            },
+            alerts: []
+          }
+        }
+      }
+    ]
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Curriculum lessons={dummyLessonData} alerts={[]} />
+      </MockedProvider>
+    )
+
+    await waitFor(() =>
+      expect(screen.queryByText('Connect to Discord')).toBeFalsy()
+    )
+  })
 })

--- a/components/ConnectToDiscordModal.test.js
+++ b/components/ConnectToDiscordModal.test.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import ConnectToDiscordModal from './ConnectToDiscordModal'
+import { render, waitFor, fireEvent, screen } from '@testing-library/react'
+
+describe('ConnectToDiscordModal component', () => {
+  it('should close modal if user opts out of connecting to Discord', async () => {
+    let res = ''
+    const expectedResult = 'potatus maximus'
+    render(
+      <ConnectToDiscordModal show={true} close={() => (res = expectedResult)} />
+    )
+    await waitFor(() => fireEvent.click(screen.getByText(/No thanks/)))
+    expect(res).toEqual(expectedResult)
+  })
+})

--- a/components/ConnectToDiscordModal.test.js
+++ b/components/ConnectToDiscordModal.test.js
@@ -3,7 +3,7 @@ import ConnectToDiscordModal from './ConnectToDiscordModal'
 import { render, waitFor, fireEvent, screen } from '@testing-library/react'
 
 describe('ConnectToDiscordModal component', () => {
-  it('should close modal if user opts out of connecting to Discord', async () => {
+  it('should call close modal function if user opts out of connecting to Discord', async () => {
     let res = ''
     const expectedResult = 'potatus maximus'
     render(
@@ -11,5 +11,14 @@ describe('ConnectToDiscordModal component', () => {
     )
     await waitFor(() => fireEvent.click(screen.getByText(/No thanks/)))
     expect(res).toEqual(expectedResult)
+  })
+  it('should not show modal if user opts out of connecting to Discord', async () => {
+    const mockProps = {
+      show: true,
+      close: jest.fn()
+    }
+    render(<ConnectToDiscordModal {...mockProps} />)
+    await waitFor(() => fireEvent.click(screen.getByText(/No thanks/)))
+    expect(mockProps.close).toHaveBeenCalledTimes(1)
   })
 })

--- a/components/ConnectToDiscordModal.tsx
+++ b/components/ConnectToDiscordModal.tsx
@@ -53,10 +53,7 @@ const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
             Connect Now
           </button>
         </NavLink>
-        <div
-          className="text-center"
-          onClick={/* istanbul ignore next */ () => close()}
-        >
+        <div className="text-center" onClick={() => close()}>
           <a href="#">No thanks, I&apos;ll study on my own.</a>
         </div>
       </div>

--- a/components/ConnectToDiscordModal.tsx
+++ b/components/ConnectToDiscordModal.tsx
@@ -30,7 +30,7 @@ const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
   /*
     show = false // means connected to Discord
 
-    show | localStorage too old | Final
+    show | showAgain            | Final
     0    |  0  (doesn't matter) |  0
     0    |  1  (doesn't matter) |  0
     1    |  0                   |  0

--- a/components/ConnectToDiscordModal.tsx
+++ b/components/ConnectToDiscordModal.tsx
@@ -1,22 +1,23 @@
 import React from 'react'
 import { ModalCard, ModalSize } from './ModalCard'
 import NavLink from './NavLink'
-import LogoutContainer from './LogoutContainer'
 
 type ConnectToDiscordModalProps = {
   show: boolean
+  close: Function
 }
 
 const discordConnectPage = `${process.env.NEXT_PUBLIC_DISCORD_CALLBACK_URI}`
 
 const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
-  show
+  show,
+  close
 }) => {
   return (
     <ModalCard
       hideable={false}
       size={ModalSize.LARGE}
-      close={/* istanbul ignore next */ () => {}}
+      close={close}
       show={show}
     >
       <div className="m-5">
@@ -52,11 +53,9 @@ const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
             Connect Now
           </button>
         </NavLink>
-        <LogoutContainer>
-          <div className="text-center">
-            <a href="#">No thanks, I&apos;ll study on my own.</a>
-          </div>
-        </LogoutContainer>
+        <div className="text-center" onClick={() => close()}>
+          <a href="#">No thanks, I&apos;ll study on my own.</a>
+        </div>
       </div>
     </ModalCard>
   )

--- a/components/ConnectToDiscordModal.tsx
+++ b/components/ConnectToDiscordModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { ModalCard, ModalSize } from './ModalCard'
 import NavLink from './NavLink'
 
@@ -9,16 +9,37 @@ type ConnectToDiscordModalProps = {
 
 const discordConnectPage = `${process.env.NEXT_PUBLIC_DISCORD_CALLBACK_URI}`
 
+const CONNECT_TO_DISCORD_LOCALSTORAGE_KEY = 'connect-to-discord'
+const SEVEN_DAYS = 1000 * 60 * 60 * 24 * 7
+
 const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
   show,
   close
 }) => {
+  const [dismissalDate, setDismissalDate] = useState(0)
+  useEffect(() => {
+    const prevDismissalDate = localStorage.getItem(CONNECT_TO_DISCORD_LOCALSTORAGE_KEY)
+    if (!prevDismissalDate) {
+      return
+    }
+    setDismissalDate(Number(prevDismissalDate))
+  }, [])
+  const showAgain = Date.now() - SEVEN_DAYS > dismissalDate
+  /*
+    show = false // means connected to Discord
+
+    show | localStorage too old | Final
+    0    |  0  (doesn't matter) |  0
+    0    |  1  (doesn't matter) |  0
+    1    |  0                   |  0
+    1    |  1                   |  1
+  */
   return (
     <ModalCard
       hideable={false}
       size={ModalSize.LARGE}
       close={close}
-      show={show}
+      show={show && showAgain}
     >
       <div className="m-5">
         <h3 className="text-center">Connect to Discord</h3>
@@ -53,7 +74,10 @@ const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
             Connect Now
           </button>
         </NavLink>
-        <div className="text-center" onClick={() => close()}>
+        <div className="text-center" onClick={() => {
+          localStorage.setItem(CONNECT_TO_DISCORD_LOCALSTORAGE_KEY, String(Date.now()))
+          close()
+        }}>
           <a href="#">No thanks, I&apos;ll study on my own.</a>
         </div>
       </div>

--- a/components/ConnectToDiscordModal.tsx
+++ b/components/ConnectToDiscordModal.tsx
@@ -53,7 +53,10 @@ const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
             Connect Now
           </button>
         </NavLink>
-        <div className="text-center" onClick={() => close()}>
+        <div
+          className="text-center"
+          onClick={/* istanbul ignore next */ () => close()}
+        >
           <a href="#">No thanks, I&apos;ll study on my own.</a>
         </div>
       </div>

--- a/components/ConnectToDiscordModal.tsx
+++ b/components/ConnectToDiscordModal.tsx
@@ -18,7 +18,9 @@ const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
 }) => {
   const [dismissalDate, setDismissalDate] = useState(0)
   useEffect(() => {
-    const prevDismissalDate = localStorage.getItem(CONNECT_TO_DISCORD_LOCALSTORAGE_KEY)
+    const prevDismissalDate = localStorage.getItem(
+      CONNECT_TO_DISCORD_LOCALSTORAGE_KEY
+    )
     if (!prevDismissalDate) {
       return
     }
@@ -74,10 +76,16 @@ const ConnectToDiscordModal: React.FC<ConnectToDiscordModalProps> = ({
             Connect Now
           </button>
         </NavLink>
-        <div className="text-center" onClick={() => {
-          localStorage.setItem(CONNECT_TO_DISCORD_LOCALSTORAGE_KEY, String(Date.now()))
-          close()
-        }}>
+        <div
+          className="text-center"
+          onClick={() => {
+            localStorage.setItem(
+              CONNECT_TO_DISCORD_LOCALSTORAGE_KEY,
+              String(Date.now())
+            )
+            close()
+          }}
+        >
           <a href="#">No thanks, I&apos;ll study on my own.</a>
         </div>
       </div>

--- a/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
+++ b/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
@@ -740,8 +740,6 @@ exports[`AdminLessonsInfo component Should create new lesson 2`] = `
 </div>
 `;
 
-exports[`AdminLessonsInfo component Should refuse creating new lesson incomplete info 1`] = `<div />`;
-
 exports[`AdminLessonsInfo component Should render non-existent lesson 1`] = `
 <div>
   <div

--- a/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
+++ b/components/admin/lessons/__snapshots__/AdminLessonInfo.test.js.snap
@@ -740,6 +740,8 @@ exports[`AdminLessonsInfo component Should create new lesson 2`] = `
 </div>
 `;
 
+exports[`AdminLessonsInfo component Should refuse creating new lesson incomplete info 1`] = `<div />`;
+
 exports[`AdminLessonsInfo component Should render non-existent lesson 1`] = `
 <div>
   <div

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -171,7 +171,10 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
   })
   return (
     <>
-      <ConnectToDiscordModal show={showConnectToDiscordModal} />
+      <ConnectToDiscordModal
+        show={showConnectToDiscordModal}
+        close={() => setShowConnectToDiscordModal(false)}
+      />
       <Layout title="Curriculum">
         {hasMounted &&
           typeof window !== 'undefined' &&

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -173,7 +173,9 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
     <>
       <ConnectToDiscordModal
         show={showConnectToDiscordModal}
-        close={() => setShowConnectToDiscordModal(false)}
+        close={
+          /* istanbul ignore next */ () => setShowConnectToDiscordModal(false)
+        }
       />
       <Layout title="Curriculum">
         {hasMounted &&

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -173,8 +173,7 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
     <>
       <ConnectToDiscordModal
         show={showConnectToDiscordModal}
-        close={
-          /* istanbul ignore next */ () => setShowConnectToDiscordModal(false)
+        close={() => setShowConnectToDiscordModal(false)
         }
       />
       <Layout title="Curriculum">

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -173,9 +173,7 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
     <>
       <ConnectToDiscordModal
         show={showConnectToDiscordModal}
-        close={
-          /* istanbul ignore next */ () => setShowConnectToDiscordModal(false)
-        }
+        close={() => setShowConnectToDiscordModal(false)}
       />
       <Layout title="Curriculum">
         {hasMounted &&

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -173,7 +173,9 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
     <>
       <ConnectToDiscordModal
         show={showConnectToDiscordModal}
-        close={() => setShowConnectToDiscordModal(false)}
+        close={
+          /* instanbul ignore next */ () => setShowConnectToDiscordModal(false)
+        }
       />
       <Layout title="Curriculum">
         {hasMounted &&

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -173,8 +173,7 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
     <>
       <ConnectToDiscordModal
         show={showConnectToDiscordModal}
-        close={() => setShowConnectToDiscordModal(false)
-        }
+        close={() => setShowConnectToDiscordModal(false)}
       />
       <Layout title="Curriculum">
         {hasMounted &&

--- a/pages/curriculum.tsx
+++ b/pages/curriculum.tsx
@@ -174,7 +174,7 @@ export const Curriculum: React.FC<Props> = ({ lessons, alerts }) => {
       <ConnectToDiscordModal
         show={showConnectToDiscordModal}
         close={
-          /* instanbul ignore next */ () => setShowConnectToDiscordModal(false)
+          /* istanbul ignore next */ () => setShowConnectToDiscordModal(false)
         }
       />
       <Layout title="Curriculum">


### PR DESCRIPTION
after further consideration, perhaps allowing user to opt out of connecting to Discord would make for a friendlier experience.

the modal will still pop up when /curriculum page refreshes though, since the component reloads.