### PR TITLE
Change DiffView styles to improve mobile experience

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1010,7 +1010,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1018,7 +1018,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1054,7 +1054,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1062,7 +1062,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1098,7 +1098,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1106,7 +1106,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1142,7 +1142,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1150,7 +1150,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1186,7 +1186,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1194,7 +1194,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1230,7 +1230,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1238,7 +1238,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1274,7 +1274,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1282,7 +1282,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1854,7 +1854,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1862,7 +1862,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1898,7 +1898,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1906,7 +1906,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1942,7 +1942,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1950,7 +1950,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -1986,7 +1986,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -1994,7 +1994,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -2030,7 +2030,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -2038,7 +2038,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -2074,7 +2074,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -2082,7 +2082,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -2118,7 +2118,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   className="css-1n7ec1i-line"
                 >
                   <td
-                    className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     onClick={null}
                   >
                     <pre
@@ -2126,7 +2126,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                     />
                   </td>
                   <td
-                    className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     onClick={[Function]}
                   >
                     <pre
@@ -3175,7 +3175,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3183,7 +3183,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3219,7 +3219,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3227,7 +3227,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3263,7 +3263,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3271,7 +3271,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3307,7 +3307,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3315,7 +3315,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3351,7 +3351,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3359,7 +3359,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3395,7 +3395,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3403,7 +3403,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3439,7 +3439,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3447,7 +3447,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3544,7 +3544,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3552,7 +3552,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3588,7 +3588,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3596,7 +3596,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3632,7 +3632,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3640,7 +3640,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3676,7 +3676,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3684,7 +3684,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3720,7 +3720,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3728,7 +3728,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3764,7 +3764,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3772,7 +3772,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -3808,7 +3808,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         className="css-1n7ec1i-line"
       >
         <td
-          className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           onClick={null}
         >
           <pre
@@ -3816,7 +3816,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
           />
         </td>
         <td
-          className="css-1548r9v-gutter css-cnnxkz-diff-added"
+          className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           onClick={[Function]}
         >
           <pre
@@ -11722,7 +11722,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -11730,7 +11730,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -11766,7 +11766,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -11774,7 +11774,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -11810,7 +11810,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -11818,7 +11818,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -11854,7 +11854,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -11862,7 +11862,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -11898,7 +11898,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -11906,7 +11906,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -11942,7 +11942,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -11950,7 +11950,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -11986,7 +11986,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -11994,7 +11994,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12030,7 +12030,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12038,7 +12038,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12074,7 +12074,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12082,7 +12082,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12118,7 +12118,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12126,7 +12126,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12162,7 +12162,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12170,7 +12170,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12206,7 +12206,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12214,7 +12214,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12250,7 +12250,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12258,7 +12258,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12294,7 +12294,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12302,7 +12302,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12338,7 +12338,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12346,7 +12346,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12382,7 +12382,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12390,7 +12390,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12426,7 +12426,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12434,7 +12434,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12470,7 +12470,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12478,7 +12478,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -12514,7 +12514,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -12522,7 +12522,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13120,7 +13120,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13128,7 +13128,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13164,7 +13164,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13172,7 +13172,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13208,7 +13208,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13216,7 +13216,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13252,7 +13252,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13260,7 +13260,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13296,7 +13296,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13304,7 +13304,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13340,7 +13340,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13348,7 +13348,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13384,7 +13384,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13392,7 +13392,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13428,7 +13428,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13436,7 +13436,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13472,7 +13472,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13480,7 +13480,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13516,7 +13516,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13524,7 +13524,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13560,7 +13560,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13568,7 +13568,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13604,7 +13604,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13612,7 +13612,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13648,7 +13648,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13656,7 +13656,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13692,7 +13692,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13700,7 +13700,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13736,7 +13736,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13744,7 +13744,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13780,7 +13780,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13788,7 +13788,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13824,7 +13824,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13832,7 +13832,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13868,7 +13868,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13876,7 +13876,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -13912,7 +13912,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -13920,7 +13920,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14516,7 +14516,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14524,7 +14524,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14560,7 +14560,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14568,7 +14568,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14604,7 +14604,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14612,7 +14612,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14648,7 +14648,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14656,7 +14656,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14692,7 +14692,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14700,7 +14700,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14736,7 +14736,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14744,7 +14744,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14780,7 +14780,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14788,7 +14788,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14824,7 +14824,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14832,7 +14832,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14868,7 +14868,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14876,7 +14876,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14912,7 +14912,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14920,7 +14920,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -14956,7 +14956,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -14964,7 +14964,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15000,7 +15000,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15008,7 +15008,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15044,7 +15044,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15052,7 +15052,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15088,7 +15088,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15096,7 +15096,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15132,7 +15132,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15140,7 +15140,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15176,7 +15176,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15184,7 +15184,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15220,7 +15220,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15228,7 +15228,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15264,7 +15264,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15272,7 +15272,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15308,7 +15308,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15316,7 +15316,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15912,7 +15912,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15920,7 +15920,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -15956,7 +15956,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -15964,7 +15964,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16000,7 +16000,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16008,7 +16008,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16044,7 +16044,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16052,7 +16052,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16088,7 +16088,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16096,7 +16096,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16132,7 +16132,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16140,7 +16140,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16176,7 +16176,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16184,7 +16184,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16220,7 +16220,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16228,7 +16228,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16264,7 +16264,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16272,7 +16272,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16308,7 +16308,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16316,7 +16316,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16352,7 +16352,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16360,7 +16360,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16396,7 +16396,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16404,7 +16404,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16440,7 +16440,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16448,7 +16448,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16484,7 +16484,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16492,7 +16492,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16528,7 +16528,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16536,7 +16536,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16572,7 +16572,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16580,7 +16580,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16616,7 +16616,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16624,7 +16624,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16660,7 +16660,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16668,7 +16668,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -16704,7 +16704,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -16712,7 +16712,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17308,7 +17308,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17316,7 +17316,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17352,7 +17352,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17360,7 +17360,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17396,7 +17396,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17404,7 +17404,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17440,7 +17440,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17448,7 +17448,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17484,7 +17484,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17492,7 +17492,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17528,7 +17528,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17536,7 +17536,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17572,7 +17572,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17580,7 +17580,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17616,7 +17616,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17624,7 +17624,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17660,7 +17660,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17668,7 +17668,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17704,7 +17704,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17712,7 +17712,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17748,7 +17748,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17756,7 +17756,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17792,7 +17792,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17800,7 +17800,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17836,7 +17836,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17844,7 +17844,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17880,7 +17880,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17888,7 +17888,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17924,7 +17924,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17932,7 +17932,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -17968,7 +17968,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -17976,7 +17976,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -18012,7 +18012,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -18020,7 +18020,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -18056,7 +18056,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -18064,7 +18064,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -18100,7 +18100,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -18108,7 +18108,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -971,7 +971,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -979,7 +979,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1015,7 +1015,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1023,7 +1023,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1059,7 +1059,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1067,7 +1067,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1103,7 +1103,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1111,7 +1111,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1147,7 +1147,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1155,7 +1155,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1191,7 +1191,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1199,7 +1199,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1235,7 +1235,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1243,7 +1243,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1775,7 +1775,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1783,7 +1783,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1819,7 +1819,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1827,7 +1827,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1863,7 +1863,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1871,7 +1871,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1907,7 +1907,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1915,7 +1915,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1951,7 +1951,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -1959,7 +1959,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -1995,7 +1995,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -2003,7 +2003,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -2039,7 +2039,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                 className="css-1n7ec1i-line"
               >
                 <td
-                  className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   onClick={null}
                 >
                   <pre
@@ -2047,7 +2047,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   />
                 </td>
                 <td
-                  className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   onClick={[Function]}
                 >
                   <pre
@@ -3056,7 +3056,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3064,7 +3064,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3100,7 +3100,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3108,7 +3108,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3144,7 +3144,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3152,7 +3152,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3188,7 +3188,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3196,7 +3196,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3232,7 +3232,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3240,7 +3240,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3276,7 +3276,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3284,7 +3284,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3320,7 +3320,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3328,7 +3328,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3385,7 +3385,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3393,7 +3393,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3429,7 +3429,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3437,7 +3437,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3473,7 +3473,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3481,7 +3481,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3517,7 +3517,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3525,7 +3525,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3561,7 +3561,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3569,7 +3569,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3605,7 +3605,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3613,7 +3613,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -3649,7 +3649,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       className="css-1n7ec1i-line"
     >
       <td
-        className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         onClick={null}
       >
         <pre
@@ -3657,7 +3657,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         />
       </td>
       <td
-        className="css-1548r9v-gutter css-cnnxkz-diff-added"
+        className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         onClick={[Function]}
       >
         <pre
@@ -11523,7 +11523,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11531,7 +11531,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11567,7 +11567,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11575,7 +11575,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11611,7 +11611,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11619,7 +11619,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11655,7 +11655,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11663,7 +11663,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11699,7 +11699,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11707,7 +11707,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11743,7 +11743,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11751,7 +11751,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11787,7 +11787,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11795,7 +11795,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11831,7 +11831,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11839,7 +11839,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11875,7 +11875,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11883,7 +11883,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11919,7 +11919,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11927,7 +11927,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -11963,7 +11963,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -11971,7 +11971,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12007,7 +12007,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12015,7 +12015,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12051,7 +12051,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12059,7 +12059,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12095,7 +12095,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12103,7 +12103,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12139,7 +12139,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12147,7 +12147,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12183,7 +12183,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12191,7 +12191,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12227,7 +12227,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12235,7 +12235,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12271,7 +12271,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12279,7 +12279,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12315,7 +12315,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12323,7 +12323,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12881,7 +12881,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12889,7 +12889,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12925,7 +12925,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12933,7 +12933,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -12969,7 +12969,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -12977,7 +12977,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13013,7 +13013,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13021,7 +13021,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13057,7 +13057,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13065,7 +13065,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13101,7 +13101,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13109,7 +13109,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13145,7 +13145,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13153,7 +13153,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13189,7 +13189,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13197,7 +13197,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13233,7 +13233,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13241,7 +13241,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13277,7 +13277,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13285,7 +13285,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13321,7 +13321,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13329,7 +13329,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13365,7 +13365,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13373,7 +13373,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13409,7 +13409,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13417,7 +13417,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13453,7 +13453,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13461,7 +13461,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13497,7 +13497,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13505,7 +13505,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13541,7 +13541,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13549,7 +13549,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13585,7 +13585,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13593,7 +13593,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13629,7 +13629,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13637,7 +13637,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -13673,7 +13673,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -13681,7 +13681,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14237,7 +14237,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14245,7 +14245,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14281,7 +14281,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14289,7 +14289,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14325,7 +14325,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14333,7 +14333,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14369,7 +14369,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14377,7 +14377,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14413,7 +14413,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14421,7 +14421,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14457,7 +14457,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14465,7 +14465,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14501,7 +14501,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14509,7 +14509,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14545,7 +14545,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14553,7 +14553,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14589,7 +14589,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14597,7 +14597,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14633,7 +14633,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14641,7 +14641,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14677,7 +14677,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14685,7 +14685,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14721,7 +14721,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14729,7 +14729,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14765,7 +14765,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14773,7 +14773,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14809,7 +14809,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14817,7 +14817,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14853,7 +14853,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14861,7 +14861,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14897,7 +14897,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14905,7 +14905,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14941,7 +14941,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14949,7 +14949,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -14985,7 +14985,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -14993,7 +14993,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15029,7 +15029,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15037,7 +15037,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15593,7 +15593,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15601,7 +15601,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15637,7 +15637,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15645,7 +15645,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15681,7 +15681,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15689,7 +15689,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15725,7 +15725,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15733,7 +15733,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15769,7 +15769,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15777,7 +15777,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15813,7 +15813,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15821,7 +15821,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15857,7 +15857,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15865,7 +15865,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15901,7 +15901,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15909,7 +15909,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15945,7 +15945,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15953,7 +15953,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -15989,7 +15989,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -15997,7 +15997,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16033,7 +16033,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16041,7 +16041,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16077,7 +16077,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16085,7 +16085,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16121,7 +16121,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16129,7 +16129,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16165,7 +16165,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16173,7 +16173,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16209,7 +16209,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16217,7 +16217,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16253,7 +16253,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16261,7 +16261,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16297,7 +16297,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16305,7 +16305,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16341,7 +16341,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16349,7 +16349,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16385,7 +16385,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16393,7 +16393,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16949,7 +16949,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -16957,7 +16957,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -16993,7 +16993,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17001,7 +17001,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17037,7 +17037,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17045,7 +17045,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17081,7 +17081,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17089,7 +17089,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17125,7 +17125,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17133,7 +17133,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17169,7 +17169,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17177,7 +17177,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17213,7 +17213,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17221,7 +17221,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17257,7 +17257,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17265,7 +17265,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17301,7 +17301,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17309,7 +17309,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17345,7 +17345,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17353,7 +17353,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17389,7 +17389,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17397,7 +17397,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17433,7 +17433,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17441,7 +17441,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17477,7 +17477,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17485,7 +17485,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17521,7 +17521,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17529,7 +17529,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17565,7 +17565,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17573,7 +17573,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17609,7 +17609,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17617,7 +17617,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17653,7 +17653,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17661,7 +17661,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17697,7 +17697,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17705,7 +17705,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre
@@ -17741,7 +17741,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               className="css-1n7ec1i-line"
             >
               <td
-                className="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 onClick={null}
               >
                 <pre
@@ -17749,7 +17749,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 />
               </td>
               <td
-                className="css-1548r9v-gutter css-cnnxkz-diff-added"
+                className="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 onClick={[Function]}
               >
                 <pre

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -789,14 +789,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -831,14 +831,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -879,14 +879,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -963,14 +963,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -999,14 +999,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1070,14 +1070,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1117,14 +1117,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1153,14 +1153,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1227,14 +1227,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1263,14 +1263,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1337,14 +1337,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1373,14 +1373,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1430,14 +1430,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1510,14 +1510,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1579,14 +1579,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1627,14 +1627,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1707,14 +1707,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1805,14 +1805,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1913,14 +1913,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -1982,14 +1982,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2035,14 +2035,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2088,14 +2088,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2124,14 +2124,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2183,14 +2183,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2263,14 +2263,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2355,14 +2355,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2496,14 +2496,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2569,14 +2569,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2617,14 +2617,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2697,14 +2697,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2804,14 +2804,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2857,14 +2857,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -2928,14 +2928,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3010,14 +3010,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3339,14 +3339,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3416,14 +3416,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3481,14 +3481,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3565,14 +3565,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3668,14 +3668,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3728,14 +3728,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3777,14 +3777,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3826,14 +3826,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -3932,14 +3932,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4039,14 +4039,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4102,14 +4102,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4145,14 +4145,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4229,14 +4229,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4297,14 +4297,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4340,14 +4340,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4412,14 +4412,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4496,14 +4496,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4588,14 +4588,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4648,14 +4648,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4691,14 +4691,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4794,14 +4794,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4886,14 +4886,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -4946,14 +4946,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5007,14 +5007,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5050,14 +5050,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5093,14 +5093,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5136,14 +5136,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5185,14 +5185,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5233,14 +5233,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5298,14 +5298,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5440,14 +5440,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5604,14 +5604,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5714,14 +5714,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5761,14 +5761,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
@@ -5797,14 +5797,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                         class="css-1n7ec1i-line"
                       >
                         <td
-                          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"
                           />
                         </td>
                         <td
-                          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                         >
                           <pre
                             class="css-14p8zw1-line-number"

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -819,14 +819,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -861,14 +861,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -909,14 +909,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -993,14 +993,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1029,14 +1029,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1100,14 +1100,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1147,14 +1147,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1183,14 +1183,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1257,14 +1257,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1293,14 +1293,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1367,14 +1367,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1403,14 +1403,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1460,14 +1460,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1540,14 +1540,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1609,14 +1609,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1657,14 +1657,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1737,14 +1737,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1835,14 +1835,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -1943,14 +1943,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2012,14 +2012,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2065,14 +2065,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2118,14 +2118,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2154,14 +2154,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2213,14 +2213,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2293,14 +2293,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2385,14 +2385,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2526,14 +2526,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2599,14 +2599,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2647,14 +2647,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2727,14 +2727,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2834,14 +2834,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2887,14 +2887,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -2989,14 +2989,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3071,14 +3071,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3400,14 +3400,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3477,14 +3477,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3542,14 +3542,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3626,14 +3626,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3729,14 +3729,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3789,14 +3789,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3838,14 +3838,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3887,14 +3887,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -3993,14 +3993,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4100,14 +4100,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4163,14 +4163,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4206,14 +4206,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4290,14 +4290,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4358,14 +4358,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4401,14 +4401,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4473,14 +4473,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4557,14 +4557,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4649,14 +4649,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4709,14 +4709,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4752,14 +4752,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4855,14 +4855,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -4947,14 +4947,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5007,14 +5007,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5068,14 +5068,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5111,14 +5111,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5154,14 +5154,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5197,14 +5197,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5246,14 +5246,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5294,14 +5294,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5359,14 +5359,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5501,14 +5501,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5665,14 +5665,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5775,14 +5775,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5822,14 +5822,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
@@ -5858,14 +5858,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           class="css-1n7ec1i-line"
                         >
                           <td
-                            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"
                             />
                           </td>
                           <td
-                            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                           >
                             <pre
                               class="css-14p8zw1-line-number"

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -16,12 +16,11 @@ const styles: ReactDiffViewerStylesOverride = {
   gutter: {
     background: '#cdffd8',
     '&:hover': {
-      fontSize: '1.2rem',
       opacity: '0.75'
     }
   },
   emptyGutter: {
-    pointerEvents: 'none'
+    display: 'none'
   }
 }
 

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -222,14 +222,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                     class="css-1n7ec1i-line"
                   >
                     <td
-                      class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
                       />
                     </td>
                     <td
-                      class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
@@ -270,14 +270,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                     class="css-1n7ec1i-line"
                   >
                     <td
-                      class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
                       />
                     </td>
                     <td
-                      class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
@@ -306,14 +306,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                     class="css-1n7ec1i-line"
                   >
                     <td
-                      class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
                       />
                     </td>
                     <td
-                      class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
@@ -400,14 +400,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                     class="css-1n7ec1i-line"
                   >
                     <td
-                      class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
                       />
                     </td>
                     <td
-                      class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
@@ -461,14 +461,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                     class="css-1n7ec1i-line"
                   >
                     <td
-                      class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
                       />
                     </td>
                     <td
-                      class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
@@ -508,14 +508,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                     class="css-1n7ec1i-line"
                   >
                     <td
-                      class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
                       />
                     </td>
                     <td
-                      class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
@@ -544,14 +544,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                     class="css-1n7ec1i-line"
                   >
                     <td
-                      class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"
                       />
                     </td>
                     <td
-                      class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                      class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
                         class="css-14p8zw1-line-number"

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -192,14 +192,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -240,14 +240,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -276,14 +276,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -370,14 +370,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -431,14 +431,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -478,14 +478,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -514,14 +514,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -22,14 +22,14 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -77,14 +77,14 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -125,14 +125,14 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -161,14 +161,14 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -472,14 +472,14 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -508,14 +508,14 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -563,14 +563,14 @@ exports[`DiffView component Should add comment box 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -624,14 +624,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -666,14 +666,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -714,14 +714,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -798,14 +798,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -834,14 +834,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -905,14 +905,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -952,14 +952,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -988,14 +988,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1062,14 +1062,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1098,14 +1098,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1172,14 +1172,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1208,14 +1208,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1265,14 +1265,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1345,14 +1345,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1414,14 +1414,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1462,14 +1462,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1542,14 +1542,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1640,14 +1640,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1748,14 +1748,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1817,14 +1817,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1870,14 +1870,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1923,14 +1923,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -1959,14 +1959,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2018,14 +2018,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2098,14 +2098,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2190,14 +2190,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2331,14 +2331,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2404,14 +2404,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2452,14 +2452,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2532,14 +2532,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2639,14 +2639,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2692,14 +2692,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -2763,14 +2763,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3099,14 +3099,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3396,14 +3396,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3473,14 +3473,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3538,14 +3538,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3622,14 +3622,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3725,14 +3725,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3785,14 +3785,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3834,14 +3834,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3883,14 +3883,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -3989,14 +3989,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4096,14 +4096,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4159,14 +4159,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4202,14 +4202,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4286,14 +4286,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4354,14 +4354,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4397,14 +4397,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4469,14 +4469,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4553,14 +4553,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4645,14 +4645,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4705,14 +4705,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4748,14 +4748,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4851,14 +4851,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -4943,14 +4943,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5003,14 +5003,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5064,14 +5064,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5107,14 +5107,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5150,14 +5150,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5193,14 +5193,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5242,14 +5242,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5290,14 +5290,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5355,14 +5355,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5497,14 +5497,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5661,14 +5661,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5771,14 +5771,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5818,14 +5818,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
@@ -5854,14 +5854,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
         class="css-1n7ec1i-line"
       >
         <td
-          class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"
           />
         </td>
         <td
-          class="css-1548r9v-gutter css-cnnxkz-diff-added"
+          class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
         >
           <pre
             class="css-14p8zw1-line-number"

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -52,14 +52,14 @@ exports[`DiffView component Should add comment box 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -107,14 +107,14 @@ exports[`DiffView component Should add comment box 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -155,14 +155,14 @@ exports[`DiffView component Should add comment box 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -191,14 +191,14 @@ exports[`DiffView component Should add comment box 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -502,14 +502,14 @@ exports[`DiffView component Should add comment box 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -538,14 +538,14 @@ exports[`DiffView component Should add comment box 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -593,14 +593,14 @@ exports[`DiffView component Should add comment box 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -685,14 +685,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -727,14 +727,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -775,14 +775,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -859,14 +859,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -895,14 +895,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -966,14 +966,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1013,14 +1013,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1049,14 +1049,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1123,14 +1123,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1159,14 +1159,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1233,14 +1233,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1269,14 +1269,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1326,14 +1326,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1406,14 +1406,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1475,14 +1475,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1523,14 +1523,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1603,14 +1603,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1701,14 +1701,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1809,14 +1809,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1878,14 +1878,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1931,14 +1931,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -1984,14 +1984,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2020,14 +2020,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2079,14 +2079,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2159,14 +2159,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2251,14 +2251,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2392,14 +2392,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2465,14 +2465,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2513,14 +2513,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2593,14 +2593,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2700,14 +2700,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2753,14 +2753,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -2855,14 +2855,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3191,14 +3191,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3488,14 +3488,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3565,14 +3565,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3630,14 +3630,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3714,14 +3714,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3817,14 +3817,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3877,14 +3877,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3926,14 +3926,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -3975,14 +3975,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4081,14 +4081,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4188,14 +4188,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4251,14 +4251,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4294,14 +4294,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4378,14 +4378,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4446,14 +4446,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4489,14 +4489,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4561,14 +4561,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4645,14 +4645,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4737,14 +4737,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4797,14 +4797,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4840,14 +4840,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -4943,14 +4943,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5035,14 +5035,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5095,14 +5095,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5156,14 +5156,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5199,14 +5199,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5242,14 +5242,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5285,14 +5285,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5334,14 +5334,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5382,14 +5382,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5447,14 +5447,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5589,14 +5589,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5753,14 +5753,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5863,14 +5863,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5910,14 +5910,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
@@ -5946,14 +5946,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
           class="css-1n7ec1i-line"
         >
           <td
-            class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"
             />
           </td>
           <td
-            class="css-1548r9v-gutter css-cnnxkz-diff-added"
+            class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
           >
             <pre
               class="css-14p8zw1-line-number"

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -140,14 +140,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -195,14 +195,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -243,14 +243,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -279,14 +279,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -368,14 +368,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -404,14 +404,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -459,14 +459,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -973,14 +973,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1028,14 +1028,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1076,14 +1076,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1112,14 +1112,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1201,14 +1201,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1237,14 +1237,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1292,14 +1292,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1755,14 +1755,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1832,14 +1832,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1897,14 +1897,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -1952,14 +1952,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2040,14 +2040,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2117,14 +2117,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2181,14 +2181,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2230,14 +2230,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2278,14 +2278,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2355,14 +2355,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2422,14 +2422,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2501,14 +2501,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2544,14 +2544,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2592,14 +2592,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2664,14 +2664,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2727,14 +2727,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2775,14 +2775,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2822,14 +2822,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -2858,14 +2858,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3338,14 +3338,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3415,14 +3415,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3480,14 +3480,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3535,14 +3535,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3623,14 +3623,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3700,14 +3700,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3764,14 +3764,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3813,14 +3813,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3861,14 +3861,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -3938,14 +3938,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4005,14 +4005,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4084,14 +4084,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4127,14 +4127,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4175,14 +4175,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4247,14 +4247,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4310,14 +4310,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4358,14 +4358,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4405,14 +4405,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -4441,14 +4441,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5296,14 +5296,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5373,14 +5373,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5438,14 +5438,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5493,14 +5493,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5581,14 +5581,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5658,14 +5658,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5722,14 +5722,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5771,14 +5771,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5819,14 +5819,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5896,14 +5896,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -5963,14 +5963,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -6042,14 +6042,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -6085,14 +6085,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -6133,14 +6133,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -6205,14 +6205,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -6268,14 +6268,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -6316,14 +6316,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -6363,14 +6363,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
@@ -6399,14 +6399,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   class="css-1n7ec1i-line"
                 >
                   <td
-                    class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"
                     />
                   </td>
                   <td
-                    class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                    class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                   >
                     <pre
                       class="css-14p8zw1-line-number"

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -110,14 +110,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -165,14 +165,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -213,14 +213,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -249,14 +249,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -338,14 +338,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -374,14 +374,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -429,14 +429,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -912,14 +912,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -967,14 +967,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1015,14 +1015,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1051,14 +1051,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1140,14 +1140,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1176,14 +1176,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1231,14 +1231,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1663,14 +1663,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1740,14 +1740,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1805,14 +1805,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1860,14 +1860,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -1948,14 +1948,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2025,14 +2025,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2089,14 +2089,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2138,14 +2138,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2186,14 +2186,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2263,14 +2263,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2330,14 +2330,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2409,14 +2409,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2452,14 +2452,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2500,14 +2500,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2572,14 +2572,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2635,14 +2635,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2683,14 +2683,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2730,14 +2730,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -2766,14 +2766,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3215,14 +3215,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3292,14 +3292,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3357,14 +3357,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3412,14 +3412,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3500,14 +3500,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3577,14 +3577,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3641,14 +3641,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3690,14 +3690,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3738,14 +3738,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3815,14 +3815,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3882,14 +3882,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -3961,14 +3961,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -4004,14 +4004,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -4052,14 +4052,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -4124,14 +4124,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -4187,14 +4187,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -4235,14 +4235,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -4282,14 +4282,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -4318,14 +4318,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5142,14 +5142,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5219,14 +5219,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5284,14 +5284,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5339,14 +5339,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5427,14 +5427,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5504,14 +5504,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5568,14 +5568,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5617,14 +5617,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5665,14 +5665,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5742,14 +5742,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5809,14 +5809,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5888,14 +5888,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5931,14 +5931,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -5979,14 +5979,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -6051,14 +6051,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -6114,14 +6114,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -6162,14 +6162,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -6209,14 +6209,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
@@ -6245,14 +6245,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                 class="css-1n7ec1i-line"
               >
                 <td
-                  class="css-1548r9v-gutter css-kvqxl6-empty-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"
                   />
                 </td>
                 <td
-                  class="css-1548r9v-gutter css-cnnxkz-diff-added"
+                  class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                 >
                   <pre
                     class="css-14p8zw1-line-number"


### PR DESCRIPTION
Closes #1452

This PR updates `ReactDiffViewer` styles to disable empty gutter (#1452) and increase the number font-size on hover because the line gets pushed when the font-size increase.

Before:
![image](https://user-images.githubusercontent.com/35906419/153870491-fbbb64f8-1304-40de-b832-cc37061c57e5.png)
![image](https://user-images.githubusercontent.com/35906419/153870529-af7cc6ee-bf47-4bb1-99fa-4d40ca912c1f.png)


After:

![image](https://user-images.githubusercontent.com/35906419/153870303-06090051-e1d9-43a3-81b3-742f012da5fd.png)
![image](https://user-images.githubusercontent.com/35906419/153870385-b4add6e1-3459-4ea5-a52b-cc4c4dec222a.png)
