### PR TITLE
drops column testable

### DIFF
--- a/prisma/migrations/20220218161843_deletes_testable/migration.sql
+++ b/prisma/migrations/20220218161843_deletes_testable/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `testable` on the `exercises` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "exercises" DROP COLUMN "testable";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,7 +182,6 @@ model Exercise {
   moduleId    Int
   description String
   answer      String
-  testable    Boolean
   testStr     String?
 
   @@map("exercises")


### PR DESCRIPTION
This pr drops the testable column in the db. The testable column was redundant. Instead we will just check if there is a testStr.