### PR TITLE
Close #1180 - Fix mdInput unexpected expand

### DIFF
--- a/components/MdInput.tsx
+++ b/components/MdInput.tsx
@@ -208,15 +208,7 @@ export const MdInput: React.FC<MdInputProps> = ({
       {preview && (
         <>
           {value ? (
-            <Markdown
-              data-testid="markdown"
-              style={{
-                minHeight:
-                  Math.min(textareaRef.current?.clientHeight || Infinity, 500) +
-                  'px'
-              }}
-              className={`${styles['preview']}`}
-            >
+            <Markdown data-testid="markdown" className={`${styles['preview']}`}>
               {value}
             </Markdown>
           ) : (

--- a/components/__snapshots__/MdInput.test.js.snap
+++ b/components/__snapshots__/MdInput.test.js.snap
@@ -36,7 +36,6 @@ exports[`MdInput Component Should display markdown preview text when switch to P
     <span
       class="preview"
       data-testid="markdown"
-      style="min-height: 500px;"
     >
       Some 
       <strong>


### PR DESCRIPTION
Close issue: #1180

`mdInput` expand by 500px when it's in preview mode and the review feedback has been changed.

Before:

https://user-images.githubusercontent.com/35906419/149682480-0a137f3c-8531-406a-ba2a-be630f1ecdf0.mp4

After:

https://user-images.githubusercontent.com/35906419/149682509-16005b4e-ed56-4ca3-95a3-ef6703133e37.mp4

