### PR TITLE
Fixes grammatical error in preflight exercise 4 of js3

### DIFF
--- a/content/lessons/js3/sublesson/preflight.mdx
+++ b/content/lessons/js3/sublesson/preflight.mdx
@@ -310,7 +310,7 @@ const zeroSquare = (num, i = 0, res = []) => {
 <Spoiler name = 'Debrief'>
 
 Here's our first experience with using mulitple iterators (engineers often call
-them i and j, or you call could them row and col) to navigate a 2D array. There
+them i and j, or you could call them row and col) to navigate a 2D array. There
 are multiple ways you could have done this, so don’t worry if yours doesn’t look
 quite like this. In this method, j keeps track of which row we're in, while i
 goes along the columns. The function increments i until each row fills up (this

--- a/content/lessons/js3/sublesson/preflight.mdx
+++ b/content/lessons/js3/sublesson/preflight.mdx
@@ -309,7 +309,7 @@ const zeroSquare = (num, i = 0, res = []) => {
 
 <Spoiler name = 'Debrief'>
 
-Here's our first experience with using mulitple iterators (engineers often call
+Here's our first experience with using multiple iterators (engineers often call
 them i and j, or you could call them row and col) to navigate a 2D array. There
 are multiple ways you could have done this, so don’t worry if yours doesn’t look
 quite like this. In this method, j keeps track of which row we're in, while i


### PR DESCRIPTION
# Problem

Closes #1216 

![](https://user-images.githubusercontent.com/60295734/147080759-8fb17c80-ed06-4a9a-8a4c-1e10dfffc9a3.png)

# Solution
Fixes 2 typos: word "multiple" and "could call" 
