### PR TITLE
Fix - Bump @types/node from 16.7.5 to 17.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@types/express-session": "^1.17.4",
     "@types/lodash": "^4.14.178",
     "@types/mdx-js__react": "^1.5.5",
-    "@types/node": "^16.7.5",
+    "@types/node": "17.0.8",
     "@types/nodemailer": "^6.4.4",
     "@types/prismjs": "^1.16.6",
     "@types/react": "^17.0.38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3974,10 +3974,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^16.7.5":
+"@types/node@*":
   version "16.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.5.tgz#96142b243977b03d99c338fdb09241d286102711"
   integrity sha512-E7SpxDXoHEpmZ9C1gSqwadhE6zPRtf3g0gJy9Y51DsImnR5TcDs3QEiV/3Q7zOM8LWaZp5Gph71NK6ElVMG1IQ==
+
+"@types/node@17.0.8":
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.8.tgz#50d680c8a8a78fe30abe6906453b21ad8ab0ad7b"
+  integrity sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==
 
 "@types/node@^10.1.0":
   version "10.17.60"


### PR DESCRIPTION
Fix the issues when updating to v17.0.8.

Issue:

URLSearchParams arguments can't be `type | undefined`

```
helpers/discordAuth.ts(65,31): error TS2345: Argument of type '{ grant_type: string; client_id: string | undefined; client_secret: string | undefined; code: string; redirect_uri: string | undefined; scope: string; }' is not assignable to parameter of type 'string | URLSearchParams | Record<string, string | readonly string[]> | Iterable<[string, string]> | readonly [string, string][] | undefined'.
```