### PR TITLE
fixes modulecrud to include lessons and authors

### DIFF
--- a/graphql/resolvers/moduleCrud.ts
+++ b/graphql/resolvers/moduleCrud.ts
@@ -24,7 +24,11 @@ export const addModule = async (
   const authorId = req.user?.id
   if (!authorId) throw new Error('No User')
   return prisma.module.create({
-    data: { authorId, content, lessonId, name }
+    data: { authorId, content, lessonId, name },
+    include: {
+      author: true,
+      lesson: true
+    }
   })
 }
 
@@ -38,5 +42,11 @@ export const deleteModule = async (
   const authorId = req.user?.id
   if (!authorId) throw new Error('No User')
   const { id } = arg
-  return prisma.module.delete({ where: { id } })
+  return prisma.module.delete({
+    where: { id },
+    include: {
+      author: true,
+      lesson: true
+    }
+  })
 }


### PR DESCRIPTION
This Pr fixes and issue I found with add and deleting modules. 
They both return a lesson, but they do not include the foreign key constraints for the user and lessons table. This results in an error where null is returned for non nullable fields. 

The solution to this is the include the tables when adding or deleting. 
