### PR TITLE
Adds ability to collapse Submission Files

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -918,7 +918,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
               className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                className="form-check mt-2 me-2"
+                className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
               >
                 <input
                   checked={false}
@@ -929,7 +929,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                   value=""
                 />
                 <label
-                  className="form-check-label"
+                  className="form-check-label text-muted"
                   htmlFor="checkBox-1-0"
                 >
                   Viewed
@@ -1784,7 +1784,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
               className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                className="form-check mt-2 me-2"
+                className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
               >
                 <input
                   checked={false}
@@ -1795,7 +1795,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                   value=""
                 />
                 <label
-                  className="form-check-label"
+                  className="form-check-label text-muted"
                   htmlFor="checkBox-1-0"
                 >
                   Viewed
@@ -3135,7 +3135,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
     className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
   >
     <div
-      className="form-check mt-2 me-2"
+      className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
     >
       <input
         checked={false}
@@ -3146,7 +3146,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
         value=""
       />
       <label
-        className="form-check-label"
+        className="form-check-label text-muted"
         htmlFor="checkBox-1-0"
       >
         Viewed
@@ -3526,7 +3526,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
     className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
   >
     <div
-      className="form-check mt-2 me-2"
+      className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
     >
       <input
         checked={false}
@@ -3537,7 +3537,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
         value=""
       />
       <label
-        className="form-check-label"
+        className="form-check-label text-muted"
         htmlFor="checkBox-1-0"
       >
         Viewed
@@ -11626,7 +11626,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
             className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check mt-2 me-2"
+              className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
             >
               <input
                 checked={false}
@@ -11637,7 +11637,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                 value=""
               />
               <label
-                className="form-check-label"
+                className="form-check-label text-muted"
                 htmlFor="checkBox-1-0"
               >
                 Viewed
@@ -13046,7 +13046,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
             className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check mt-2 me-2"
+              className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
             >
               <input
                 checked={false}
@@ -13057,7 +13057,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                 value=""
               />
               <label
-                className="form-check-label"
+                className="form-check-label text-muted"
                 htmlFor="checkBox-1-0"
               >
                 Viewed
@@ -14464,7 +14464,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
             className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check mt-2 me-2"
+              className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
             >
               <input
                 checked={false}
@@ -14475,7 +14475,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                 value=""
               />
               <label
-                className="form-check-label"
+                className="form-check-label text-muted"
                 htmlFor="checkBox-1-0"
               >
                 Viewed
@@ -15882,7 +15882,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
             className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check mt-2 me-2"
+              className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
             >
               <input
                 checked={false}
@@ -15893,7 +15893,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                 value=""
               />
               <label
-                className="form-check-label"
+                className="form-check-label text-muted"
                 htmlFor="checkBox-1-0"
               >
                 Viewed
@@ -17300,7 +17300,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
             className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check mt-2 me-2"
+              className="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
             >
               <input
                 checked={false}
@@ -17311,7 +17311,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                 value=""
               />
               <label
-                className="form-check-label"
+                className="form-check-label text-muted"
                 htmlFor="checkBox-1-0"
               >
                 Viewed

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -915,10 +915,10 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
             className="position-relative"
           >
             <div
-              className="position-absolute w-100 d-flex justify-content-end p-1"
+              className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                className="form-check p-2"
+                className="form-check mt-2 me-2"
               >
                 <input
                   checked={false}
@@ -1781,10 +1781,10 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
             className="position-relative"
           >
             <div
-              className="position-absolute w-100 d-flex justify-content-end p-1"
+              className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                className="form-check p-2"
+                className="form-check mt-2 me-2"
               >
                 <input
                   checked={false}
@@ -3132,10 +3132,10 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
   className="position-relative"
 >
   <div
-    className="position-absolute w-100 d-flex justify-content-end p-1"
+    className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
   >
     <div
-      className="form-check p-2"
+      className="form-check mt-2 me-2"
     >
       <input
         checked={false}
@@ -3523,10 +3523,10 @@ exports[`Storyshots Components/DiffView Default 1`] = `
   className="position-relative"
 >
   <div
-    className="position-absolute w-100 d-flex justify-content-end p-1"
+    className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
   >
     <div
-      className="form-check p-2"
+      className="form-check mt-2 me-2"
     >
       <input
         checked={false}
@@ -11623,10 +11623,10 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
           className="position-relative"
         >
           <div
-            className="position-absolute w-100 d-flex justify-content-end p-1"
+            className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check p-2"
+              className="form-check mt-2 me-2"
             >
               <input
                 checked={false}
@@ -13043,10 +13043,10 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
           className="position-relative"
         >
           <div
-            className="position-absolute w-100 d-flex justify-content-end p-1"
+            className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check p-2"
+              className="form-check mt-2 me-2"
             >
               <input
                 checked={false}
@@ -14461,10 +14461,10 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
           className="position-relative"
         >
           <div
-            className="position-absolute w-100 d-flex justify-content-end p-1"
+            className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check p-2"
+              className="form-check mt-2 me-2"
             >
               <input
                 checked={false}
@@ -15879,10 +15879,10 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
           className="position-relative"
         >
           <div
-            className="position-absolute w-100 d-flex justify-content-end p-1"
+            className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check p-2"
+              className="form-check mt-2 me-2"
             >
               <input
                 checked={false}
@@ -17297,10 +17297,10 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
           className="position-relative"
         >
           <div
-            className="position-absolute w-100 d-flex justify-content-end p-1"
+            className="position-absolute w-100 d-flex flex-row justify-content-end p-1"
           >
             <div
-              className="form-check p-2"
+              className="form-check mt-2 me-2"
             >
               <input
                 checked={false}

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -917,6 +917,24 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
             <div
               className="position-absolute w-100 d-flex justify-content-end p-1"
             >
+              <div
+                className="form-check p-2"
+              >
+                <input
+                  checked={false}
+                  className="form-check-input"
+                  id="flexCheckChecked-1"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <label
+                  className="form-check-label"
+                  htmlFor="flexCheckChecked-1"
+                >
+                  Viewed
+                </label>
+              </div>
               <button
                 className="btn borderless btn-outline-primary btn-outline-bg-primary"
                 onClick={[Function]}
@@ -1765,6 +1783,24 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
             <div
               className="position-absolute w-100 d-flex justify-content-end p-1"
             >
+              <div
+                className="form-check p-2"
+              >
+                <input
+                  checked={false}
+                  className="form-check-input"
+                  id="flexCheckChecked-1"
+                  onChange={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+                <label
+                  className="form-check-label"
+                  htmlFor="flexCheckChecked-1"
+                >
+                  Viewed
+                </label>
+              </div>
               <button
                 className="btn borderless btn-outline-primary btn-outline-bg-primary"
                 onClick={[Function]}
@@ -3098,6 +3134,24 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
   <div
     className="position-absolute w-100 d-flex justify-content-end p-1"
   >
+    <div
+      className="form-check p-2"
+    >
+      <input
+        checked={false}
+        className="form-check-input"
+        id="flexCheckChecked-1"
+        onChange={[Function]}
+        type="checkbox"
+        value=""
+      />
+      <label
+        className="form-check-label"
+        htmlFor="flexCheckChecked-1"
+      >
+        Viewed
+      </label>
+    </div>
     <button
       className="btn borderless btn-outline-primary btn-outline-bg-primary"
       onClick={[Function]}
@@ -3471,6 +3525,24 @@ exports[`Storyshots Components/DiffView Default 1`] = `
   <div
     className="position-absolute w-100 d-flex justify-content-end p-1"
   >
+    <div
+      className="form-check p-2"
+    >
+      <input
+        checked={false}
+        className="form-check-input"
+        id="flexCheckChecked-1"
+        onChange={[Function]}
+        type="checkbox"
+        value=""
+      />
+      <label
+        className="form-check-label"
+        htmlFor="flexCheckChecked-1"
+      >
+        Viewed
+      </label>
+    </div>
     <button
       className="btn borderless btn-outline-primary btn-outline-bg-primary"
       onClick={[Function]}
@@ -11553,6 +11625,24 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
           <div
             className="position-absolute w-100 d-flex justify-content-end p-1"
           >
+            <div
+              className="form-check p-2"
+            >
+              <input
+                checked={false}
+                className="form-check-input"
+                id="flexCheckChecked-1"
+                onChange={[Function]}
+                type="checkbox"
+                value=""
+              />
+              <label
+                className="form-check-label"
+                htmlFor="flexCheckChecked-1"
+              >
+                Viewed
+              </label>
+            </div>
             <button
               className="btn borderless btn-outline-primary btn-outline-bg-primary"
               onClick={[Function]}
@@ -12955,6 +13045,24 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
           <div
             className="position-absolute w-100 d-flex justify-content-end p-1"
           >
+            <div
+              className="form-check p-2"
+            >
+              <input
+                checked={false}
+                className="form-check-input"
+                id="flexCheckChecked-1"
+                onChange={[Function]}
+                type="checkbox"
+                value=""
+              />
+              <label
+                className="form-check-label"
+                htmlFor="flexCheckChecked-1"
+              >
+                Viewed
+              </label>
+            </div>
             <button
               className="btn borderless btn-outline-primary btn-outline-bg-primary"
               onClick={[Function]}
@@ -14355,6 +14463,24 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
           <div
             className="position-absolute w-100 d-flex justify-content-end p-1"
           >
+            <div
+              className="form-check p-2"
+            >
+              <input
+                checked={false}
+                className="form-check-input"
+                id="flexCheckChecked-1"
+                onChange={[Function]}
+                type="checkbox"
+                value=""
+              />
+              <label
+                className="form-check-label"
+                htmlFor="flexCheckChecked-1"
+              >
+                Viewed
+              </label>
+            </div>
             <button
               className="btn borderless btn-outline-primary btn-outline-bg-primary"
               onClick={[Function]}
@@ -15755,6 +15881,24 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
           <div
             className="position-absolute w-100 d-flex justify-content-end p-1"
           >
+            <div
+              className="form-check p-2"
+            >
+              <input
+                checked={false}
+                className="form-check-input"
+                id="flexCheckChecked-1"
+                onChange={[Function]}
+                type="checkbox"
+                value=""
+              />
+              <label
+                className="form-check-label"
+                htmlFor="flexCheckChecked-1"
+              >
+                Viewed
+              </label>
+            </div>
             <button
               className="btn borderless btn-outline-primary btn-outline-bg-primary"
               onClick={[Function]}
@@ -17155,6 +17299,24 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
           <div
             className="position-absolute w-100 d-flex justify-content-end p-1"
           >
+            <div
+              className="form-check p-2"
+            >
+              <input
+                checked={false}
+                className="form-check-input"
+                id="flexCheckChecked-1"
+                onChange={[Function]}
+                type="checkbox"
+                value=""
+              />
+              <label
+                className="form-check-label"
+                htmlFor="flexCheckChecked-1"
+              >
+                Viewed
+              </label>
+            </div>
             <button
               className="btn borderless btn-outline-primary btn-outline-bg-primary"
               onClick={[Function]}

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -923,14 +923,14 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                 <input
                   checked={false}
                   className="form-check-input"
-                  id="flexCheckChecked-1"
+                  id="checkBox-1-0"
                   onChange={[Function]}
                   type="checkbox"
                   value=""
                 />
                 <label
                   className="form-check-label"
-                  htmlFor="flexCheckChecked-1"
+                  htmlFor="checkBox-1-0"
                 >
                   Viewed
                 </label>
@@ -1789,14 +1789,14 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                 <input
                   checked={false}
                   className="form-check-input"
-                  id="flexCheckChecked-1"
+                  id="checkBox-1-0"
                   onChange={[Function]}
                   type="checkbox"
                   value=""
                 />
                 <label
                   className="form-check-label"
-                  htmlFor="flexCheckChecked-1"
+                  htmlFor="checkBox-1-0"
                 >
                   Viewed
                 </label>
@@ -3140,14 +3140,14 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
       <input
         checked={false}
         className="form-check-input"
-        id="flexCheckChecked-1"
+        id="checkBox-1-0"
         onChange={[Function]}
         type="checkbox"
         value=""
       />
       <label
         className="form-check-label"
-        htmlFor="flexCheckChecked-1"
+        htmlFor="checkBox-1-0"
       >
         Viewed
       </label>
@@ -3531,14 +3531,14 @@ exports[`Storyshots Components/DiffView Default 1`] = `
       <input
         checked={false}
         className="form-check-input"
-        id="flexCheckChecked-1"
+        id="checkBox-1-0"
         onChange={[Function]}
         type="checkbox"
         value=""
       />
       <label
         className="form-check-label"
-        htmlFor="flexCheckChecked-1"
+        htmlFor="checkBox-1-0"
       >
         Viewed
       </label>
@@ -11631,14 +11631,14 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
               <input
                 checked={false}
                 className="form-check-input"
-                id="flexCheckChecked-1"
+                id="checkBox-1-0"
                 onChange={[Function]}
                 type="checkbox"
                 value=""
               />
               <label
                 className="form-check-label"
-                htmlFor="flexCheckChecked-1"
+                htmlFor="checkBox-1-0"
               >
                 Viewed
               </label>
@@ -13051,14 +13051,14 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
               <input
                 checked={false}
                 className="form-check-input"
-                id="flexCheckChecked-1"
+                id="checkBox-1-0"
                 onChange={[Function]}
                 type="checkbox"
                 value=""
               />
               <label
                 className="form-check-label"
-                htmlFor="flexCheckChecked-1"
+                htmlFor="checkBox-1-0"
               >
                 Viewed
               </label>
@@ -14469,14 +14469,14 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
               <input
                 checked={false}
                 className="form-check-input"
-                id="flexCheckChecked-1"
+                id="checkBox-1-0"
                 onChange={[Function]}
                 type="checkbox"
                 value=""
               />
               <label
                 className="form-check-label"
-                htmlFor="flexCheckChecked-1"
+                htmlFor="checkBox-1-0"
               >
                 Viewed
               </label>
@@ -15887,14 +15887,14 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
               <input
                 checked={false}
                 className="form-check-input"
-                id="flexCheckChecked-1"
+                id="checkBox-1-0"
                 onChange={[Function]}
                 type="checkbox"
                 value=""
               />
               <label
                 className="form-check-label"
-                htmlFor="flexCheckChecked-1"
+                htmlFor="checkBox-1-0"
               >
                 Viewed
               </label>
@@ -17305,14 +17305,14 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
               <input
                 checked={false}
                 className="form-check-input"
-                id="flexCheckChecked-1"
+                id="checkBox-1-0"
                 onChange={[Function]}
                 type="checkbox"
                 value=""
               />
               <label
                 className="form-check-label"
-                htmlFor="flexCheckChecked-1"
+                htmlFor="checkBox-1-0"
               >
                 Viewed
               </label>

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -107,11 +107,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="progress-card__container card shadow-sm mt-3 bg-primary text-white px-3 px-xl-4 py-2 border-0"
           >
-            <h4
-              class="progress-card__title mt-4 text-center "
-            >
-              Join C0D3 now and start your software engineering journey!
-            </h4>
             <div
               class="mt-3"
             >
@@ -1286,11 +1281,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="progress-card__container card shadow-sm mt-3 bg-primary text-white px-3 px-xl-4 py-2 border-0"
           >
-            <h4
-              class="progress-card__title mt-4 text-center "
-            >
-              Join C0D3 now and start your software engineering journey!
-            </h4>
             <div
               class="mt-3"
             >

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -107,6 +107,11 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="progress-card__container card shadow-sm mt-3 bg-primary text-white px-3 px-xl-4 py-2 border-0"
           >
+            <h4
+              class="progress-card__title mt-4 text-center "
+            >
+              Join C0D3 now and start your software engineering journey!
+            </h4>
             <div
               class="mt-3"
             >
@@ -1281,6 +1286,11 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="progress-card__container card shadow-sm mt-3 bg-primary text-white px-3 px-xl-4 py-2 border-0"
           >
+            <h4
+              class="progress-card__title mt-4 text-center "
+            >
+              Join C0D3 now and start your software engineering journey!
+            </h4>
             <div
               class="mt-3"
             >

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -776,7 +776,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                       class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
                     >
                       <div
-                        class="form-check mt-2 me-2"
+                        class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
                       >
                         <input
                           class="form-check-input"
@@ -785,7 +785,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           value=""
                         />
                         <label
-                          class="form-check-label"
+                          class="form-check-label text-muted"
                           for="checkBox-108-0"
                         >
                           Viewed
@@ -2966,7 +2966,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                       class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
                     >
                       <div
-                        class="form-check mt-2 me-2"
+                        class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
                       >
                         <input
                           class="form-check-input"
@@ -2975,7 +2975,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                           value=""
                         />
                         <label
-                          class="form-check-label"
+                          class="form-check-label text-muted"
                           for="checkBox-108-1"
                         >
                           Viewed

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -775,6 +775,22 @@ exports[`Lesson Page Should render new submissions 1`] = `
                     <div
                       class="position-absolute w-100 d-flex justify-content-end p-1"
                     >
+                      <div
+                        class="form-check p-2"
+                      >
+                        <input
+                          class="form-check-input"
+                          id="flexCheckChecked-108"
+                          type="checkbox"
+                          value=""
+                        />
+                        <label
+                          class="form-check-label"
+                          for="flexCheckChecked-108"
+                        >
+                          Viewed
+                        </label>
+                      </div>
                       <button
                         class="btn borderless btn-outline-primary btn-outline-bg-primary"
                       >
@@ -2949,6 +2965,22 @@ exports[`Lesson Page Should render new submissions 1`] = `
                     <div
                       class="position-absolute w-100 d-flex justify-content-end p-1"
                     >
+                      <div
+                        class="form-check p-2"
+                      >
+                        <input
+                          class="form-check-input"
+                          id="flexCheckChecked-108"
+                          type="checkbox"
+                          value=""
+                        />
+                        <label
+                          class="form-check-label"
+                          for="flexCheckChecked-108"
+                        >
+                          Viewed
+                        </label>
+                      </div>
                       <button
                         class="btn borderless btn-outline-primary btn-outline-bg-primary"
                       >

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -773,10 +773,10 @@ exports[`Lesson Page Should render new submissions 1`] = `
                     class="position-relative"
                   >
                     <div
-                      class="position-absolute w-100 d-flex justify-content-end p-1"
+                      class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
                     >
                       <div
-                        class="form-check p-2"
+                        class="form-check mt-2 me-2"
                       >
                         <input
                           class="form-check-input"
@@ -2963,10 +2963,10 @@ exports[`Lesson Page Should render new submissions 1`] = `
                     class="position-relative"
                   >
                     <div
-                      class="position-absolute w-100 d-flex justify-content-end p-1"
+                      class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
                     >
                       <div
-                        class="form-check p-2"
+                        class="form-check mt-2 me-2"
                       >
                         <input
                           class="form-check-input"

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -780,13 +780,13 @@ exports[`Lesson Page Should render new submissions 1`] = `
                       >
                         <input
                           class="form-check-input"
-                          id="flexCheckChecked-108"
+                          id="checkBox-108-0"
                           type="checkbox"
                           value=""
                         />
                         <label
                           class="form-check-label"
-                          for="flexCheckChecked-108"
+                          for="checkBox-108-0"
                         >
                           Viewed
                         </label>
@@ -2970,13 +2970,13 @@ exports[`Lesson Page Should render new submissions 1`] = `
                       >
                         <input
                           class="form-check-input"
-                          id="flexCheckChecked-108"
+                          id="checkBox-108-1"
                           type="checkbox"
                           value=""
                         />
                         <label
                           class="form-check-label"
-                          for="flexCheckChecked-108"
+                          for="checkBox-108-1"
                         >
                           Viewed
                         </label>

--- a/components/DiffView.test.js
+++ b/components/DiffView.test.js
@@ -23,6 +23,19 @@ describe('DiffView component', () => {
     expect(container).toMatchSnapshot()
     expect(await screen.findByText('second line comment')).toBeVisible()
   })
+  test('Should render collapsed diff', async () => {
+    const { container } = render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <DiffView
+          submission={dummySumissions[0]}
+          generalStatus={SubmissionStatus.Open}
+        />
+      </MockedProvider>
+    )
+    userEvent.click(screen.getByText('Viewed'))
+    expect(container).toMatchSnapshot()
+    expect(screen.queryByText('4')).toBeNull()
+  })
   test('Should render diff with no comments', () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -40,7 +40,9 @@ const DiffView: React.FC<{
   type fileComments = Record<string, { lines: number[]; comments: Comment[] }>
   //every file gets unique index in format of submissionId:fileName
   const [commentsState, setCommentsState] = React.useState<fileComments>({})
-  const [isViewable, setIsViewable] = React.useState(false)
+  const [viewableStates, setViewableStates] = React.useState(
+    new Array(files.length).fill(false)
+  )
 
   useEffect(() => {
     const commentsMap =
@@ -98,16 +100,18 @@ const DiffView: React.FC<{
 
     return (
       <div className="position-relative">
-        <div className="position-absolute w-100 d-flex justify-content-end p-1">
-          <div className="form-check p-2">
+        <div className="position-absolute w-100 d-flex flex-row justify-content-end p-1">
+          <div className="form-check mt-2 me-2">
             <input
               className="form-check-input"
               type="checkbox"
               value=""
               id={`checkBox-${id}-${fileIdx}`}
-              checked={isViewable}
+              checked={viewableStates[fileIdx]}
               onChange={() => {
-                setIsViewable(!isViewable)
+                const newViewableStates = [...viewableStates]
+                newViewableStates[fileIdx] = !newViewableStates[fileIdx]
+                setViewableStates(newViewableStates)
               }}
             ></input>
             <label
@@ -122,7 +126,7 @@ const DiffView: React.FC<{
         <div className={scssStyles.diffView}>
           <ReactDiffViewer
             key={_.uniqueId()}
-            newValue={!isViewable ? newValue.join('\n') : ''}
+            newValue={!viewableStates[fileIdx] ? newValue.join('\n') : ''}
             renderContent={syntaxHighlight}
             splitView={false}
             leftTitle={`${newPath}`}

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -101,7 +101,9 @@ const DiffView: React.FC<{
     return (
       <div className="position-relative">
         <div className="position-absolute w-100 d-flex flex-row justify-content-end p-1">
-          <div className="form-check mt-2 me-2">
+          <div
+            className={`${scssStyles.checkBoxBorder} form-check pe-2 mt-2 me-2 border rounded`}
+          >
             <input
               className="form-check-input"
               type="checkbox"
@@ -115,7 +117,7 @@ const DiffView: React.FC<{
               }}
             ></input>
             <label
-              className="form-check-label"
+              className="form-check-label text-muted"
               htmlFor={`checkBox-${id}-${fileIdx}`}
             >
               Viewed

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -40,6 +40,7 @@ const DiffView: React.FC<{
   type fileComments = Record<string, { lines: number[]; comments: Comment[] }>
   //every file gets unique index in format of submissionId:fileName
   const [commentsState, setCommentsState] = React.useState<fileComments>({})
+  const [isViewable, setIsViewable] = React.useState(false)
 
   useEffect(() => {
     const commentsMap =
@@ -98,12 +99,27 @@ const DiffView: React.FC<{
     return (
       <div className="position-relative">
         <div className="position-absolute w-100 d-flex justify-content-end p-1">
+          <div className="form-check p-2">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              value=""
+              id="flexCheckChecked"
+              checked={isViewable}
+              onChange={() => {
+                setIsViewable(!isViewable)
+              }}
+            ></input>
+            <label className="form-check-label" htmlFor="flexCheckChecked">
+              Viewed
+            </label>
+          </div>
           <CopyButton value={newValue.join('\n')} />
         </div>
         <div className={scssStyles.diffView}>
           <ReactDiffViewer
             key={_.uniqueId()}
-            newValue={newValue.join('\n')}
+            newValue={!isViewable ? newValue.join('\n') : ''}
             renderContent={syntaxHighlight}
             splitView={false}
             leftTitle={`${newPath}`}

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -60,7 +60,7 @@ const DiffView: React.FC<{
     //rerunning useEffect on id rerenders submission when student clicks on another challenge
   }, [id, comments])
 
-  const renderFile = ({ hunks, newPath }: File) => {
+  const renderFile = ({ hunks, newPath }: File, fileIdx: number) => {
     const newValue: string[] = []
     if (!hunks.length || !newPath) return
     let extension = newPath.split('.').pop()!
@@ -104,7 +104,7 @@ const DiffView: React.FC<{
               className="form-check-input"
               type="checkbox"
               value=""
-              id={`flexCheckChecked-${id}`}
+              id={`checkBox-${id}-${fileIdx}`}
               checked={isViewable}
               onChange={() => {
                 setIsViewable(!isViewable)
@@ -112,7 +112,7 @@ const DiffView: React.FC<{
             ></input>
             <label
               className="form-check-label"
-              htmlFor={`flexCheckChecked-${id}`}
+              htmlFor={`checkBox-${id}-${fileIdx}`}
             >
               Viewed
             </label>

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -104,13 +104,16 @@ const DiffView: React.FC<{
               className="form-check-input"
               type="checkbox"
               value=""
-              id="flexCheckChecked"
+              id={`flexCheckChecked-${id}`}
               checked={isViewable}
               onChange={() => {
                 setIsViewable(!isViewable)
               }}
             ></input>
-            <label className="form-check-label" htmlFor="flexCheckChecked">
+            <label
+              className="form-check-label"
+              htmlFor={`flexCheckChecked-${id}`}
+            >
               Viewed
             </label>
           </div>

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -183,13 +183,13 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                 >
                   <input
                     class="form-check-input"
-                    id="flexCheckChecked-3502"
+                    id="checkBox-3502-0"
                     type="checkbox"
                     value=""
                   />
                   <label
                     class="form-check-label"
-                    for="flexCheckChecked-3502"
+                    for="checkBox-3502-0"
                   >
                     Viewed
                   </label>

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -176,10 +176,10 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
               class="position-relative"
             >
               <div
-                class="position-absolute w-100 d-flex justify-content-end p-1"
+                class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
               >
                 <div
-                  class="form-check p-2"
+                  class="form-check mt-2 me-2"
                 >
                   <input
                     class="form-check-input"

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -178,6 +178,22 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
               <div
                 class="position-absolute w-100 d-flex justify-content-end p-1"
               >
+                <div
+                  class="form-check p-2"
+                >
+                  <input
+                    class="form-check-input"
+                    id="flexCheckChecked-3502"
+                    type="checkbox"
+                    value=""
+                  />
+                  <label
+                    class="form-check-label"
+                    for="flexCheckChecked-3502"
+                  >
+                    Viewed
+                  </label>
+                </div>
                 <button
                   class="btn borderless btn-outline-primary btn-outline-bg-primary"
                 >

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -179,7 +179,7 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                 class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
               >
                 <div
-                  class="form-check mt-2 me-2"
+                  class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
                 >
                   <input
                     class="form-check-input"
@@ -188,7 +188,7 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                     value=""
                   />
                   <label
-                    class="form-check-label"
+                    class="form-check-label text-muted"
                     for="checkBox-3502-0"
                   >
                     Viewed

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -9,7 +9,7 @@ exports[`DiffView component Should add comment box 1`] = `
       class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
     >
       <div
-        class="form-check mt-2 me-2"
+        class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
       >
         <input
           class="form-check-input"
@@ -18,7 +18,7 @@ exports[`DiffView component Should add comment box 1`] = `
           value=""
         />
         <label
-          class="form-check-label"
+          class="form-check-label text-muted"
           for="checkBox-104-0"
         >
           Viewed
@@ -662,7 +662,7 @@ exports[`DiffView component Should render collapsed diff 1`] = `
       class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
     >
       <div
-        class="form-check mt-2 me-2"
+        class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
       >
         <input
           class="form-check-input"
@@ -671,7 +671,7 @@ exports[`DiffView component Should render collapsed diff 1`] = `
           value=""
         />
         <label
-          class="form-check-label"
+          class="form-check-label text-muted"
           for="checkBox-104-0"
         >
           Viewed
@@ -736,7 +736,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
       class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
     >
       <div
-        class="form-check mt-2 me-2"
+        class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
       >
         <input
           class="form-check-input"
@@ -745,7 +745,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
           value=""
         />
         <label
-          class="form-check-label"
+          class="form-check-label text-muted"
           for="checkBox-108-0"
         >
           Viewed
@@ -2926,7 +2926,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
       class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
     >
       <div
-        class="form-check mt-2 me-2"
+        class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
       >
         <input
           class="form-check-input"
@@ -2935,7 +2935,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
           value=""
         />
         <label
-          class="form-check-label"
+          class="form-check-label text-muted"
           for="checkBox-108-1"
         >
           Viewed

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -6,10 +6,10 @@ exports[`DiffView component Should add comment box 1`] = `
     class="position-relative"
   >
     <div
-      class="position-absolute w-100 d-flex justify-content-end p-1"
+      class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
     >
       <div
-        class="form-check p-2"
+        class="form-check mt-2 me-2"
       >
         <input
           class="form-check-input"
@@ -659,10 +659,10 @@ exports[`DiffView component Should render collapsed diff 1`] = `
     class="position-relative"
   >
     <div
-      class="position-absolute w-100 d-flex justify-content-end p-1"
+      class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
     >
       <div
-        class="form-check p-2"
+        class="form-check mt-2 me-2"
       >
         <input
           class="form-check-input"
@@ -733,10 +733,10 @@ exports[`DiffView component Should render diff with comments 1`] = `
     class="position-relative"
   >
     <div
-      class="position-absolute w-100 d-flex justify-content-end p-1"
+      class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
     >
       <div
-        class="form-check p-2"
+        class="form-check mt-2 me-2"
       >
         <input
           class="form-check-input"
@@ -2923,10 +2923,10 @@ exports[`DiffView component Should render diff with comments 1`] = `
     class="position-relative"
   >
     <div
-      class="position-absolute w-100 d-flex justify-content-end p-1"
+      class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
     >
       <div
-        class="form-check p-2"
+        class="form-check mt-2 me-2"
       >
         <input
           class="form-check-input"

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -8,6 +8,22 @@ exports[`DiffView component Should add comment box 1`] = `
     <div
       class="position-absolute w-100 d-flex justify-content-end p-1"
     >
+      <div
+        class="form-check p-2"
+      >
+        <input
+          class="form-check-input"
+          id="flexCheckChecked-104"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="form-check-label"
+          for="flexCheckChecked-104"
+        >
+          Viewed
+        </label>
+      </div>
       <button
         class="btn borderless btn-outline-primary btn-outline-bg-primary"
       >
@@ -637,6 +653,80 @@ exports[`DiffView component Should add comment box 1`] = `
 </div>
 `;
 
+exports[`DiffView component Should render collapsed diff 1`] = `
+<div>
+  <div
+    class="position-relative"
+  >
+    <div
+      class="position-absolute w-100 d-flex justify-content-end p-1"
+    >
+      <div
+        class="form-check p-2"
+      >
+        <input
+          class="form-check-input"
+          id="flexCheckChecked-104"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="form-check-label"
+          for="flexCheckChecked-104"
+        >
+          Viewed
+        </label>
+      </div>
+      <button
+        class="btn borderless btn-outline-primary btn-outline-bg-primary"
+      >
+        <svg
+          aria-hidden="true"
+          class="octicon octicon-copy"
+          fill="currentColor"
+          height="16"
+          role="img"
+          style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"
+            fill-rule="evenodd"
+          />
+          <path
+            d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="diffView"
+    >
+      <table
+        class="css-b02w0u-diff-container"
+      >
+        <tbody>
+          <tr>
+            <td
+              class="css-1rwygp7-title-block"
+              colspan="4"
+            >
+              <pre
+                class="css-pa3tg-content-text"
+              >
+                js0/1.js
+              </pre>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DiffView component Should render diff with comments 1`] = `
 <div>
   <div
@@ -645,6 +735,22 @@ exports[`DiffView component Should render diff with comments 1`] = `
     <div
       class="position-absolute w-100 d-flex justify-content-end p-1"
     >
+      <div
+        class="form-check p-2"
+      >
+        <input
+          class="form-check-input"
+          id="flexCheckChecked-108"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="form-check-label"
+          for="flexCheckChecked-108"
+        >
+          Viewed
+        </label>
+      </div>
       <button
         class="btn borderless btn-outline-primary btn-outline-bg-primary"
       >
@@ -2819,6 +2925,22 @@ exports[`DiffView component Should render diff with comments 1`] = `
     <div
       class="position-absolute w-100 d-flex justify-content-end p-1"
     >
+      <div
+        class="form-check p-2"
+      >
+        <input
+          class="form-check-input"
+          id="flexCheckChecked-108"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="form-check-label"
+          for="flexCheckChecked-108"
+        >
+          Viewed
+        </label>
+      </div>
       <button
         class="btn borderless btn-outline-primary btn-outline-bg-primary"
       >

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -13,13 +13,13 @@ exports[`DiffView component Should add comment box 1`] = `
       >
         <input
           class="form-check-input"
-          id="flexCheckChecked-104"
+          id="checkBox-104-0"
           type="checkbox"
           value=""
         />
         <label
           class="form-check-label"
-          for="flexCheckChecked-104"
+          for="checkBox-104-0"
         >
           Viewed
         </label>
@@ -666,13 +666,13 @@ exports[`DiffView component Should render collapsed diff 1`] = `
       >
         <input
           class="form-check-input"
-          id="flexCheckChecked-104"
+          id="checkBox-104-0"
           type="checkbox"
           value=""
         />
         <label
           class="form-check-label"
-          for="flexCheckChecked-104"
+          for="checkBox-104-0"
         >
           Viewed
         </label>
@@ -740,13 +740,13 @@ exports[`DiffView component Should render diff with comments 1`] = `
       >
         <input
           class="form-check-input"
-          id="flexCheckChecked-108"
+          id="checkBox-108-0"
           type="checkbox"
           value=""
         />
         <label
           class="form-check-label"
-          for="flexCheckChecked-108"
+          for="checkBox-108-0"
         >
           Viewed
         </label>
@@ -2930,13 +2930,13 @@ exports[`DiffView component Should render diff with comments 1`] = `
       >
         <input
           class="form-check-input"
-          id="flexCheckChecked-108"
+          id="checkBox-108-1"
           type="checkbox"
           value=""
         />
         <label
           class="form-check-label"
-          for="flexCheckChecked-108"
+          for="checkBox-108-1"
         >
           Viewed
         </label>

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -96,6 +96,22 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
             <div
               class="position-absolute w-100 d-flex justify-content-end p-1"
             >
+              <div
+                class="form-check p-2"
+              >
+                <input
+                  class="form-check-input"
+                  id="flexCheckChecked-104"
+                  type="checkbox"
+                  value=""
+                />
+                <label
+                  class="form-check-label"
+                  for="flexCheckChecked-104"
+                >
+                  Viewed
+                </label>
+              </div>
               <button
                 class="btn borderless btn-outline-primary btn-outline-bg-primary"
               >
@@ -933,6 +949,22 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
             <div
               class="position-absolute w-100 d-flex justify-content-end p-1"
             >
+              <div
+                class="form-check p-2"
+              >
+                <input
+                  class="form-check-input"
+                  id="flexCheckChecked-104"
+                  type="checkbox"
+                  value=""
+                />
+                <label
+                  class="form-check-label"
+                  for="flexCheckChecked-104"
+                >
+                  Viewed
+                </label>
+              </div>
               <button
                 class="btn borderless btn-outline-primary btn-outline-bg-primary"
               >
@@ -1719,6 +1751,22 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
             <div
               class="position-absolute w-100 d-flex justify-content-end p-1"
             >
+              <div
+                class="form-check p-2"
+              >
+                <input
+                  class="form-check-input"
+                  id="flexCheckChecked-104"
+                  type="checkbox"
+                  value=""
+                />
+                <label
+                  class="form-check-label"
+                  for="flexCheckChecked-104"
+                >
+                  Viewed
+                </label>
+              </div>
               <button
                 class="btn borderless btn-outline-primary btn-outline-bg-primary"
               >
@@ -2505,6 +2553,22 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
             <div
               class="position-absolute w-100 d-flex justify-content-end p-1"
             >
+              <div
+                class="form-check p-2"
+              >
+                <input
+                  class="form-check-input"
+                  id="flexCheckChecked-104"
+                  type="checkbox"
+                  value=""
+                />
+                <label
+                  class="form-check-label"
+                  for="flexCheckChecked-104"
+                >
+                  Viewed
+                </label>
+              </div>
               <button
                 class="btn borderless btn-outline-primary btn-outline-bg-primary"
               >
@@ -4092,6 +4156,22 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
             <div
               class="position-absolute w-100 d-flex justify-content-end p-1"
             >
+              <div
+                class="form-check p-2"
+              >
+                <input
+                  class="form-check-input"
+                  id="flexCheckChecked-104"
+                  type="checkbox"
+                  value=""
+                />
+                <label
+                  class="form-check-label"
+                  for="flexCheckChecked-104"
+                >
+                  Viewed
+                </label>
+              </div>
               <button
                 class="btn borderless btn-outline-primary btn-outline-bg-primary"
               >
@@ -6054,6 +6134,22 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
             <div
               class="position-absolute w-100 d-flex justify-content-end p-1"
             >
+              <div
+                class="form-check p-2"
+              >
+                <input
+                  class="form-check-input"
+                  id="flexCheckChecked-104"
+                  type="checkbox"
+                  value=""
+                />
+                <label
+                  class="form-check-label"
+                  for="flexCheckChecked-104"
+                >
+                  Viewed
+                </label>
+              </div>
               <button
                 class="btn borderless btn-outline-primary btn-outline-bg-primary"
               >

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -94,10 +94,10 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
             class="position-relative"
           >
             <div
-              class="position-absolute w-100 d-flex justify-content-end p-1"
+              class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check p-2"
+                class="form-check mt-2 me-2"
               >
                 <input
                   class="form-check-input"
@@ -947,10 +947,10 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
             class="position-relative"
           >
             <div
-              class="position-absolute w-100 d-flex justify-content-end p-1"
+              class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check p-2"
+                class="form-check mt-2 me-2"
               >
                 <input
                   class="form-check-input"
@@ -1749,10 +1749,10 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
             class="position-relative"
           >
             <div
-              class="position-absolute w-100 d-flex justify-content-end p-1"
+              class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check p-2"
+                class="form-check mt-2 me-2"
               >
                 <input
                   class="form-check-input"
@@ -2551,10 +2551,10 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
             class="position-relative"
           >
             <div
-              class="position-absolute w-100 d-flex justify-content-end p-1"
+              class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check p-2"
+                class="form-check mt-2 me-2"
               >
                 <input
                   class="form-check-input"
@@ -4154,10 +4154,10 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
             class="position-relative"
           >
             <div
-              class="position-absolute w-100 d-flex justify-content-end p-1"
+              class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check p-2"
+                class="form-check mt-2 me-2"
               >
                 <input
                   class="form-check-input"
@@ -6132,10 +6132,10 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
             class="position-relative"
           >
             <div
-              class="position-absolute w-100 d-flex justify-content-end p-1"
+              class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check p-2"
+                class="form-check mt-2 me-2"
               >
                 <input
                   class="form-check-input"

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -101,13 +101,13 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
               >
                 <input
                   class="form-check-input"
-                  id="flexCheckChecked-104"
+                  id="checkBox-104-0"
                   type="checkbox"
                   value=""
                 />
                 <label
                   class="form-check-label"
-                  for="flexCheckChecked-104"
+                  for="checkBox-104-0"
                 >
                   Viewed
                 </label>
@@ -954,13 +954,13 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
               >
                 <input
                   class="form-check-input"
-                  id="flexCheckChecked-104"
+                  id="checkBox-104-0"
                   type="checkbox"
                   value=""
                 />
                 <label
                   class="form-check-label"
-                  for="flexCheckChecked-104"
+                  for="checkBox-104-0"
                 >
                   Viewed
                 </label>
@@ -1756,13 +1756,13 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
               >
                 <input
                   class="form-check-input"
-                  id="flexCheckChecked-104"
+                  id="checkBox-104-0"
                   type="checkbox"
                   value=""
                 />
                 <label
                   class="form-check-label"
-                  for="flexCheckChecked-104"
+                  for="checkBox-104-0"
                 >
                   Viewed
                 </label>
@@ -2558,13 +2558,13 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
               >
                 <input
                   class="form-check-input"
-                  id="flexCheckChecked-104"
+                  id="checkBox-104-0"
                   type="checkbox"
                   value=""
                 />
                 <label
                   class="form-check-label"
-                  for="flexCheckChecked-104"
+                  for="checkBox-104-0"
                 >
                   Viewed
                 </label>
@@ -4161,13 +4161,13 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
               >
                 <input
                   class="form-check-input"
-                  id="flexCheckChecked-104"
+                  id="checkBox-104-0"
                   type="checkbox"
                   value=""
                 />
                 <label
                   class="form-check-label"
-                  for="flexCheckChecked-104"
+                  for="checkBox-104-0"
                 >
                   Viewed
                 </label>
@@ -6139,13 +6139,13 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
               >
                 <input
                   class="form-check-input"
-                  id="flexCheckChecked-104"
+                  id="checkBox-104-0"
                   type="checkbox"
                   value=""
                 />
                 <label
                   class="form-check-label"
-                  for="flexCheckChecked-104"
+                  for="checkBox-104-0"
                 >
                   Viewed
                 </label>

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -97,7 +97,7 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
               class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check mt-2 me-2"
+                class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
               >
                 <input
                   class="form-check-input"
@@ -106,7 +106,7 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                   value=""
                 />
                 <label
-                  class="form-check-label"
+                  class="form-check-label text-muted"
                   for="checkBox-104-0"
                 >
                   Viewed
@@ -950,7 +950,7 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
               class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check mt-2 me-2"
+                class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
               >
                 <input
                   class="form-check-input"
@@ -959,7 +959,7 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                   value=""
                 />
                 <label
-                  class="form-check-label"
+                  class="form-check-label text-muted"
                   for="checkBox-104-0"
                 >
                   Viewed
@@ -1752,7 +1752,7 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
               class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check mt-2 me-2"
+                class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
               >
                 <input
                   class="form-check-input"
@@ -1761,7 +1761,7 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                   value=""
                 />
                 <label
-                  class="form-check-label"
+                  class="form-check-label text-muted"
                   for="checkBox-104-0"
                 >
                   Viewed
@@ -2554,7 +2554,7 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
               class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check mt-2 me-2"
+                class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
               >
                 <input
                   class="form-check-input"
@@ -2563,7 +2563,7 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                   value=""
                 />
                 <label
-                  class="form-check-label"
+                  class="form-check-label text-muted"
                   for="checkBox-104-0"
                 >
                   Viewed
@@ -4157,7 +4157,7 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
               class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check mt-2 me-2"
+                class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
               >
                 <input
                   class="form-check-input"
@@ -4166,7 +4166,7 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                   value=""
                 />
                 <label
-                  class="form-check-label"
+                  class="form-check-label text-muted"
                   for="checkBox-104-0"
                 >
                   Viewed
@@ -6135,7 +6135,7 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
               class="position-absolute w-100 d-flex flex-row justify-content-end p-1"
             >
               <div
-                class="form-check mt-2 me-2"
+                class="checkBoxBorder form-check pe-2 mt-2 me-2 border rounded"
               >
                 <input
                   class="form-check-input"
@@ -6144,7 +6144,7 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                   value=""
                 />
                 <label
-                  class="form-check-label"
+                  class="form-check-label text-muted"
                   for="checkBox-104-0"
                 >
                   Viewed

--- a/scss/diffView.module.scss
+++ b/scss/diffView.module.scss
@@ -2,3 +2,7 @@
 .diffView tr:first-child {
   display: grid;
 }
+
+.checkBoxBorder {
+  padding-left: 2em;
+}


### PR DESCRIPTION
**Closes #1420**

I used the checkbox element from bootstrap used [here](https://getbootstrap.com/docs/5.0/forms/checks-radios/#checks)
Added a state (viewableStates) that keeps track when a diff is viewed or not for each file in a submission and renders accordingly. Below are the differences in collapsed and not collapsed states.

**IsViewable is true**
![image](https://user-images.githubusercontent.com/23374591/155800909-35771390-7beb-47d8-bdc5-1b5778e48d5a.png)

**IsViewable is false**
![image](https://user-images.githubusercontent.com/23374591/155800995-8758261a-a11c-4d8f-9e39-7b2a0043183e.png)

If you guys have any styling suggestions to make it look better, let me know!

