### PR TITLE
Updating Landing page - Curriculum text

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -24712,12 +24712,12 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
               }
             }
           >
-            Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spending a penny. The exercises and challenges are designed to be difficult to force you to ask questions. Students who have passed the lessons are available in the chatrooms to help you with your questions.
+            Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spenxding a penny. The exercises and challenges are designed to be difficult to force you to ask questions. chat channel. Students who have passed the lessons are available in the chatroom to help you with your questions.
              
             <span
               className="fw-light text-warning"
             >
-              (Meetups are currently unavailable due to COVID-19)
+              (Meetups are unavailable due to COVID-19)
             </span>
           </p>
         </div>

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -24712,17 +24712,13 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
               }
             }
           >
-            Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spending a penny. The exercises and challenges are designed to be difficult to force you to ask questions. Support is available in our chat channel or in-person at one of our
+            Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spenxding a penny. The exercises and challenges are designed to be difficult to force you to ask questions. chat channel. Students who have passed the lessons are available in the chatroom to help you with your questions.
              
-            <a
-              className="text-warning noUnderline"
-              href="https://www.meetup.com/San-Jose-C0D3/"
-              rel="noopener noreferrer"
-              target="_blank"
+            <span
+              className="fw-light text-warning"
             >
-              meetup groups
-            </a>
-            . Students who have passed the lessons may be available at the meetup or in the chatroom to help you with your questions.
+              (Meetups are unavailable due to COVID-19)
+            </span>
           </p>
         </div>
       </div>

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -24712,12 +24712,12 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
               }
             }
           >
-            Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spenxding a penny. The exercises and challenges are designed to be difficult to force you to ask questions. chat channel. Students who have passed the lessons are available in the chatroom to help you with your questions.
+            Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spending a penny. The exercises and challenges are designed to be difficult to force you to ask questions. Students who have passed the lessons are available in the chatrooms to help you with your questions.
              
             <span
               className="fw-light text-warning"
             >
-              (Meetups are unavailable due to COVID-19)
+              (Meetups are currently unavailable due to COVID-19)
             </span>
           </p>
         </div>

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -315,12 +315,12 @@ exports[`Index Page Should render index page 1`] = `
               class="mt-3 fw-light"
               style="line-height: 1.5;"
             >
-              Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spenxding a penny. The exercises and challenges are designed to be difficult to force you to ask questions. chat channel. Students who have passed the lessons are available in the chatroom to help you with your questions.
+              Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spending a penny. The exercises and challenges are designed to be difficult to force you to ask questions. Students who have passed the lessons are available in the chatrooms to help you with your questions.
                
               <span
                 class="fw-light text-warning"
               >
-                (Meetups are unavailable due to COVID-19)
+                (Meetups are currently unavailable due to COVID-19)
               </span>
             </p>
           </div>

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -315,17 +315,13 @@ exports[`Index Page Should render index page 1`] = `
               class="mt-3 fw-light"
               style="line-height: 1.5;"
             >
-              Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spending a penny. The exercises and challenges are designed to be difficult to force you to ask questions. Support is available in our chat channel or in-person at one of our
+              Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spenxding a penny. The exercises and challenges are designed to be difficult to force you to ask questions. chat channel. Students who have passed the lessons are available in the chatroom to help you with your questions.
                
-              <a
-                class="text-warning noUnderline"
-                href="https://www.meetup.com/San-Jose-C0D3/"
-                rel="noopener noreferrer"
-                target="_blank"
+              <span
+                class="fw-light text-warning"
               >
-                meetup groups
-              </a>
-              . Students who have passed the lessons may be available at the meetup or in the chatroom to help you with your questions.
+                (Meetups are unavailable due to COVID-19)
+              </span>
             </p>
           </div>
         </div>

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -315,12 +315,12 @@ exports[`Index Page Should render index page 1`] = `
               class="mt-3 fw-light"
               style="line-height: 1.5;"
             >
-              Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spending a penny. The exercises and challenges are designed to be difficult to force you to ask questions. Students who have passed the lessons are available in the chatrooms to help you with your questions.
+              Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spenxding a penny. The exercises and challenges are designed to be difficult to force you to ask questions. chat channel. Students who have passed the lessons are available in the chatroom to help you with your questions.
                
               <span
                 class="fw-light text-warning"
               >
-                (Meetups are currently unavailable due to COVID-19)
+                (Meetups are unavailable due to COVID-19)
               </span>
             </p>
           </div>

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -161,19 +161,14 @@ const LandingPage: React.FC = () => {
                 Each lesson in our curriculum is designed to be hands on and you
                 will learn by working through the exercises in the curriculum.
                 All hosting will be provided for you so you can proudly share
-                your accomplishments with the world without spending a penny.
+                your accomplishments with the world without spenxding a penny.
                 The exercises and challenges are designed to be difficult to
-                force you to ask questions. Support is available in our chat
-                channel or in-person at one of our{' '}
-                <NavLink
-                  path="https://www.meetup.com/San-Jose-C0D3/"
-                  className="text-warning"
-                  external
-                >
-                  meetup groups
-                </NavLink>
-                . Students who have passed the lessons may be available at the
-                meetup or in the chatroom to help you with your questions.
+                force you to ask questions. chat channel. Students who have
+                passed the lessons are available in the chatroom to help you
+                with your questions.{' '}
+                <span className="fw-light text-warning">
+                  (Meetups are unavailable due to COVID-19)
+                </span>
               </p>
             </div>
           </div>

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -161,13 +161,12 @@ const LandingPage: React.FC = () => {
                 Each lesson in our curriculum is designed to be hands on and you
                 will learn by working through the exercises in the curriculum.
                 All hosting will be provided for you so you can proudly share
-                your accomplishments with the world without spenxding a penny.
+                your accomplishments with the world without spending a penny.
                 The exercises and challenges are designed to be difficult to
-                force you to ask questions. chat channel. Students who have
-                passed the lessons are available in the chatroom to help you
-                with your questions.{' '}
+                force you to ask questions. Students who have passed the lessons
+                are available in the chatrooms to help you with your questions.{' '}
                 <span className="fw-light text-warning">
-                  (Meetups are unavailable due to COVID-19)
+                  (Meetups are currently unavailable due to COVID-19)
                 </span>
               </p>
             </div>

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -161,12 +161,13 @@ const LandingPage: React.FC = () => {
                 Each lesson in our curriculum is designed to be hands on and you
                 will learn by working through the exercises in the curriculum.
                 All hosting will be provided for you so you can proudly share
-                your accomplishments with the world without spending a penny.
+                your accomplishments with the world without spenxding a penny.
                 The exercises and challenges are designed to be difficult to
-                force you to ask questions. Students who have passed the lessons
-                are available in the chatrooms to help you with your questions.{' '}
+                force you to ask questions. chat channel. Students who have
+                passed the lessons are available in the chatroom to help you
+                with your questions.{' '}
                 <span className="fw-light text-warning">
-                  (Meetups are currently unavailable due to COVID-19)
+                  (Meetups are unavailable due to COVID-19)
                 </span>
               </p>
             </div>


### PR DESCRIPTION
Closes #1475 

Some students such as in [this message](https://discord.com/channels/828783458469675019/828783458469675022/942993056167243776), [this](https://discord.com/channels/828783458469675019/828783458469675022/942851260036575253), [and this](https://discord.com/channels/828783458469675019/831750088367800331/940650815306223677) thought there's meetups but there aren't because COVID-19. This PR updates the curriculum text to reflect the fact that no meetups will be held (temporary)

Before:

<img width="597" alt="image" src="https://user-images.githubusercontent.com/35906419/154810402-c795dbe0-8a74-4f57-be1d-39e1b38e7b01.png">


After:

<img width="597" alt="image" src="https://user-images.githubusercontent.com/35906419/154810370-3653a53e-d4a7-4ad8-8eb8-7b14f6a5e161.png">
