### PR TITLE
updates package.json to run test in band and updates .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ DB_NAME=c0d3
 DB_PW=admin
 DB_HOST=localhost
 DB_PORT=5432
-DB_URL="postgresql://${DB_USER}:${DB_PW}@${DB_HOST}:5432/${DB_NAME}?connection_limit=1"
+DB_URL="postgresql://${DB_USER}:${DB_PW}@${DB_HOST}:${DB_PORT}/${DB_NAME}?connection_limit=1"
 
 # EMAIL CONFIG
 SMTP_HOST=smtp.example.com

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "autofix": "yarn lint:fix && svgo --folder=public --recursive && svgo --folder=assets --recursive",
     "storybook": "start-storybook -p $STORY_PORT -c .storybook -s ./public",
     "build-storybook": "build-storybook -c .storybook -s ./public",
-    "test": "TZ=UTC jest --coverage",
+    "test": "TZ=UTC jest --coverage --runInBand",
     "ts-node": "ts-node --compiler-options {\\\"module\\\":\\\"CommonJS\\\"}",
     "type-check": "tsc",
     "generate": "graphql-codegen --config codegen.yml",


### PR DESCRIPTION
# Changes 

## .env.example
.env.example was hard coded for port 5432. I updated the file to use the DB_PORT variable instead of the hardcoded port. 

## package.json
We have begun to use the --runInBand flag when running the test. 
I updated test script to use the --runInBand flag.