### PR TITLE
adds_module_migration

### DIFF
--- a/prisma/migrations/20220124135034_added_module/migration.sql
+++ b/prisma/migrations/20220124135034_added_module/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "modules" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "lessonId" INTEGER NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "content" TEXT NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "modules" ADD FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "modules" ADD FOREIGN KEY ("lessonId") REFERENCES "lessons"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Lesson {
   starLesson  Star[]       @relation("starLesson")
   submissions Submission[]
   userLessons UserLesson[]
+  modules     Module[]
 
   @@map("lessons")
 }
@@ -151,6 +152,21 @@ model User {
   submissions               Submission[] @relation("userSubmissions")
   userLessons               UserLesson[]
   comments                  Comment[]
+  modules                   Module[]
 
   @@map("users")
+}
+
+model Module {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @db.Timestamptz(6)
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  Int
+  lesson    Lesson   @relation(fields: [lessonId], references: [id])
+  lessonId  Int
+  name      String   @db.VarChar(255)
+  content   String
+
+  @@map("modules")
 }


### PR DESCRIPTION
This issue closes https://github.com/garageScript/c0d3-app/issues/1334.

This adds a table to the c0d3 Postgres database. 
https://www.prisma.io/docs/concepts/components/prisma-migrate

I edited the ```prisma.schema``` file to add module model.  It has two foreign keys to a user(author) and lesson. 
After I edited the model I ran ```npx prisma migrate dev``` on the terminal. 
This is the first step in allowing crud operations for modules. Modules will be used to organize exercises for the dojo. 
