### PR TITLE
Bump @testing-library/user-event from 12.8.3 to 13.5.0

### DIFF
--- a/components/admin/lessons/AdminLessonChallenges.test.js
+++ b/components/admin/lessons/AdminLessonChallenges.test.js
@@ -76,15 +76,19 @@ describe('AdminLessonChallenges component', () => {
       </MockedProvider>
     )
     expect(container).toMatchSnapshot()
-    const titles = screen.getAllByTestId('input1')
-    const descriptions = screen.getAllByTestId('textbox')
-    const orders = screen.getAllByTestId('input3')
-    userEvent.clear(titles[0])
-    userEvent.clear(descriptions[0])
-    userEvent.clear(orders[0])
-    await userEvent.type(titles[0], 'New title', { delay: 1 })
-    await userEvent.type(descriptions[0], 'New description', { delay: 1 })
-    await userEvent.type(orders[0], '15', { delay: 1 })
+    const title = screen.getAllByTestId('input1')[0]
+    const description = screen.getAllByTestId('textbox')[0]
+    const order = screen.getAllByTestId('input3')[0]
+
+    title.setSelectionRange(0, title.value.length)
+    description.setSelectionRange(0, description.value.length)
+    order.setSelectionRange(0, order.value.length)
+
+    await userEvent.type(title, '{backspace}New title', { delay: 1 })
+    await userEvent.type(description, '{backspace}New description', {
+      delay: 1
+    })
+    await userEvent.type(order, '{backspace}15', { delay: 1 })
     await waitFor(() =>
       userEvent.click(screen.getAllByText('Update Challenge')[0])
     )
@@ -121,15 +125,17 @@ describe('AdminLessonChallenges component', () => {
         />
       </MockedProvider>
     )
-    const titles = screen.getAllByTestId('input1')
-    const descriptions = screen.getAllByTestId('textbox')
-    const orders = screen.getAllByTestId('input3')
-    userEvent.clear(titles[0])
-    userEvent.clear(descriptions[0])
-    userEvent.clear(orders[0])
-    await userEvent.type(titles[0], 'New title', { delay: 1 })
-    await userEvent.type(descriptions[0], 'New description', { delay: 1 })
-    await userEvent.type(orders[0], '', { delay: 1 })
+    const title = screen.getAllByTestId('input1')[0]
+    const description = screen.getAllByTestId('textbox')[0]
+    const order = screen.getAllByTestId('input3')[0]
+    title.setSelectionRange(0, title.value.length)
+    description.setSelectionRange(0, description.value.length)
+    order.setSelectionRange(0, order.value.length)
+    await userEvent.type(title, '{backspace}New title', { delay: 1 })
+    await userEvent.type(description, '{backspace}New description', {
+      delay: 1
+    })
+    await userEvent.type(order, '{backspace}', { delay: 1 })
     await waitFor(() =>
       userEvent.click(screen.getAllByText('Update Challenge')[0])
     )
@@ -152,7 +158,7 @@ describe('AdminLessonChallenges component', () => {
     const order = screen.getByTestId('input2')
     await userEvent.type(title, 'New challenge', { delay: 1 })
     await userEvent.type(description, 'New challenge description', { delay: 1 })
-    await userEvent.type(order, '', { delay: 1 })
+    await userEvent.type(order, '{backspace}', { delay: 1 })
     await waitFor(() => userEvent.click(screen.getByText('Create Challenge')))
     await waitFor(() => expect(reload).not.toBeCalled())
     await waitFor(() => expect(screen.getByText('Required')).toBeTruthy())

--- a/components/admin/lessons/AdminLessonInfo.test.js
+++ b/components/admin/lessons/AdminLessonInfo.test.js
@@ -106,7 +106,17 @@ describe('AdminLessonsInfo component', () => {
         />
       </MockedProvider>
     )
+
     const newLesson = screen.getAllByTestId('input1')[1]
+
+    /*
+     * Previously we were using the clear function from the userEvent library
+     * After updating to version 13.5.0, the clear function stopped working so
+     * to work around that I used setSelectionRange and with the type userEvent,
+     * I was able to modify the inputs. The link to the docs is below:
+     * https://testing-library.com/docs/ecosystem-user-event/#typeelement-text-options
+     */
+
     newLesson.setSelectionRange(0, 16)
     await userEvent.type(newLesson, 'New Lesson', {
       delay: 1

--- a/components/admin/lessons/AdminLessonInfo.test.js
+++ b/components/admin/lessons/AdminLessonInfo.test.js
@@ -106,8 +106,9 @@ describe('AdminLessonsInfo component', () => {
         />
       </MockedProvider>
     )
-    userEvent.clear(screen.getAllByTestId('input1')[1])
-    await userEvent.type(screen.getAllByTestId('input1')[1], 'New Lesson', {
+    const newLesson = screen.getAllByTestId('input1')[1]
+    newLesson.setSelectionRange(0, 16)
+    await userEvent.type(newLesson, 'New Lesson', {
       delay: 1
     })
     const description = screen.getByText(
@@ -115,8 +116,9 @@ describe('AdminLessonsInfo component', () => {
     )
     description.setSelectionRange(0, 52)
     await userEvent.type(description, 'New description', { delay: 1 })
-    userEvent.clear(screen.getByTestId('input6'))
-    await userEvent.type(screen.getByTestId('input6'), '10', { delay: 1 })
+    const order = screen.getByTestId('input6')
+    order.setSelectionRange(0, 1)
+    await userEvent.type(order, '10', { delay: 1 })
     await waitFor(() =>
       userEvent.click(screen.getByRole('button', { name: 'Update Lesson' }))
     )

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
-    "@testing-library/user-event": "^12.7.0",
+    "@testing-library/user-event": "^13.5.0",
     "@types/bcrypt": "^5.0.0",
     "@types/express-session": "^1.17.4",
     "@types/lodash": "^4.14.178",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,10 +4455,10 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
 
-"@testing-library/user-event@^12.7.0":
-  version "12.8.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.8.3.tgz#1aa3ed4b9f79340a1e1836bc7f57c501e838704a"
-  integrity sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==
+"@testing-library/user-event@^13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
This updates https://github.com/garageScript/c0d3-app/pull/1146

Bumps [@testing-library/user-event](https://github.com/testing-library/user-event) from 12.8.3 to 13.5.0.
- [Release notes](https://github.com/testing-library/user-event/releases)
- [Changelog](https://github.com/testing-library/user-event/blob/main/CHANGELOG.md)
- [Commits](https://github.com/testing-library/user-event/compare/v12.8.3...v13.5.0)

---
updated-dependencies:
- dependency-name: "@testing-library/user-event"
  dependency-type: direct:development
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>