### PR TITLE
Fix LessonCard completion badge styles

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -7867,7 +7867,7 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
           </a>
         </div>
         <span
-          className="lesson-card__badge badge rounded-pill bg-success p-0"
+          className="lesson-card__badge badge rounded-pill p-0"
         >
           <svg
             fill="none"
@@ -7970,7 +7970,7 @@ exports[`Storyshots Components/LessonCard With Completed 1`] = `
           </a>
         </h4>
         <span
-          className="lesson-card__badge badge rounded-pill bg-success mt-2 me-2 py-2 d-flex align-items-center"
+          className="lesson-card__badge badge rounded-pill mt-2 me-2 py-2 d-flex align-items-center"
         >
           <svg
             fill="none"

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -3427,7 +3427,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </a>
                 </div>
                 <span
-                  class="lesson-card__badge badge rounded-pill bg-success p-0"
+                  class="lesson-card__badge badge rounded-pill p-0"
                 >
                   <svg
                     fill="none"
@@ -3523,7 +3523,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </a>
                 </h4>
                 <span
-                  class="lesson-card__badge badge rounded-pill bg-success mt-2 me-2 py-2 d-flex align-items-center"
+                  class="lesson-card__badge badge rounded-pill mt-2 me-2 py-2 d-flex align-items-center"
                 >
                   <svg
                     fill="none"
@@ -3610,7 +3610,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </a>
                 </div>
                 <span
-                  class="lesson-card__badge badge rounded-pill bg-success p-0"
+                  class="lesson-card__badge badge rounded-pill p-0"
                 >
                   <svg
                     fill="none"
@@ -3706,7 +3706,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </a>
                 </h4>
                 <span
-                  class="lesson-card__badge badge rounded-pill bg-success mt-2 me-2 py-2 d-flex align-items-center"
+                  class="lesson-card__badge badge rounded-pill mt-2 me-2 py-2 d-flex align-items-center"
                 >
                   <svg
                     fill="none"
@@ -3793,7 +3793,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </a>
                 </div>
                 <span
-                  class="lesson-card__badge badge rounded-pill bg-success p-0"
+                  class="lesson-card__badge badge rounded-pill p-0"
                 >
                   <svg
                     fill="none"
@@ -3889,7 +3889,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   </a>
                 </h4>
                 <span
-                  class="lesson-card__badge badge rounded-pill bg-success mt-2 me-2 py-2 d-flex align-items-center"
+                  class="lesson-card__badge badge rounded-pill mt-2 me-2 py-2 d-flex align-items-center"
                 >
                   <svg
                     fill="none"

--- a/components/LessonCard.tsx
+++ b/components/LessonCard.tsx
@@ -50,8 +50,7 @@ const ReviewCount: React.FC<ReviewCountProps> = props => {
   const pendingSubmissionsCount = data.submissions.reduce(
     (acc: number, val: any) => {
       if (val.status === SubmissionStatus.Open) {
-        acc = acc + 1
-        return acc
+        return acc + 1
       }
       return acc
     },
@@ -91,7 +90,7 @@ const LessonCard: React.FC<Props> = props => {
           </div>
           {props.currentState === 'completed' && (
             <span
-              className={`${styles['lesson-card__badge']} badge rounded-pill bg-success p-0`}
+              className={`${styles['lesson-card__badge']} badge rounded-pill p-0`}
             >
               <CheckCircle size="15" />
               <span className="mx-1 d-none d-md-block">COMPLETED</span>
@@ -156,7 +155,7 @@ const LessonCard: React.FC<Props> = props => {
           </h4>
           {props.currentState === 'completed' && (
             <span
-              className={`${styles['lesson-card__badge']} badge rounded-pill bg-success mt-2 me-2 py-2 d-flex align-items-center`}
+              className={`${styles['lesson-card__badge']} badge rounded-pill mt-2 me-2 py-2 d-flex align-items-center`}
             >
               <CheckCircle size="15" />
               <span className="mx-1 d-none d-md-block">COMPLETED</span>

--- a/components/__snapshots__/LessonCard.test.js.snap
+++ b/components/__snapshots__/LessonCard.test.js.snap
@@ -23,7 +23,7 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
             />
           </div>
           <span
-            class="lesson-card__badge badge rounded-pill bg-success p-0"
+            class="lesson-card__badge badge rounded-pill p-0"
           >
             <svg
               fill="none"
@@ -113,7 +113,7 @@ exports[`Lesson Card Complete State Should render lessonCard with loading... 1`]
             />
           </h4>
           <span
-            class="lesson-card__badge badge rounded-pill bg-success mt-2 me-2 py-2 d-flex align-items-center"
+            class="lesson-card__badge badge rounded-pill mt-2 me-2 py-2 d-flex align-items-center"
           >
             <svg
               fill="none"
@@ -201,7 +201,7 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
             />
           </div>
           <span
-            class="lesson-card__badge badge rounded-pill bg-success p-0"
+            class="lesson-card__badge badge rounded-pill p-0"
           >
             <svg
               fill="none"
@@ -290,7 +290,7 @@ exports[`Lesson Card Complete State Should render lessonCard with null if no dat
             />
           </h4>
           <span
-            class="lesson-card__badge badge rounded-pill bg-success mt-2 me-2 py-2 d-flex align-items-center"
+            class="lesson-card__badge badge rounded-pill mt-2 me-2 py-2 d-flex align-items-center"
           >
             <svg
               fill="none"
@@ -377,7 +377,7 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
             />
           </div>
           <span
-            class="lesson-card__badge badge rounded-pill bg-success p-0"
+            class="lesson-card__badge badge rounded-pill p-0"
           >
             <svg
               fill="none"
@@ -466,7 +466,7 @@ exports[`Lesson Card Complete State Should render lessonCard with submission cou
             />
           </h4>
           <span
-            class="lesson-card__badge badge rounded-pill bg-success mt-2 me-2 py-2 d-flex align-items-center"
+            class="lesson-card__badge badge rounded-pill mt-2 me-2 py-2 d-flex align-items-center"
           >
             <svg
               fill="none"

--- a/scss/lessonCard.module.scss
+++ b/scss/lessonCard.module.scss
@@ -13,7 +13,7 @@
   padding-right: 1em;
   margin-left: auto;
   @media (max-width: 768px) {
-    background-color: transparent;
+    background-color: transparent !important;
     color: #00cf92;
     margin-left: auto;
     & > svg {

--- a/scss/lessonCard.module.scss
+++ b/scss/lessonCard.module.scss
@@ -1,3 +1,5 @@
+@use './_variables.module';
+
 .lesson-card__container_inprogress {
   border-width: 2px;
 }
@@ -12,8 +14,9 @@
   padding-left: 1em;
   padding-right: 1em;
   margin-left: auto;
+  background-color: variables.$success;
   @media (max-width: 768px) {
-    background-color: transparent !important;
+    background-color: transparent;
     color: #00cf92;
     margin-left: auto;
     & > svg {


### PR DESCRIPTION
Closes #1405 

This PR force `background: transparent` declaration to be applied with the `!important` flag so it overrides bootstrap background styles.

Before:

![image](https://user-images.githubusercontent.com/35906419/154267253-1e499cdf-ab38-44e4-acef-5a3919026ace.png)

After:

![image](https://user-images.githubusercontent.com/35906419/154267318-9231a7d5-7bd7-4746-a167-8eb150c33b8d.png)
