### PR TITLE
UpdateCache/helper: add support for deleting submission comment

### DIFF
--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -151,6 +151,7 @@ const ChallengeQuestionCardDisplay: React.FC<{
 
     const update = updateCache(
       submission.id,
+      undefined,
       commentValue,
       name,
       username,

--- a/components/CommentBox.tsx
+++ b/components/CommentBox.tsx
@@ -35,6 +35,7 @@ const CommentBox: React.FC<{
   const [input, setInput] = useState('')
   const update = updateCache(
     submissionId,
+    undefined,
     input,
     name!,
     username!,

--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -172,6 +172,7 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({ submissionData }) => {
   const [showAccordion, setShowAccordion] = useState(false)
   const update = updateCache(
     submissionState.id,
+    undefined,
     commentValue,
     name,
     username,

--- a/helpers/updateCache.test.js
+++ b/helpers/updateCache.test.js
@@ -125,10 +125,9 @@ describe('updateCache helper', () => {
       variables: { userId: 1, challengeId: 23 },
       data: { getPreviousSubmissions: submissionsData }
     })
-    expect(() => {
+    expect(() =>
       updateCache(
         11,
-        1,
         1,
         'Test comment!',
         'Test User',
@@ -139,6 +138,6 @@ describe('updateCache helper', () => {
         23,
         1
       )(cache)
-    })
+    )
   })
 })

--- a/helpers/updateCache.test.js
+++ b/helpers/updateCache.test.js
@@ -119,25 +119,35 @@ describe('updateCache helper', () => {
     ).toThrow('Incorrect submission id (no submission was found)')
   })
   it('should delete previous submission comment in cache', () => {
+    expect.assertions(1)
+
     const cache = new InMemoryCache({ addTypename: false })
+
     cache.writeQuery({
       query: GET_PREVIOUS_SUBMISSIONS,
       variables: { userId: 1, challengeId: 23 },
       data: { getPreviousSubmissions: submissionsData }
     })
-    expect(() =>
-      updateCache(
-        11,
-        1,
-        'Test comment!',
-        'Test User',
-        'testuser',
-        2,
-        undefined,
-        undefined,
-        23,
-        1
-      )(cache)
-    )
+
+    updateCache(
+      0,
+      1,
+      'Test comment!',
+      'Test User',
+      'testuser',
+      2,
+      undefined,
+      undefined,
+      23,
+      1
+    )(cache)
+
+    const newCache = cache.readQuery({
+      query: GET_PREVIOUS_SUBMISSIONS,
+      variables: { userId: 1, challengeId: 23 },
+      data: { getPreviousSubmissions: submissionsData }
+    })
+
+    expect(newCache.getPreviousSubmissions[0].comments.length).toEqual(0)
   })
 })

--- a/helpers/updateCache.test.js
+++ b/helpers/updateCache.test.js
@@ -54,6 +54,7 @@ describe('updateCache helper', () => {
     })
     updateCache(
       0,
+      undefined,
       'Test comment!',
       'Test User',
       'testuser',
@@ -69,6 +70,7 @@ describe('updateCache helper', () => {
     expect(() => {
       updateCache(
         0,
+        undefined,
         'Test comment!',
         'Test User',
         'testuser',
@@ -90,6 +92,7 @@ describe('updateCache helper', () => {
     expect(() =>
       updateCache(
         11,
+        undefined,
         'Test comment!',
         'Test User',
         'testuser',
@@ -100,5 +103,28 @@ describe('updateCache helper', () => {
         1
       )(cache)
     ).toThrow('Incorrect submission id (no submission was found)')
+  })
+  it('should delete previous submission comment in cache', () => {
+    const cache = new InMemoryCache({ addTypename: false })
+    cache.writeQuery({
+      query: GET_PREVIOUS_SUBMISSIONS,
+      variables: { userId: 1, challengeId: 23 },
+      data: { getPreviousSubmissions: submissionsData }
+    })
+    expect(() => {
+      updateCache(
+        11,
+        1,
+        1,
+        'Test comment!',
+        'Test User',
+        'testuser',
+        2,
+        undefined,
+        undefined,
+        23,
+        1
+      )(cache)
+    })
   })
 })

--- a/helpers/updateCache.test.js
+++ b/helpers/updateCache.test.js
@@ -41,7 +41,21 @@ const submission = {
   },
   createdAt: '123',
   updatedAt: '123',
-  comments: []
+  comments: [
+    {
+      id: 1,
+      content: 'test comment',
+      submissionId: 0,
+      createdAt: '124',
+      authorId: 1,
+      line: 22,
+      fileName: 'js7/1.js',
+      author: {
+        username: 'fake reviewer',
+        name: 'fake reviewer'
+      }
+    }
+  ]
 }
 const submissionsData = [submission, { ...submission, id: 1 }]
 describe('updateCache helper', () => {

--- a/helpers/updateCache.ts
+++ b/helpers/updateCache.ts
@@ -15,9 +15,10 @@ import _ from 'lodash'
 */
 export const updateCache = (
   submissionId: number,
-  content: string,
-  name: string,
-  username: string,
+  commentToDeleteId?: number,
+  content?: string,
+  name?: string,
+  username?: string,
   lessonId?: number,
   line?: number,
   fileName?: string,
@@ -40,16 +41,22 @@ export const updateCache = (
     const copy = _.cloneDeep(current) as RecursivePartial<Submission>[]
     if (!copy.length)
       throw new Error('Incorrect submission id (no submission was found)')
-    copy[0].comments!.push({
-      content,
-      fileName,
-      line,
-      submissionId,
-      author: {
-        name,
-        username
-      }
-    })
+
+    if (commentToDeleteId) {
+      _.remove(copy[0].comments!, comment => comment!.id === commentToDeleteId)
+    } else {
+      copy[0].comments!.push({
+        content,
+        fileName,
+        line,
+        submissionId,
+        author: {
+          name,
+          username
+        }
+      })
+    }
+
     const newData = data?.getPreviousSubmissions?.map(s => {
       if (s.id === submissionId) return copy[0]
       return s


### PR DESCRIPTION
Related to #893 

`UpdateCache` helper will support deleting comments. It'll then be used in `SubmissionComments` to delete a comment when the user click the delete button.