### PR TITLE
adds_exercise_migration

### DIFF
--- a/prisma/migrations/20220212111059_adds_exercises/migration.sql
+++ b/prisma/migrations/20220212111059_adds_exercises/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "exercises" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+    "authorId" INTEGER NOT NULL,
+    "moduleId" INTEGER NOT NULL,
+    "description" TEXT NOT NULL,
+    "answer" TEXT NOT NULL,
+    "testable" BOOLEAN NOT NULL,
+    "testStr" TEXT NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "exercises" ADD FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "exercises" ADD FOREIGN KEY ("moduleId") REFERENCES "modules"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,20 +153,38 @@ model User {
   userLessons               UserLesson[]
   comments                  Comment[]
   modules                   Module[]
+  exercises                 Exercise[]
 
   @@map("users")
 }
 
 model Module {
-  id        Int      @id @default(autoincrement())
-  createdAt DateTime @default(now()) @db.Timestamptz(6)
-  updatedAt DateTime @updatedAt @db.Timestamptz(6)
-  author    User     @relation(fields: [authorId], references: [id])
+  id        Int        @id @default(autoincrement())
+  createdAt DateTime   @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime   @updatedAt @db.Timestamptz(6)
+  author    User       @relation(fields: [authorId], references: [id])
   authorId  Int
-  lesson    Lesson   @relation(fields: [lessonId], references: [id])
+  lesson    Lesson     @relation(fields: [lessonId], references: [id])
   lessonId  Int
-  name      String   @db.VarChar(255)
+  name      String     @db.VarChar(255)
   content   String
+  exercises Exercise[]
 
   @@map("modules")
+}
+
+model Exercise {
+  id          Int      @id @default(autoincrement())
+  createdAt   DateTime @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime @updatedAt @db.Timestamptz(6)
+  author      User     @relation(fields: [authorId], references: [id])
+  authorId    Int
+  module      Module   @relation(fields: [moduleId], references: [id])
+  moduleId    Int
+  description String
+  answer      String
+  testable    Boolean
+  testStr     String
+
+  @@map("exercises")
 }


### PR DESCRIPTION
This Pr continues the dojo implantation.  It adds the Exercise table to the db via prisma migration.
Exercise table has two foreign keys. Modules and Users.
Each exercise will belong to a module. 
This lays the foundation for exercise crud. 