### PR TITLE
Bump prettier from 2.3.2 to 2.5.1

### DIFF
--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -268,64 +268,58 @@ type ChallengesCompletedCardProps = {
   chatUrl: string
 }
 
-export const ChallengesCompletedCard: React.FC<ChallengesCompletedCardProps> =
-  ({ imageSrc, chatUrl, reviewUrl, starGiven, lessonId }) => {
-    const [show, setShow] = useState<boolean>(false)
-    const [star, setStar] = useState<string>(starGiven)
-    return (
-      <>
-        <GiveStarCard
-          close={() => setShow(false)}
-          show={show}
-          starGiven={star}
-          setStarGiven={setStar}
-          lessonId={lessonId}
-        />
-        <div className="card text-center shadow-sm">
-          <div className="card-body">
-            <img
-              src={`/assets/curriculum/icons/${imageSrc}`}
-              className="mt-3"
-            />
-            <h4 className="card-title mt-2">Congratulations!</h4>
-            <p className="success-message">
-              You have successfully completed all challenges
-            </p>
-            <p className="review-message">
-              You can help your peers by
-              <NavLink
-                path={chatUrl}
-                className="font-weight-bold mx-1"
-                external
-              >
-                answering questions
-              </NavLink>
-              they have in the lesson and
-              <NavLink
-                path={reviewUrl}
-                className="font-weight-bold mx-1"
-                external
-              >
-                reviewing challenge submissions
-              </NavLink>
-            </p>
-          </div>
-          <div className="card-footer d-flex bg-primary">
-            <p className="text-white mr-3 my-2">
-              You can show your appreciation to the user that helped you the
-              most by giving them a star
-            </p>
-            <button
-              className="btn btn-light text-primary font-weight-bold ml-auto"
-              onClick={() => setShow(true)}
+export const ChallengesCompletedCard: React.FC<
+  ChallengesCompletedCardProps
+> = ({ imageSrc, chatUrl, reviewUrl, starGiven, lessonId }) => {
+  const [show, setShow] = useState<boolean>(false)
+  const [star, setStar] = useState<string>(starGiven)
+  return (
+    <>
+      <GiveStarCard
+        close={() => setShow(false)}
+        show={show}
+        starGiven={star}
+        setStarGiven={setStar}
+        lessonId={lessonId}
+      />
+      <div className="card text-center shadow-sm">
+        <div className="card-body">
+          <img src={`/assets/curriculum/icons/${imageSrc}`} className="mt-3" />
+          <h4 className="card-title mt-2">Congratulations!</h4>
+          <p className="success-message">
+            You have successfully completed all challenges
+          </p>
+          <p className="review-message">
+            You can help your peers by
+            <NavLink path={chatUrl} className="font-weight-bold mx-1" external>
+              answering questions
+            </NavLink>
+            they have in the lesson and
+            <NavLink
+              path={reviewUrl}
+              className="font-weight-bold mx-1"
+              external
             >
-              Give Star
-            </button>
-          </div>
+              reviewing challenge submissions
+            </NavLink>
+          </p>
         </div>
-      </>
-    )
-  }
+        <div className="card-footer d-flex bg-primary">
+          <p className="text-white mr-3 my-2">
+            You can show your appreciation to the user that helped you the most
+            by giving them a star
+          </p>
+          <button
+            className="btn btn-light text-primary font-weight-bold ml-auto"
+            onClick={() => setShow(true)}
+          >
+            Give Star
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}
 
 type ChallengeMaterialProps = {
   challenges: Challenge[]

--- a/components/mdx/ModalImage.tsx
+++ b/components/mdx/ModalImage.tsx
@@ -4,29 +4,30 @@ import Image, { ImageProps } from 'next/image'
 
 type Proportions = 'long' | 'tall'
 
-const ModalImage: React.FC<ImageProps & { proportions?: Proportions }> =
-  props => {
-    const [show, setShow] = useState(false)
-    const handle = (state: boolean) => () => setShow(state)
-    return (
-      <>
-        <Image className="mdx-image" {...props} onClick={handle(true)} />
-        <Modal
-          className="mdx-modal-image"
-          show={show}
-          onHide={handle(false)}
-          centered
-          onClick={handle(false)}
-        >
-          <Modal.Body>
-            <img
-              src={props.src as string}
-              className={`${props.proportions || 'mdx-modal__inner-image'}`}
-            />
-          </Modal.Body>
-        </Modal>
-      </>
-    )
-  }
+const ModalImage: React.FC<
+  ImageProps & { proportions?: Proportions }
+> = props => {
+  const [show, setShow] = useState(false)
+  const handle = (state: boolean) => () => setShow(state)
+  return (
+    <>
+      <Image className="mdx-image" {...props} onClick={handle(true)} />
+      <Modal
+        className="mdx-modal-image"
+        show={show}
+        onHide={handle(false)}
+        centered
+        onClick={handle(false)}
+      >
+        <Modal.Body>
+          <img
+            src={props.src as string}
+            className={`${props.proportions || 'mdx-modal__inner-image'}`}
+          />
+        </Modal.Body>
+      </Modal>
+    </>
+  )
+}
 
 export default ModalImage

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -13,14 +13,15 @@ export type Maybe<T> = T | null
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K]
 }
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]?: Maybe<T[SubKey]> }
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
-  { [SubKey in K]: Maybe<T[SubKey]> }
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>
+}
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>
+}
 export type RequireFields<T, K extends keyof T> = {
   [X in Exclude<keyof T, K>]?: T[X]
-} &
-  { [P in K]-?: NonNullable<T[P]> }
+} & { [P in K]-?: NonNullable<T[P]> }
 const defaultOptions = {}
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -1570,8 +1571,7 @@ export type AcceptSubmissionProps<
     AcceptSubmissionMutation,
     AcceptSubmissionMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withAcceptSubmission<
   TProps,
   TChildProps = {},
@@ -1663,8 +1663,7 @@ export type AddAlertProps<
     AddAlertMutation,
     AddAlertMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withAddAlert<
   TProps,
   TChildProps = {},
@@ -1755,8 +1754,7 @@ export type AddCommentProps<
     AddCommentMutation,
     AddCommentMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withAddComment<
   TProps,
   TChildProps = {},
@@ -1834,8 +1832,7 @@ export const UsersDocument = gql`
 `
 export type UsersProps<TChildProps = {}, TDataName extends string = 'data'> = {
   [key in TDataName]: ApolloReactHoc.DataValue<UsersQuery, UsersQueryVariables>
-} &
-  TChildProps
+} & TChildProps
 export function withUsers<
   TProps,
   TChildProps = {},
@@ -1917,8 +1914,7 @@ export type ChangeAdminRightsProps<
     ChangeAdminRightsMutation,
     ChangeAdminRightsMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withChangeAdminRights<
   TProps,
   TChildProps = {},
@@ -2024,8 +2020,7 @@ export type CreateChallengeProps<
     CreateChallengeMutation,
     CreateChallengeMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withCreateChallenge<
   TProps,
   TChildProps = {},
@@ -2142,8 +2137,7 @@ export type CreateLessonProps<
     CreateLessonMutation,
     CreateLessonMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withCreateLesson<
   TProps,
   TChildProps = {},
@@ -2242,8 +2236,7 @@ export type CreateSubmissionProps<
     CreateSubmissionMutation,
     CreateSubmissionMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withCreateSubmission<
   TProps,
   TChildProps = {},
@@ -2387,8 +2380,7 @@ export type GetAppProps<TChildProps = {}, TDataName extends string = 'data'> = {
     GetAppQuery,
     GetAppQueryVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withGetApp<
   TProps,
   TChildProps = {},
@@ -2468,8 +2460,7 @@ export type LessonMentorsProps<
     LessonMentorsQuery,
     LessonMentorsQueryVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withLessonMentors<
   TProps,
   TChildProps = {},
@@ -2572,8 +2563,7 @@ export type GetLessonsProps<
     GetLessonsQuery,
     GetLessonsQueryVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withGetLessons<
   TProps,
   TChildProps = {},
@@ -2690,8 +2680,7 @@ export type GetPreviousSubmissionsProps<
     GetPreviousSubmissionsQuery,
     GetPreviousSubmissionsQueryVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withGetPreviousSubmissions<
   TProps,
   TChildProps = {},
@@ -2809,8 +2798,7 @@ export type GetSessionProps<
     GetSessionQuery,
     GetSessionQueryVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withGetSession<
   TProps,
   TChildProps = {},
@@ -2927,8 +2915,7 @@ export type SubmissionsProps<
     SubmissionsQuery,
     SubmissionsQueryVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withSubmissions<
   TProps,
   TChildProps = {},
@@ -3022,8 +3009,7 @@ export type LoginProps<
     LoginMutation,
     LoginMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withLogin<
   TProps,
   TChildProps = {},
@@ -3104,8 +3090,7 @@ export type LogoutProps<
     LogoutMutation,
     LogoutMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withLogout<
   TProps,
   TChildProps = {},
@@ -3192,8 +3177,7 @@ export type RejectSubmissionProps<
     RejectSubmissionMutation,
     RejectSubmissionMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withRejectSubmission<
   TProps,
   TChildProps = {},
@@ -3276,8 +3260,7 @@ export type RemoveAlertProps<
     RemoveAlertMutation,
     RemoveAlertMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withRemoveAlert<
   TProps,
   TChildProps = {},
@@ -3358,8 +3341,7 @@ export type ReqPwResetProps<
     ReqPwResetMutation,
     ReqPwResetMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withReqPwReset<
   TProps,
   TChildProps = {},
@@ -3439,8 +3421,7 @@ export type SetStarProps<
     SetStarMutation,
     SetStarMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withSetStar<
   TProps,
   TChildProps = {},
@@ -3533,8 +3514,7 @@ export type SignupProps<
     SignupMutation,
     SignupMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withSignup<
   TProps,
   TChildProps = {},
@@ -3641,8 +3621,7 @@ export type UpdateChallengeProps<
     UpdateChallengeMutation,
     UpdateChallengeMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withUpdateChallenge<
   TProps,
   TChildProps = {},
@@ -3762,8 +3741,7 @@ export type UpdateLessonProps<
     UpdateLessonMutation,
     UpdateLessonMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withUpdateLesson<
   TProps,
   TChildProps = {},
@@ -3852,8 +3830,7 @@ export type ChangePwProps<
     ChangePwMutation,
     ChangePwMutationVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withChangePw<
   TProps,
   TChildProps = {},
@@ -3984,8 +3961,7 @@ export type UserInfoProps<
     UserInfoQuery,
     UserInfoQueryVariables
   >
-} &
-  TChildProps
+} & TChildProps
 export function withUserInfo<
   TProps,
   TChildProps = {},

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "babel-jest": "^27.4.5",
     "babel-plugin-prismjs": "^2.1.0",
-    "copy-webpack-plugin": "^9.0.1",
+    "copy-webpack-plugin": "^10.2.0",
     "eslint": "^7.32.0",
     "eslint-config-next": "^12.0.7",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "jest": "^27.1.0",
     "jest-mock-extended": "^2.0.4",
     "lint-staged": "^12.1.4",
-    "prettier": "^2.3.2",
+    "prettier": "^2.5.1",
     "prisma": "^2.29.1",
     "react-test-renderer": "^17.0.1",
     "remark-gfm": "^1.0.0",

--- a/scss/selectIteration.module.scss
+++ b/scss/selectIteration.module.scss
@@ -10,7 +10,8 @@
   min-height: 2.5rem;
   max-width: max-content;
 
-  &.active, &:hover {
+  &.active,
+  &:hover {
     // Warning variant button has non-white color
     color: white !important;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3738,6 +3738,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
@@ -4509,10 +4514,24 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv-keywords@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
+  integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
@@ -4522,6 +4541,16 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.8.0:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
+  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
@@ -4922,6 +4951,11 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array-union@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
+  integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
 
 array-uniq@^1.0.1:
   version "1.0.3"
@@ -6455,17 +6489,16 @@ copy-to-clipboard@^3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
-copy-webpack-plugin@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz#b71d21991599f61a4ee00ba79087b8ba279bbb59"
-  integrity sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==
+copy-webpack-plugin@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-10.2.0.tgz#24c2d256953a55400a1ec66be4e0eccd1c4ae958"
+  integrity sha512-my6iXII95c78w14HzYCNya5TlJYa44lOppAge5GSTMM1SyDxNsVGCJvhP4/ld6snm8lzjn3XOonMZD6s1L86Og==
   dependencies:
-    fast-glob "^3.2.5"
-    glob-parent "^6.0.0"
-    globby "^11.0.3"
+    fast-glob "^3.2.7"
+    glob-parent "^6.0.1"
+    globby "^12.0.2"
     normalize-path "^3.0.0"
-    p-limit "^3.1.0"
-    schema-utils "^3.0.0"
+    schema-utils "^4.0.0"
     serialize-javascript "^6.0.0"
 
 core-js-compat@^3.14.0, core-js-compat@^3.8.1:
@@ -8051,19 +8084,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.1.1:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
-  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-    picomatch "^2.2.1"
-
-fast-glob@^3.2.5:
+fast-glob@^3.1.1, fast-glob@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
@@ -8650,19 +8671,19 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.1.tgz#42054f685eb6a44e7a7d189a96efa40a54971aa7"
-  integrity sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
-    is-glob "^4.0.1"
+    is-glob "^4.0.3"
 
 glob-promise@^3.4.0:
   version "3.4.0"
@@ -8759,6 +8780,18 @@ globby@^11.0.2, globby@^11.0.3, globby@^11.0.4:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
+
+globby@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-12.0.2.tgz#53788b2adf235602ed4cabfea5c70a1139e1ab11"
+  integrity sha512-lAsmb/5Lww4r7MM9nCCliDZVIKbZTavrsunAsHLr9oHthrZP1qi7/gAnHOsUs9bLvEt2vKVJhHmxuL7QbDuPdQ==
+  dependencies:
+    array-union "^3.0.1"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.7"
+    ignore "^5.1.8"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
 
 globby@^9.2.0:
   version "9.2.0"
@@ -9347,6 +9380,11 @@ ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+ignore@^5.1.8:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 image-size@1.0.0:
   version "1.0.0"
@@ -11649,7 +11687,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.2.3, merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -14414,6 +14452,16 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+schema-utils@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.0.0.tgz#60331e9e3ae78ec5d16353c467c34b3a0a1d3df7"
+  integrity sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.8.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.0.0"
+
 scuid@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/scuid/-/scuid-1.1.0.tgz#d3f9f920956e737a60f72d0e4ad280bf324d5dab"
@@ -14648,6 +14696,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
 slice-ansi@0.0.4:
   version "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13152,15 +13152,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.2.1:
+prettier@^2.2.1, prettier@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
-
-prettier@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
-  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-error@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
**I fixed the errors by running `yarn lint:fix` which fixed the lint errors that was causing the dependabot PR to fail.**
Updates: https://github.com/garageScript/c0d3-app/pull/1243

You can trigger Dependabot actions by commenting on this PR:
- `@dependabot rebase` will rebase this PR
- `@dependabot recreate` will recreate this PR, overwriting any edits that have been made to it
- `@dependabot merge` will merge this PR after your CI passes on it
- `@dependabot squash and merge` will squash and merge this PR after your CI passes on it
- `@dependabot cancel merge` will cancel a previously requested merge and block automerging
- `@dependabot reopen` will reopen this PR if it is closed
- `@dependabot close` will close this PR and stop Dependabot recreating it. You can achieve the same result by closing it manually
- `@dependabot ignore this major version` will close this PR and stop Dependabot creating any more for this major version (unless you reopen the PR or upgrade to it yourself)
- `@dependabot ignore this minor version` will close this PR and stop Dependabot creating any more for this minor version (unless you reopen the PR or upgrade to it yourself)
- `@dependabot ignore this dependency` will close this PR and stop Dependabot creating any more for this dependency (unless you reopen the PR or upgrade to it yourself)


</details>