### PR TITLE
Updates promises.mdx

### DIFF
--- a/content/lessons/js3/sublesson/promises.mdx
+++ b/content/lessons/js3/sublesson/promises.mdx
@@ -271,6 +271,11 @@ object a value. Whatever value you set will be exported. `module.exports` is a
 keyword provided by nodeJS. You've seen it used to export solution files to a
 test file.
 
+> Some modules are dropping support for commonJS. You may have to use import
+> instead of require and write "type": "module" into your package.json file.
+> Read more
+> [ESM modules](https://www.digitalocean.com/community/tutorials/js-modules-es6)
+
 ```jsx
 module.exports = [1, 2, 3] // What is module.exports?
 // What type of data is module?

--- a/content/lessons/js3/sublesson/promises.mdx
+++ b/content/lessons/js3/sublesson/promises.mdx
@@ -271,8 +271,8 @@ object a value. Whatever value you set will be exported. `module.exports` is a
 keyword provided by nodeJS. You've seen it used to export solution files to a
 test file.
 
-> Some modules are dropping support for commonJS. You may have to use import
-> instead of require and write "type": "module" into your package.json file.
+> Some modules are dropping support for commonJS. You may have to use `import`
+> instead of `require` and write `"type": "module"` into your `package.json` file.
 > Read more
 > [ESM modules](https://www.digitalocean.com/community/tutorials/js-modules-es6)
 


### PR DESCRIPTION
# Problem
`node-fetch v3` has dropped support for commonjs. As a result, `require('node-fetch')` no longer works, causing our sample code to give an error.

# Solution
This PR will give a quick update to students about how they could fix the problem by changing `package.json` type to allow them to use `import` instead of `require`.