### PR TITLE
Mitigate the issue of creating a submission based on the cliToken ID

### DIFF
--- a/@types/user.d.ts
+++ b/@types/user.d.ts
@@ -6,3 +6,8 @@ export type UserInfo = {
   discordUsername: string
   discordAvatarUrl: string
 }
+
+export type CliToken = {
+  id: number
+  cliToken: string
+}

--- a/helpers/controllers/submissionController.test.js
+++ b/helpers/controllers/submissionController.test.js
@@ -83,14 +83,7 @@ describe('Submissions Mutations', () => {
 
     test('should set id to the decoded clientToken id when req.user is undefined', async () => {
       await createSubmission(null, args, { ...ctx, req: { user: null } })
-      expect(prismaMock.submission.findFirst).toBeCalledWith({
-        where: {
-          challengeId: args.challengeId,
-          lessonId: args.lessonId,
-          user: { id: 1210 },
-          status: SubmissionStatus.Open
-        }
-      })
+      expect(prismaMock.user.findFirst).toBeCalled()
     })
 
     test('should send message to Sentry if req.user does not exist and cliToken does', async () => {

--- a/helpers/controllers/submissionController.test.js
+++ b/helpers/controllers/submissionController.test.js
@@ -78,6 +78,18 @@ describe('Submissions Mutations', () => {
         'Invalid args'
       )
     })
+
+    test('should set id to the decoded clientToken id when req.user is undefined', async () => {
+      await createSubmission(null, args, { ...ctx, req: { user: null } })
+      expect(prismaMock.submission.findFirst).toBeCalledWith({
+        where: {
+          challengeId: args.challengeId,
+          lessonId: args.lessonId,
+          user: { id: 1210 },
+          status: SubmissionStatus.Open
+        }
+      })
+    })
   })
 
   describe('acceptSubmission', () => {

--- a/helpers/controllers/submissionController.test.js
+++ b/helpers/controllers/submissionController.test.js
@@ -43,6 +43,7 @@ describe('Submissions Mutations', () => {
       diff: 'fakeDiff',
       lessonId: 1
     }
+    const ctx = { req: { user: { id: 2 } } }
 
     beforeEach(() => {
       prismaMock.submission.create.mockResolvedValue({
@@ -53,7 +54,7 @@ describe('Submissions Mutations', () => {
     })
 
     test('should save and return submission', async () => {
-      await expect(createSubmission(null, args)).resolves.toEqual({
+      await expect(createSubmission(null, args, ctx)).resolves.toEqual({
         id: 1,
         diff: 'fakeDiff',
         lesson: {
@@ -68,12 +69,12 @@ describe('Submissions Mutations', () => {
 
     test('should overwrite previous submission status if it exists', async () => {
       prismaMock.submission.findFirst.mockResolvedValue({ id: 1 })
-      await createSubmission(null, args)
+      await createSubmission(null, args, ctx)
       expect(prismaMock.submission.update).toBeCalled()
     })
 
     test('should throw error Invalid args', () => {
-      return expect(createSubmission(null, null)).rejects.toThrow(
+      return expect(createSubmission(null, null, ctx)).rejects.toThrow(
         'Invalid args'
       )
     })

--- a/helpers/controllers/submissionController.ts
+++ b/helpers/controllers/submissionController.ts
@@ -12,6 +12,7 @@ import prisma from '../../prisma'
 import { hasPassedLesson } from '../hasPassedLesson'
 import { updateSubmission } from '../updateSubmission'
 import { sendSubmissionNotification, IdType } from '../discordBot'
+import { decode } from '../encoding'
 
 export const createSubmission = async (
   _parent: void,
@@ -19,10 +20,12 @@ export const createSubmission = async (
   ctx: Context
 ): Promise<CreateSubmissionMutation['createSubmission']> => {
   const { req } = ctx
-  const { id } = req.user!
 
   if (!args) throw new Error('Invalid args')
-  const { challengeId, diff, lessonId } = args
+  const { challengeId, cliToken, diff, lessonId } = args
+
+  const id = !req.user || !req.user.id ? decode(cliToken).id : req.user.id
+
   const previousSubmission = await prisma.submission.findFirst({
     where: {
       challengeId,

--- a/helpers/controllers/submissionController.ts
+++ b/helpers/controllers/submissionController.ts
@@ -26,10 +26,10 @@ export const createSubmission = async (
   if (!args) throw new Error('Invalid args')
   const { challengeId, cliToken, diff, lessonId } = args
 
-  const decodedCliToken: CliToken = cliToken && decode(cliToken)
-  let id = !req.user ? decodedCliToken.id : req.user.id
+  let id = req.user!?.id
 
-  if (!req.user && cliToken) {
+  if (!id && cliToken) {
+    const decodedCliToken: CliToken = cliToken && decode(cliToken)
     const user = await prisma.user.findFirst({
       where: { cliToken: decodedCliToken.cliToken }
     })

--- a/helpers/controllers/submissionController.ts
+++ b/helpers/controllers/submissionController.ts
@@ -27,12 +27,14 @@ export const createSubmission = async (
   const { challengeId, cliToken, diff, lessonId } = args
 
   const decodedCliToken: CliToken = cliToken && decode(cliToken)
-  const id = !req.user || !req.user.id ? decodedCliToken.id : req.user.id
+  let id = !req.user ? decodedCliToken.id : req.user.id
 
   if (!req.user && cliToken) {
     const user = await prisma.user.findFirst({
       where: { cliToken: decodedCliToken.cliToken }
     })
+
+    id = user!?.id
 
     Sentry.captureException({
       message: `${user?.id}/${user?.username} is using the wrong CLI version. Must be 2.2.5`

--- a/helpers/controllers/submissionController.ts
+++ b/helpers/controllers/submissionController.ts
@@ -9,18 +9,20 @@ import {
   SubmissionStatus
 } from '../../graphql'
 import prisma from '../../prisma'
-import { decode } from '../encoding'
 import { hasPassedLesson } from '../hasPassedLesson'
 import { updateSubmission } from '../updateSubmission'
 import { sendSubmissionNotification, IdType } from '../discordBot'
 
 export const createSubmission = async (
   _parent: void,
-  args: MutationCreateSubmissionArgs
+  args: MutationCreateSubmissionArgs,
+  ctx: Context
 ): Promise<CreateSubmissionMutation['createSubmission']> => {
+  const { req } = ctx
+  const { id } = req.user!
+
   if (!args) throw new Error('Invalid args')
-  const { challengeId, cliToken, diff, lessonId } = args
-  const { id } = decode(cliToken)
+  const { challengeId, diff, lessonId } = args
   const previousSubmission = await prisma.submission.findFirst({
     where: {
       challengeId,

--- a/helpers/middleware/user.test.js
+++ b/helpers/middleware/user.test.js
@@ -12,7 +12,7 @@ const mockUserInfo = {
   password: '$2b$10$W9KwQ6Sbi0RJjD2GZYX9BugAtgSm/W999gNW1f/XiRcI6NiC9pTdK',
   email: 'superduperkamehameha@gmail.com',
   isAdmin: false,
-  cliToken: 'KfizzIlWp111fizzDbuzzr'
+  cliToken: 'W29iamVjdCBPYmplY3Rd'
 }
 
 const res = {}
@@ -26,15 +26,39 @@ const next = () => {}
 describe('User Middleware', () => {
   beforeEach(() => {
     prismaMock.user.findUnique.mockResolvedValue(mockUserInfo)
+    prismaMock.user.findFirst.mockResolvedValue(mockUserInfo)
   })
   test('Should return null when userId property of req.session is not there', async () => {
-    const req = { session: '' }
+    const req = {
+      session: '',
+      headers: {
+        authorization: null
+      }
+    }
     await userMiddleware(req, res, next)
     expect(req.user).toBeNull
   })
 
   test('Should return correct info from database if session.userId exists', async () => {
-    const req = { session: { userId: 'noob' } }
+    const req = {
+      session: {
+        userId: 'noob'
+      },
+      headers: {
+        authorization: null
+      }
+    }
+    await userMiddleware(req, res, next)
+    expect(req.user).toEqual(mockUserInfo)
+  })
+  test('Should return correct info from database if authorization header exists', async () => {
+    const req = {
+      session: { userId: 'noob' },
+      headers: {
+        authorization:
+          'Bearer eyJpZCI6MSwiY2xpVG9rZW4iOiJXMjlpYW1WamRDQlBZbXBsWTNSZCJ9'
+      }
+    }
     await userMiddleware(req, res, next)
     expect(req.user).toEqual(mockUserInfo)
   })

--- a/helpers/middleware/user.ts
+++ b/helpers/middleware/user.ts
@@ -1,13 +1,29 @@
 import { LoggedRequest } from '../../@types/helpers'
 import { NextApiResponse } from 'next'
 import prisma from '../../prisma'
+import { decode } from '../encoding'
+import { CliToken } from '../../@types/user'
 
-export default async (
+const userMiddleware = async (
   req: LoggedRequest,
   _: NextApiResponse,
   next: () => void
 ) => {
   req.user = null
+
+  const auth = req.headers.authorization
+  const cliToken = auth && auth.split(' ')[1]
+  if (cliToken) {
+    const decodedCliToken: CliToken = decode(cliToken)
+
+    const user = await prisma.user.findFirst({
+      where: { cliToken: decodedCliToken.cliToken }
+    })
+
+    req.user = user
+    return next()
+  }
+
   const { session } = req
   if (session?.userId) {
     const { userId: id } = session
@@ -16,3 +32,5 @@ export default async (
   }
   next()
 }
+
+export default userMiddleware


### PR DESCRIPTION
Closes #1551 

This PR will:
- Populate the user object based on the cliToken if it's available
- Retrieve the user ID from the req.user object rather than the `cliToken` but keep the `cliToken` to keep it compatible with users who have older CLI versions.
- Send an event to Sentry with the user's username and ID when `cliToken` exists and `req.user` doesn't