### PR TITLE
fix: ProfileSubmission badge styles not applied

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -10348,7 +10348,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span
@@ -10429,7 +10429,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span
@@ -10516,7 +10516,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span
@@ -10600,7 +10600,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span
@@ -10681,7 +10681,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span
@@ -10753,7 +10753,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span
@@ -10840,7 +10840,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span
@@ -10915,7 +10915,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span
@@ -10999,7 +10999,7 @@ exports[`Storyshots Components/ProfileSubmissions Profile Submissions Card 1`] =
           className="lesson_image_container"
         >
           <p
-            className="lesson_image_star_badge badge badge-pill badge-primary"
+            className="lesson_image_star_badge badge badge-pill bg-primary"
           >
             2
             <span

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -3905,7 +3905,7 @@ exports[`user profile test Should render profile 1`] = `
                   class="lesson_image_container"
                 >
                   <p
-                    class="lesson_image_star_badge badge badge-pill badge-primary"
+                    class="lesson_image_star_badge badge badge-pill bg-primary"
                   >
                     1
                     <span
@@ -3986,7 +3986,7 @@ exports[`user profile test Should render profile 1`] = `
                   class="lesson_image_container"
                 >
                   <p
-                    class="lesson_image_star_badge badge badge-pill badge-primary"
+                    class="lesson_image_star_badge badge badge-pill bg-primary"
                   >
                     1
                     <span
@@ -4073,7 +4073,7 @@ exports[`user profile test Should render profile 1`] = `
                   class="lesson_image_container"
                 >
                   <p
-                    class="lesson_image_star_badge badge badge-pill badge-primary"
+                    class="lesson_image_star_badge badge badge-pill bg-primary"
                   >
                     1
                     <span
@@ -4968,7 +4968,7 @@ exports[`user profile test should render discord avatar and username if user con
                   class="lesson_image_container"
                 >
                   <p
-                    class="lesson_image_star_badge badge badge-pill badge-primary"
+                    class="lesson_image_star_badge badge badge-pill bg-primary"
                   >
                     1
                     <span
@@ -5049,7 +5049,7 @@ exports[`user profile test should render discord avatar and username if user con
                   class="lesson_image_container"
                 >
                   <p
-                    class="lesson_image_star_badge badge badge-pill badge-primary"
+                    class="lesson_image_star_badge badge badge-pill bg-primary"
                   >
                     1
                     <span
@@ -5136,7 +5136,7 @@ exports[`user profile test should render discord avatar and username if user con
                   class="lesson_image_container"
                 >
                   <p
-                    class="lesson_image_star_badge badge badge-pill badge-primary"
+                    class="lesson_image_star_badge badge badge-pill bg-primary"
                   >
                     1
                     <span

--- a/components/ProfileSubmissions.tsx
+++ b/components/ProfileSubmissions.tsx
@@ -61,7 +61,7 @@ const ProfileSubmissions: React.FC<LessonChallengeProps> = ({ lessons }) => {
     if (lesson.starsReceived && lesson.starsReceived.length) {
       starBadge = (
         <p
-          className={`${styles['lesson_image_star_badge']} badge badge-pill badge-primary`}
+          className={`${styles['lesson_image_star_badge']} badge badge-pill bg-primary`}
         >
           {lesson.starsReceived && lesson.starsReceived.length}
           <span className="ms-1">


### PR DESCRIPTION
Closes #1529 

This PR change `badge-primary` to `bg-primary` to apply the background primary color.

*why: related to bootstrap [v5](https://getbootstrap.com/docs/5.0/migration/) changes*

Before:

![image](https://user-images.githubusercontent.com/35906419/156572638-8b111532-11e9-436a-8996-dbe1dddcae16.png)


After:

![image](https://user-images.githubusercontent.com/35906419/156572757-c5c66549-9344-4be1-8786-316418c1f675.png)
