### PR TITLE
Create CopyButton component

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -3000,6 +3000,41 @@ exports[`Storyshots Components/ContributorCard Basic 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/CopyButton Basic 1`] = `
+<button
+  className="btn borderless btn-outline-primary btn-outline-bg-primary"
+  onClick={[Function]}
+  style={
+    Object {
+      "color": "primary",
+    }
+  }
+>
+  <svg
+    aria-hidden="true"
+    className="octicon octicon-copy"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<path fill-rule=\\"evenodd\\" d=\\"M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z\\"></path><path fill-rule=\\"evenodd\\" d=\\"M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z\\"></path>",
+      }
+    }
+    fill="currentColor"
+    height={16}
+    role="img"
+    style={
+      Object {
+        "display": "inline-block",
+        "overflow": "visible",
+        "userSelect": "none",
+        "verticalAlign": "text-bottom",
+      }
+    }
+    viewBox="0 0 16 16"
+    width={16}
+  />
+</button>
+`;
+
 exports[`Storyshots Components/DiffView Closed 1`] = `
 <table
   className="css-1n5o7vh-diff-container"

--- a/components/CopyButton.test.js
+++ b/components/CopyButton.test.js
@@ -21,7 +21,7 @@ describe('Copy Button component', () => {
     const { container } = render(<CopyButton value={testText} />)
 
     const button = container.querySelector('.btn')
-    expect(button).toBeTruthy()
+    expect(button.classList.contains('btn-outline-bg-primary')).toBeTruthy()
   })
 
   test('Button type should be set to success on copy', async () => {

--- a/components/CopyButton.test.js
+++ b/components/CopyButton.test.js
@@ -1,0 +1,80 @@
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import React from 'react'
+import CopyButton from './CopyButton'
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: {
+    writeText: () => {}
+  },
+  configurable: true
+})
+const testText = 'Test Text'
+
+describe('Copy Button component', () => {
+  test('Should render correctly', () => {
+    const { container } = render(<CopyButton value={testText} />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Button type should be set to primary on render', () => {
+    const { container } = render(<CopyButton value={testText} />)
+
+    const button = container.querySelector('.btn')
+    expect(button).toBeTruthy()
+  })
+
+  test('Button type should be set to success on copy', async () => {
+    const { container } = render(<CopyButton value={testText} />)
+
+    const button = container.querySelector('.btn')
+
+    fireEvent.click(button)
+    await waitFor(() =>
+      expect(button.classList.contains('btn-outline-bg-success')).toBeTruthy()
+    )
+  })
+
+  test('Button type should be set to info on error', async () => {
+    // Reset clipboard so writeText is undefined
+    Object.defineProperty(navigator, 'clipboard', {
+      value: null
+    })
+
+    const { container } = render(<CopyButton value={testText} />)
+
+    const button = container.querySelector('.btn')
+
+    fireEvent.click(button)
+    await waitFor(() =>
+      expect(button.classList.contains('btn-outline-bg-info')).toBeTruthy()
+    )
+  })
+
+  test('Button type should be primary after 2 seconds on successful copy', async () => {
+    jest.useFakeTimers()
+    jest.spyOn(global, 'setTimeout')
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: () => {}
+      }
+    })
+
+    const { container } = render(<CopyButton value={testText} />)
+
+    const button = container.querySelector('.btn')
+    fireEvent.click(button)
+
+    await waitFor(() =>
+      expect(button.classList.contains('btn-outline-bg-success')).toBeTruthy()
+    )
+
+    jest.advanceTimersByTime(2000)
+
+    await waitFor(() => {
+      expect(button.classList.contains('btn-outline-bg-primary')).toBeTruthy()
+      expect(setTimeout).toHaveBeenCalled()
+    })
+  })
+})

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react'
+import { Button } from './theme/Button'
+import { AlertIcon, CheckIcon, CopyIcon } from '@primer/octicons-react'
+import * as Sentry from '@sentry/react'
+import { ColorTypes } from './theme/colors'
+
+enum State {
+  NotCopied,
+  Copied,
+  Error
+}
+
+enum ColorType {
+  Primary = 'primary',
+  Info = 'info',
+  Success = 'success'
+}
+
+const CopyButton: React.FC<{ value: any }> = ({ value }: { value: any }) => {
+  const [copyState, setCopyState] = useState<State>(State.NotCopied)
+  const [type, setType] = useState(ColorType.Primary)
+
+  const showSuccess = () => {
+    setTimeout(() => {
+      setCopyState(State.NotCopied)
+      setType(ColorType.Primary)
+    }, 2000)
+
+    return <CheckIcon />
+  }
+
+  const handleOnClick = async () => {
+    try {
+      setType(ColorType.Primary)
+      await navigator.clipboard.writeText(value)
+      setCopyState(State.Copied)
+      setType(ColorType.Success)
+    } catch (e) {
+      setCopyState(State.Error)
+      setType(ColorType.Info)
+      Sentry.captureException(e)
+    }
+  }
+
+  return (
+    <Button
+      outline
+      type={type}
+      color={type as ColorTypes}
+      onClick={handleOnClick}
+    >
+      {copyState === State.Copied ? (
+        showSuccess()
+      ) : copyState === State.Error ? (
+        <AlertIcon />
+      ) : (
+        <CopyIcon />
+      )}
+    </Button>
+  )
+}
+
+export default CopyButton

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -16,7 +16,11 @@ enum ColorType {
   Success = 'success'
 }
 
-const CopyButton: React.FC<{ value: any }> = ({ value }: { value: any }) => {
+const CopyButton: React.FC<{ value: string }> = ({
+  value
+}: {
+  value: string
+}) => {
   const [copyState, setCopyState] = useState<State>(State.NotCopied)
   const [type, setType] = useState(ColorType.Primary)
 

--- a/components/__snapshots__/CopyButton.test.js.snap
+++ b/components/__snapshots__/CopyButton.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Copy Button component Should render correctly 1`] = `
+<div>
+  <button
+    class="btn borderless btn-outline-primary btn-outline-bg-primary"
+  >
+    <svg
+      aria-hidden="true"
+      class="octicon octicon-copy"
+      fill="currentColor"
+      height="16"
+      role="img"
+      style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+      viewBox="0 0 16 16"
+      width="16"
+    >
+      <path
+        d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"
+        fill-rule="evenodd"
+      />
+      <path
+        d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </button>
+</div>
+`;

--- a/stories/components/CopyButton.stories.tsx
+++ b/stories/components/CopyButton.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import CopyButton from '../../components/CopyButton'
+
+export default {
+  component: CopyButton,
+  title: 'Components/CopyButton'
+}
+
+export const Basic: React.FC = () => <CopyButton value={'Test Text'} />


### PR DESCRIPTION
Related to #1324 

It creates `CopyButton` that its purpose is to copy text to the user's clipboard onClick event. Could also be used in other places like Dojo exercises.

Will be implemented in the next PR.

Demo:
![CopyButton demo](https://user-images.githubusercontent.com/35906419/153712129-fc42c6ed-638a-410c-ae0f-133679213ff3.gif)

