### PR TITLE
fix: Signup page errors are broken

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -25363,7 +25363,7 @@ exports[`Storyshots Pages/Signup Signup 1`] = `
         onSubmit={[Function]}
       >
         <div
-          className="form-group d-grid"
+          className="form-group d-grid mt-3"
         >
           <input
             autoFocus={true}
@@ -25456,7 +25456,7 @@ exports[`Storyshots Pages/Signup Signup Basic 1`] = `
         onSubmit={[Function]}
       >
         <div
-          className="form-group d-grid"
+          className="form-group d-grid mt-3"
         >
           <input
             autoFocus={true}
@@ -25543,14 +25543,20 @@ exports[`Storyshots Pages/Signup Signup Errors 1`] = `
         className="card-text"
       />
       <div
-        className="bg-light m-auto px-5 border-0"
-        data-testid="error-message"
+        className="alert d-flex justify-content-between mt-3 alert-danger"
+        role="alert"
       >
-        <h5
-          className="text-danger"
+        <div
+          className="d-flex gap-3"
         >
-           User does not exist
-        </h5>
+          <img
+            className="img-fluid"
+            height={24}
+            src="/assets/curriculum/icons/exclamation.svg"
+            width={24}
+          />
+          UserInput Error: User does not exist 
+        </div>
       </div>
       <form
         action="#"
@@ -25559,7 +25565,7 @@ exports[`Storyshots Pages/Signup Signup Errors 1`] = `
         onSubmit={[Function]}
       >
         <div
-          className="form-group d-grid"
+          className="form-group d-grid mt-3"
         >
           <input
             autoFocus={true}
@@ -25662,7 +25668,7 @@ exports[`Storyshots Pages/Signup Signup Loading 1`] = `
         onSubmit={[Function]}
       >
         <div
-          className="form-group d-grid"
+          className="form-group d-grid mt-3"
         >
           <input
             autoFocus={true}

--- a/__tests__/pages/__snapshots__/signup.test.js.snap
+++ b/__tests__/pages/__snapshots__/signup.test.js.snap
@@ -20,21 +20,26 @@ exports[`Signup Page Should render errors on fail 1`] = `
           class="card-text"
         />
         <div
-          class="bg-light m-auto px-5 border-0"
-          data-testid="error-message"
+          class="alert d-flex justify-content-between mt-3 alert-danger"
+          role="alert"
         >
-          <h5
-            class="text-danger"
+          <div
+            class="d-flex gap-3"
           >
-             Server cannot be reached. Please try again. If this problem persists, please send an email to support@c0d3.com
-          </h5>
+            <img
+              height="24"
+              src="/assets/curriculum/icons/exclamation.svg"
+              width="24"
+            />
+            Server Error: Server cannot be reached. Please try again. If this problem persists, please send an email to support@c0d3.com 
+          </div>
         </div>
         <form
           action="#"
           data-testid="form"
         >
           <div
-            class="form-group d-grid"
+            class="form-group d-grid mt-3"
           >
             <input
               class="form-control form-control-lg fw-light mb-3 "

--- a/__tests__/pages/signup.test.js
+++ b/__tests__/pages/signup.test.js
@@ -128,7 +128,7 @@ describe('Signup Page', () => {
     await waitFor(() => {
       expect(
         getByText(
-          'Server cannot be reached. Please try again. If this problem persists, please send an email to support@c0d3.com'
+          'Server Error: Server cannot be reached. Please try again. If this problem persists, please send an email to support@c0d3.com'
         )
       ).toBeTruthy()
       expect(container).toMatchSnapshot()

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -16,6 +16,7 @@ import SIGNUP_USER from '../graphql/queries/signupUser'
 
 import { WithLayout } from '../@types/page'
 import Title from '../components/Title'
+import Alert from '../components/Alert'
 
 type Values = {
   email: string
@@ -50,16 +51,7 @@ const initialValues: Values = {
 const ErrorMessage: React.FC<ErrorDisplayProps> = ({ signupErrors }) => {
   if (!signupErrors || !signupErrors.length) return <></>
   const errorMessages = signupErrors.map((message, idx) => {
-    const formattedMessage = message.split(':')[1]
-    return (
-      <div
-        key={idx}
-        data-testid="error-message"
-        className="bg-light m-auto px-5 border-0"
-      >
-        <h5 className="text-danger">{formattedMessage}</h5>
-      </div>
-    )
+    return <Alert key={idx} alert={{ id: -1, text: message, type: 'urgent' }} />
   })
   return <>{errorMessages}</>
 }
@@ -98,7 +90,7 @@ const SignupForm: React.FC<SignupFormProps> = ({
         onSubmit={handleSubmit}
       >
         <Form data-testid="form">
-          <div className="form-group d-grid">
+          <div className="form-group d-grid mt-3">
             <Field
               name="email"
               placeholder="Email address"


### PR DESCRIPTION
Closes #1511 

This PR remove the line that split the error message by the colon `:` in order to make the message appear and change the element that render the error to the `Alert` component.

Before: No errors

After:

<img width="660" alt="Screen Shot 2022-02-22 at 10 12 00 PM" src="https://user-images.githubusercontent.com/35906419/155199660-58060f83-62b3-4519-acae-aff9ea5726c9.png">

