### PR TITLE
Fixes issue with js2 test and solution for less3Diff

### DIFF
--- a/content/lessons/js2/sublesson/introduction_to_testing_inner_properties.mdx
+++ b/content/lessons/js2/sublesson/introduction_to_testing_inner_properties.mdx
@@ -205,6 +205,10 @@ re-run the tests (or leave them running with `--watch`).
        const result = fn.less3Diff('jk', 'lm')
        expect(result).toEqual(true)
      })
+     it('should return false on strings equal to 3 and that are different', () => {
+       const result = fn.less3Diff('cho', 'tis')
+       expect(result).toEqual(false)
+     })
    })
    ```
 
@@ -232,11 +236,11 @@ re-run the tests (or leave them running with `--watch`).
 
    ```jsx
    const less3Diff = (str1, str2, i = 0, differences = 0) => {
-     if (i === str1.length) {
-       return true
-     }
      if (differences > 2) {
        return false
+     }
+     if (i === str1.length) {
+       return true
      }
      if (str1[i] !== str2[i]) {
        differences = differences + 1


### PR DESCRIPTION
# Problem
Closes #1195

Problem `less3Diff` should return true if there are **fewer than 3 differences**. The provided example code returns `true` for exactly 3 difference, which is incorrect.

# Solution
This change
* fixes the solution sample code. 
* Adds a test to make sure exactly 3 difference always returns false