### PR TITLE
Refactor updateCache helper parameters

### DIFF
--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -149,18 +149,16 @@ const ChallengeQuestionCardDisplay: React.FC<{
         />
       )
 
-    const update = updateCache(
-      submission.id,
-      undefined,
-      commentValue,
+    const update = updateCache({
+      submissionId: submission.id,
+      content: commentValue,
       name,
       username,
-      submission.lessonId,
-      undefined,
-      undefined,
-      submission.challengeId,
-      submission.user.id
-    )
+      lessonId: submission.lessonId,
+      challengeId: submission.challengeId,
+      userId: submission.user.id
+    })
+
     return (
       <div className="card shadow-sm border-0 mt-3">
         {submission.createdAt && (

--- a/components/CommentBox.tsx
+++ b/components/CommentBox.tsx
@@ -40,18 +40,17 @@ const CommentBox: React.FC<{
   const comments = commentsData?.filter(comment => comment.line === line)
   const [hidden, setHidden] = useState(false)
   const [input, setInput] = useState('')
-  const update = updateCache(
+  const update = updateCache({
     submissionId,
-    undefined,
-    input,
-    name!,
-    username!,
-    lessonId,
+    content: input,
+    name,
+    username,
+    lessonId: lessonId!,
     line,
     fileName,
-    challengeId,
-    userId
-  )
+    challengeId: challengeId!,
+    userId: userId!
+  })
 
   const [addComment] = useAddCommentMutation()
   return (

--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -170,18 +170,17 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({ submissionData }) => {
   })
   const [previousSubmissions, setPreviousSubmissions] = useState(data)
   const [showAccordion, setShowAccordion] = useState(false)
-  const update = updateCache(
-    submissionState.id,
-    undefined,
-    commentValue,
+
+  const update = updateCache({
+    submissionId: submissionState.id,
+    content: commentValue,
     name,
     username,
-    lessonId,
-    undefined,
-    undefined,
-    challengeId,
-    user.id
-  )
+    lessonId: lessonId!,
+    challengeId: challengeId!,
+    userId: user.id!
+  })
+
   useEffect(() => {
     if (data?.getPreviousSubmissions) {
       setPreviousSubmissions(data)

--- a/helpers/updateCache.test.js
+++ b/helpers/updateCache.test.js
@@ -122,7 +122,7 @@ describe('updateCache helper', () => {
 
     updateCache({
       submissionId: 0,
-      commentToDelete: 1,
+      commentToDeleteId: 1,
       content: 'Test comment!',
       name: 'Test User',
       username: 'testuser',

--- a/helpers/updateCache.test.js
+++ b/helpers/updateCache.test.js
@@ -66,34 +66,28 @@ describe('updateCache helper', () => {
       variables: { userId: 1, challengeId: 23 },
       data: { getPreviousSubmissions: submissionsData }
     })
-    updateCache(
-      0,
-      undefined,
-      'Test comment!',
-      'Test User',
-      'testuser',
-      2,
-      undefined,
-      undefined,
-      23,
-      1
-    )(cache)
+    updateCache({
+      submissionId: 0,
+      content: 'Test comment!',
+      name: 'Test User',
+      username: 'testuser',
+      lessonId: 2,
+      challengeId: 23,
+      userId: 1
+    })(cache)
   })
   it('should throw an error if there is no cache to update', () => {
     const cache = new InMemoryCache({ addTypename: false })
     expect(() => {
-      updateCache(
-        0,
-        undefined,
-        'Test comment!',
-        'Test User',
-        'testuser',
-        2,
-        undefined,
-        undefined,
-        23,
-        1
-      )(cache)
+      updateCache({
+        submissionId: 0,
+        content: 'Test comment!',
+        name: 'Test User',
+        username: 'testuser',
+        lessonId: 2,
+        challengeId: 23,
+        userId: 1
+      })(cache)
     }).toThrow('No cache to update')
   })
   it('should throw if no submission is found', () => {
@@ -104,18 +98,15 @@ describe('updateCache helper', () => {
       data: { getPreviousSubmissions: submissionsData }
     })
     expect(() =>
-      updateCache(
-        11,
-        undefined,
-        'Test comment!',
-        'Test User',
-        'testuser',
-        2,
-        undefined,
-        undefined,
-        23,
-        1
-      )(cache)
+      updateCache({
+        submissionId: 11,
+        content: 'Test comment!',
+        name: 'Test User',
+        username: 'testuser',
+        lessonId: 2,
+        challengeId: 23,
+        userId: 1
+      })(cache)
     ).toThrow('Incorrect submission id (no submission was found)')
   })
   it('should delete previous submission comment in cache', () => {
@@ -129,18 +120,16 @@ describe('updateCache helper', () => {
       data: { getPreviousSubmissions: submissionsData }
     })
 
-    updateCache(
-      0,
-      1,
-      'Test comment!',
-      'Test User',
-      'testuser',
-      2,
-      undefined,
-      undefined,
-      23,
-      1
-    )(cache)
+    updateCache({
+      submissionId: 0,
+      commentToDelete: 1,
+      content: 'Test comment!',
+      name: 'Test User',
+      username: 'testuser',
+      lessonId: 2,
+      challengeId: 23,
+      userId: 1
+    })(cache)
 
     const newCache = cache.readQuery({
       query: GET_PREVIOUS_SUBMISSIONS,

--- a/helpers/updateCache.ts
+++ b/helpers/updateCache.ts
@@ -13,18 +13,32 @@ import _ from 'lodash'
   closure is used because it's the only way to pass additional arguments to update function 
   (update has only two arguments - cache and result of query)
 */
-export const updateCache = (
-  submissionId: number,
-  commentToDeleteId?: number,
-  content?: string,
-  name?: string,
-  username?: string,
-  lessonId?: number,
-  line?: number,
-  fileName?: string,
-  challengeId?: number,
-  userId?: number
-) => {
+
+type UpdateCacheParams = {
+  submissionId: number
+  lessonId: number
+  challengeId: number
+  userId: number
+  commentToDeleteId?: number
+  content?: string
+  name?: string
+  username?: string
+  line?: number
+  fileName?: string
+}
+
+export const updateCache = ({
+  submissionId,
+  commentToDeleteId,
+  content,
+  name,
+  username,
+  lessonId,
+  line,
+  fileName,
+  challengeId,
+  userId
+}: UpdateCacheParams) => {
   return (cache: ApolloCache<AddCommentMutation>) => {
     const data = cache.readQuery<GetPreviousSubmissionsQuery>({
       query: GET_PREVIOUS_SUBMISSIONS,


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-app/issues/1446

This PR refactor `updateCache` helper to have a single typed object as a parameter instead of 10 parameters.