### PR TITLE
Adds exercise crud

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -258,12 +258,12 @@ export type MutationUpdateChallengeArgs = {
 }
 
 export type MutationUpdateExerciseArgs = {
-  answer?: InputMaybe<Scalars['String']>
-  description?: InputMaybe<Scalars['String']>
+  answer: Scalars['String']
+  description: Scalars['String']
   id: Scalars['Int']
-  moduleId?: InputMaybe<Scalars['Int']>
+  moduleId: Scalars['Int']
   testStr?: InputMaybe<Scalars['String']>
-  testable?: InputMaybe<Scalars['Boolean']>
+  testable: Scalars['Boolean']
 }
 
 export type MutationUpdateLessonArgs = {
@@ -1444,7 +1444,10 @@ export type MutationResolvers<
     ResolversTypes['Exercise'],
     ParentType,
     ContextType,
-    RequireFields<MutationUpdateExerciseArgs, 'id'>
+    RequireFields<
+      MutationUpdateExerciseArgs,
+      'answer' | 'description' | 'id' | 'moduleId' | 'testable'
+    >
   >
   updateLesson?: Resolver<
     Array<ResolversTypes['Lesson']>,

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -113,7 +113,7 @@ export type Mutation = {
   acceptSubmission?: Maybe<Submission>
   addAlert?: Maybe<Array<Maybe<Alert>>>
   addComment?: Maybe<Comment>
-  addExercise?: Maybe<Exercise>
+  addExercise: Exercise
   addModule?: Maybe<Module>
   changeAdminRights?: Maybe<SuccessResponse>
   changePw?: Maybe<AuthResponse>
@@ -1316,7 +1316,7 @@ export type MutationResolvers<
     RequireFields<MutationAddCommentArgs, 'content' | 'submissionId'>
   >
   addExercise?: Resolver<
-    Maybe<ResolversTypes['Exercise']>,
+    ResolversTypes['Exercise'],
     ParentType,
     ContextType,
     RequireFields<

--- a/graphql/queryResolvers/exerciseCrud.test.js
+++ b/graphql/queryResolvers/exerciseCrud.test.js
@@ -1,0 +1,249 @@
+/**
+ * @jest-environment node
+ */
+import prismaMock from '../../__tests__/utils/prismaMock'
+import {
+  exercises,
+  deleteExercise,
+  addExercise,
+  updateExercise
+} from './exerciseCrud'
+const unsigned = {
+  req: {
+    user: {}
+  }
+}
+const AdminCtx = {
+  req: {
+    user: { isAdmin: true, id: 1 }
+  }
+}
+const mockExercises = [
+  {
+    id: 1,
+    description: 'const a = 3 what is a',
+    answer: 3
+  },
+  {
+    id: 2,
+    description: 'What is love',
+    answer: 'No'
+  }
+]
+
+describe('It should return all exercises', () => {
+  test('Should return exercises', () => {
+    prismaMock.exercise.findMany.mockResolvedValue(mockExercises)
+    expect(exercises()).resolves.toEqual(mockExercises)
+  })
+})
+
+describe('It should add exercises', () => {
+  test('It should make an exercise', async () => {
+    prismaMock.exercise.create.mockResolvedValue({
+      id: 1,
+      authorId: 1,
+      description: "What's 2",
+      answer: 'Number',
+      testable: false
+    })
+    expect(
+      await addExercise(
+        {},
+        { description: "What's 2", answer: 'Number' },
+        AdminCtx
+      )
+    ).toEqual({
+      id: 1,
+      authorId: 1,
+      description: "What's 2",
+      answer: 'Number',
+      testable: false
+    })
+  })
+  test('it should check user id ', () => {
+    expect(
+      addExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: false
+        },
+        {
+          req: {}
+        }
+      )
+    ).rejects.toThrowError()
+  })
+  test('it should check if testStr is present with testable ', () => {
+    expect(
+      addExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: true
+        },
+        {
+          req: { user: { id: 3 } }
+        }
+      )
+    ).rejects.toThrow(new Error('Testable must have test string'))
+  })
+})
+
+describe('It should update an exercise', () => {
+  test('should update a users name ', async () => {
+    const exer = {
+      id: 1,
+      description: 'Whats 2',
+      answer: 2
+    }
+
+    prismaMock.exercise.update.mockResolvedValue(exer)
+
+    await expect(updateExercise({}, exer, AdminCtx)).resolves.toEqual({
+      id: 1,
+      description: 'Whats 2',
+      answer: 2
+    })
+  })
+  test('It should check if user is signed in', () => {
+    expect(
+      updateExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: false
+        },
+        {
+          req: {}
+        }
+      )
+    ).rejects.toThrowError()
+  })
+  test('It should check if user is signed in', () => {
+    expect(
+      updateExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: false
+        },
+        {
+          req: {}
+        }
+      )
+    ).rejects.toThrowError()
+  })
+  test('It should check if user is signed in', () => {
+    expect(
+      updateExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: false
+        },
+        {
+          AdminCtx
+        }
+      )
+    ).rejects.toThrow(new Error('Not authorized to change'))
+  })
+  test('it should check if testStr is present with testable ', () => {
+    expect(
+      updateExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: true
+        },
+        {
+          req: { user: { id: 3 } }
+        }
+      )
+    ).rejects.toThrow(new Error('Testable must have test string'))
+  })
+  test('It should check user ', () => {
+    expect(
+      updateExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: false,
+          authorId: 2
+        },
+        {
+          req: { user: { id: 333 } }
+        }
+      )
+    ).rejects.toThrow(new Error('Not authorized to delete'))
+  })
+})
+describe('It should test delete', () => {
+  test('it should delete module', () => {
+    prismaMock.exercise.delete.mockResolvedValue({ success: true })
+    expect(deleteExercise({}, { id: 1 }, AdminCtx)).resolves.toEqual({
+      success: true
+    })
+  })
+  test('should check id when deleting', () => {
+    expect(
+      deleteExercise(
+        {},
+        {
+          id: 1
+        },
+        {
+          req: { user: {} }
+        }
+      )
+    ).rejects.toThrow(new Error('No User'))
+  })
+  test('It should check if user is signed in', () => {
+    expect(
+      updateExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: false
+        },
+        {
+          AdminCtx
+        }
+      )
+    ).rejects.toThrow(new Error('Not authorized to delete'))
+  })
+  test('It should check if user is signed in', () => {
+    expect(
+      deleteExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: false,
+          authorId: 2
+        },
+        {
+          req: { user: { id: 333 } }
+        }
+      )
+    ).rejects.toThrow(new Error('Not authorized to delete'))
+  })
+})

--- a/graphql/queryResolvers/exerciseCrud.test.js
+++ b/graphql/queryResolvers/exerciseCrud.test.js
@@ -8,11 +8,7 @@ import {
   addExercise,
   updateExercise
 } from './exerciseCrud'
-const unsigned = {
-  req: {
-    user: {}
-  }
-}
+
 const AdminCtx = {
   req: {
     user: { isAdmin: true, id: 1 }
@@ -66,9 +62,9 @@ describe('It should add exercises', () => {
       addExercise(
         {},
         {
-          content: 'testing',
-          name: 'Using functions to make pie',
-          lessonId: 1,
+          description: 'testing',
+          answer: 'Using functions to make pie',
+          moduleId: 1,
           testable: false
         },
         {
@@ -82,9 +78,9 @@ describe('It should add exercises', () => {
       addExercise(
         {},
         {
-          content: 'testing',
-          name: 'Using functions to make pie',
-          lessonId: 1,
+          description: 'Whats 2 + 3',
+          answer: 'Pie',
+          moduleId: 1,
           testable: true
         },
         {
@@ -116,9 +112,9 @@ describe('It should update an exercise', () => {
       updateExercise(
         {},
         {
-          content: 'testing',
-          name: 'Using functions to make pie',
-          lessonId: 1,
+          answer: 'testing',
+          description: 'Using functions to make pie',
+          moduleId: 1,
           testable: false
         },
         {
@@ -126,47 +122,15 @@ describe('It should update an exercise', () => {
         }
       )
     ).rejects.toThrowError()
-  })
-  test('It should check if user is signed in', () => {
-    expect(
-      updateExercise(
-        {},
-        {
-          content: 'testing',
-          name: 'Using functions to make pie',
-          lessonId: 1,
-          testable: false
-        },
-        {
-          req: {}
-        }
-      )
-    ).rejects.toThrowError()
-  })
-  test('It should check if user is signed in', () => {
-    expect(
-      updateExercise(
-        {},
-        {
-          content: 'testing',
-          name: 'Using functions to make pie',
-          lessonId: 1,
-          testable: false
-        },
-        {
-          AdminCtx
-        }
-      )
-    ).rejects.toThrow(new Error('Not authorized to change'))
   })
   test('it should check if testStr is present with testable ', () => {
     expect(
       updateExercise(
         {},
         {
-          content: 'testing',
-          name: 'Using functions to make pie',
-          lessonId: 1,
+          description: '333',
+          answer: 'number',
+          moduleId: 1,
           testable: true
         },
         {
@@ -175,7 +139,7 @@ describe('It should update an exercise', () => {
       )
     ).rejects.toThrow(new Error('Testable must have test string'))
   })
-  test('It should check user ', () => {
+  test('It should check user is author of exercise', () => {
     expect(
       updateExercise(
         {},
@@ -213,23 +177,7 @@ describe('It should test delete', () => {
       )
     ).rejects.toThrow(new Error('No User'))
   })
-  test('It should check if user is signed in', () => {
-    expect(
-      updateExercise(
-        {},
-        {
-          content: 'testing',
-          name: 'Using functions to make pie',
-          lessonId: 1,
-          testable: false
-        },
-        {
-          AdminCtx
-        }
-      )
-    ).rejects.toThrow(new Error('Not authorized to delete'))
-  })
-  test('It should check if user is signed in', () => {
+  test('It should check if user can delte their own exercise', () => {
     expect(
       deleteExercise(
         {},

--- a/graphql/queryResolvers/exerciseCrud.ts
+++ b/graphql/queryResolvers/exerciseCrud.ts
@@ -1,0 +1,28 @@
+import prisma from '../../prisma'
+import { MutationAddExerciseArgs } from '..'
+import { Context } from '../../@types/helpers'
+import { Exercise } from '..'
+import { isAdminOrThrow } from '../../helpers/isAdmin'
+
+export const exercises = async () => {
+  return await prisma.exercise.findMany({
+    include: {
+      author: true,
+      module: true
+    }
+  })
+}
+
+export const addExercise = async (
+  _parent: void,
+  args: MutationAddExerciseArgs,
+  { req }: Context
+): Promise<Exercise> => {
+  isAdminOrThrow(req)
+  const authorId = req.user?.id
+  if (!authorId) throw new Error('No user')
+  const { moduleId, description, answer, testable, testStr } = args
+  return prisma.exercise.create({
+    data: { authorId, moduleId, description, answer, testStr, testable }
+  })
+}

--- a/graphql/queryResolvers/exerciseCrud.ts
+++ b/graphql/queryResolvers/exerciseCrud.ts
@@ -1,7 +1,7 @@
 import prisma from '../../prisma'
-import { MutationAddExerciseArgs } from '..'
+import { MutationAddExerciseArgs, SuccessResponse } from '..'
 import { Context } from '../../@types/helpers'
-import { Exercise } from '..'
+import type { Exercise } from '@prisma/client'
 import { isAdminOrThrow } from '../../helpers/isAdmin'
 
 export const exercises = async () => {
@@ -21,8 +21,24 @@ export const addExercise = async (
   isAdminOrThrow(req)
   const authorId = req.user?.id
   if (!authorId) throw new Error('No user')
-  const { moduleId, description, answer, testable, testStr } = args
   return prisma.exercise.create({
-    data: { authorId, moduleId, description, answer, testStr, testable }
+    data: { authorId, ...args }
   })
+}
+
+export const updateExercise = async (
+  _parent: void,
+  args: MutationAddExerciseArgs,
+  { req }: Context
+): Exercise => {
+  const authorId = req.user?.id
+  if (!authorId) throw new Error('No user')
+}
+
+export const deleteExercise = async (
+  _parent: void,
+  args: MutationAddExerciseArgs,
+  { req }: Context
+): SuccessResponse => {
+  return { success: true }
 }

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -32,7 +32,12 @@ import {
 import { getPreviousSubmissions } from './queryResolvers/getPreviousSubmissions'
 import { deleteComment } from './queryResolvers/deleteComment'
 import { addModule, modules, deleteModule } from './queryResolvers/moduleCrud'
-import { exercises, addExercise } from './queryResolvers/exerciseCrud'
+import {
+  exercises,
+  addExercise,
+  updateExercise,
+  deleteExercise
+} from './queryResolvers/exerciseCrud'
 export default {
   Query: {
     submissions,
@@ -58,6 +63,8 @@ export default {
     createLesson,
     updateLesson,
     addExercise,
+    updateExercise,
+    deleteExercise,
     login,
     logout,
     signup,

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -32,7 +32,7 @@ import {
 import { getPreviousSubmissions } from './queryResolvers/getPreviousSubmissions'
 import { deleteComment } from './queryResolvers/deleteComment'
 import { addModule, modules, deleteModule } from './queryResolvers/moduleCrud'
-
+import { exercises, addExercise } from './queryResolvers/exerciseCrud'
 export default {
   Query: {
     submissions,
@@ -41,6 +41,7 @@ export default {
     isTokenValid,
     userInfo,
     lessons,
+    exercises,
     modules,
     session,
     alerts,
@@ -56,6 +57,7 @@ export default {
     rejectSubmission,
     createLesson,
     updateLesson,
+    addExercise,
     login,
     logout,
     signup,

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -64,7 +64,7 @@ export default gql`
       answer: String!
       testable: Boolean!
       testStr: String
-    ): Exercise
+    ): Exercise!
     updateExercise(
       id: Int!
       moduleId: Int

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -67,10 +67,10 @@ export default gql`
     ): Exercise!
     updateExercise(
       id: Int!
-      moduleId: Int
-      description: String
-      answer: String
-      testable: Boolean
+      moduleId: Int!
+      description: String!
+      answer: String!
+      testable: Boolean!
       testStr: String
     ): Exercise!
     deleteExercise(id: Int!): SuccessResponse


### PR DESCRIPTION
This pr closes https://github.com/garageScript/c0d3-app/issues/1470 
The typedefs were updated to make the response a non nullable exercise return for addExercise.

It also changes updateExercise  in typedefs.  It now make arguments non nullable.  This makes graphql throw an error right away instead of checking if every argument is null in the code.  They are non nullable in the db so they must be checked. 

This pr also adds exercise crud and test.
The exercises a building block to the dojo. They will allow students to interactively learn. 

```yarn generate``` was also run to update arguments. 
