### PR TITLE
deletes preview

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["orderByRelation"]
+  provider = "prisma-client-js"
 }
 
 datasource db {


### PR DESCRIPTION
This change fixes a prisma warning that shows up:

```
Preview feature "orderByRelation" is deprecated. The functionality can be used without specifying it as a preview feature.
```