### PR TITLE
fixes_testStr_makes_optional

### DIFF
--- a/prisma/migrations/20220216203608_fixes_test_str/migration.sql
+++ b/prisma/migrations/20220216203608_fixes_test_str/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "exercises" ALTER COLUMN "testStr" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -184,7 +184,7 @@ model Exercise {
   description String
   answer      String
   testable    Boolean
-  testStr     String
+  testStr     String?
 
   @@map("exercises")
 }


### PR DESCRIPTION
This pr fixes the previous migration and makes testStr optional.
The reason we want testStr optional is because if we choose testable as false. We don't have to add a testStr.