### PR TITLE
Improve DiffViewer styles

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -11585,10 +11585,10 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
       className="rounded-lg position-relative pt-5"
     >
       <div
-        className="descAccordion accordion"
+        className="card__descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordionItem accordion-item"
+          className="bg-white mb-2 false accordion__item accordion-item"
         >
           <h2
             className="accordion-header"
@@ -13005,10 +13005,10 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
       className="rounded-lg position-relative pt-5"
     >
       <div
-        className="descAccordion accordion"
+        className="card__descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordionItem accordion-item"
+          className="bg-white mb-2 false accordion__item accordion-item"
         >
           <h2
             className="accordion-header"
@@ -14423,10 +14423,10 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
       className="rounded-lg position-relative pt-5"
     >
       <div
-        className="descAccordion accordion"
+        className="card__descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordionItem accordion-item"
+          className="bg-white mb-2 false accordion__item accordion-item"
         >
           <h2
             className="accordion-header"
@@ -15841,10 +15841,10 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
       className="rounded-lg position-relative pt-5"
     >
       <div
-        className="descAccordion accordion"
+        className="card__descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordionItem accordion-item"
+          className="bg-white mb-2 false accordion__item accordion-item"
         >
           <h2
             className="accordion-header"
@@ -17259,10 +17259,10 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
       className="rounded-lg position-relative pt-5"
     >
       <div
-        className="descAccordion accordion"
+        className="card__descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordionItem accordion-item"
+          className="bg-white mb-2 false accordion__item accordion-item"
         >
           <h2
             className="accordion-header"

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -972,12 +972,12 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
               className="diffView"
             >
               <table
-                className="css-b02w0u-diff-container"
+                className="css-1p5fn6o-diff-container"
               >
                 <tbody>
                   <tr>
                     <td
-                      className="css-1rwygp7-title-block"
+                      className="css-1gyvngn-title-block"
                       colSpan={4}
                     >
                       <pre
@@ -995,7 +995,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1003,7 +1003,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         1
                       </pre>
@@ -1039,7 +1039,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1047,7 +1047,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         2
                       </pre>
@@ -1083,7 +1083,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1091,7 +1091,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         3
                       </pre>
@@ -1127,7 +1127,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1135,7 +1135,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         4
                       </pre>
@@ -1171,7 +1171,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1179,7 +1179,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         5
                       </pre>
@@ -1215,7 +1215,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1223,7 +1223,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         6
                       </pre>
@@ -1259,7 +1259,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1267,7 +1267,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         7
                       </pre>
@@ -1838,12 +1838,12 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
               className="diffView"
             >
               <table
-                className="css-b02w0u-diff-container"
+                className="css-1p5fn6o-diff-container"
               >
                 <tbody>
                   <tr>
                     <td
-                      className="css-1rwygp7-title-block"
+                      className="css-1gyvngn-title-block"
                       colSpan={4}
                     >
                       <pre
@@ -1861,7 +1861,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1869,7 +1869,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         1
                       </pre>
@@ -1905,7 +1905,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1913,7 +1913,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         2
                       </pre>
@@ -1949,7 +1949,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -1957,7 +1957,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         3
                       </pre>
@@ -1993,7 +1993,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -2001,7 +2001,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         4
                       </pre>
@@ -2037,7 +2037,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -2045,7 +2045,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         5
                       </pre>
@@ -2081,7 +2081,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -2089,7 +2089,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         6
                       </pre>
@@ -2125,7 +2125,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={null}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       />
                     </td>
                     <td
@@ -2133,7 +2133,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                       onClick={[Function]}
                     >
                       <pre
-                        className="css-14p8zw1-line-number"
+                        className="css-iepx6s-line-number"
                       >
                         7
                       </pre>
@@ -3189,12 +3189,12 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
     className="diffView"
   >
     <table
-      className="css-b02w0u-diff-container"
+      className="css-1p5fn6o-diff-container"
     >
       <tbody>
         <tr>
           <td
-            className="css-1rwygp7-title-block"
+            className="css-1gyvngn-title-block"
             colSpan={4}
           >
             <pre
@@ -3212,7 +3212,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3220,7 +3220,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               1
             </pre>
@@ -3256,7 +3256,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3264,7 +3264,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               2
             </pre>
@@ -3300,7 +3300,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3308,7 +3308,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               3
             </pre>
@@ -3344,7 +3344,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3352,7 +3352,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               4
             </pre>
@@ -3388,7 +3388,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3396,7 +3396,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               5
             </pre>
@@ -3432,7 +3432,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3440,7 +3440,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               6
             </pre>
@@ -3476,7 +3476,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3484,7 +3484,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               7
             </pre>
@@ -3580,12 +3580,12 @@ exports[`Storyshots Components/DiffView Default 1`] = `
     className="diffView"
   >
     <table
-      className="css-b02w0u-diff-container"
+      className="css-1p5fn6o-diff-container"
     >
       <tbody>
         <tr>
           <td
-            className="css-1rwygp7-title-block"
+            className="css-1gyvngn-title-block"
             colSpan={4}
           >
             <pre
@@ -3603,7 +3603,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3611,7 +3611,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               1
             </pre>
@@ -3647,7 +3647,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3655,7 +3655,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               2
             </pre>
@@ -3691,7 +3691,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3699,7 +3699,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               3
             </pre>
@@ -3735,7 +3735,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3743,7 +3743,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               4
             </pre>
@@ -3779,7 +3779,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3787,7 +3787,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               5
             </pre>
@@ -3823,7 +3823,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3831,7 +3831,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               6
             </pre>
@@ -3867,7 +3867,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={null}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             />
           </td>
           <td
@@ -3875,7 +3875,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
             onClick={[Function]}
           >
             <pre
-              className="css-14p8zw1-line-number"
+              className="css-iepx6s-line-number"
             >
               7
             </pre>
@@ -11588,7 +11588,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
         className="descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordion-item"
+          className="bg-white mb-2 false accordionItem accordion-item"
         >
           <h2
             className="accordion-header"
@@ -11680,12 +11680,12 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
             className="diffView"
           >
             <table
-              className="css-b02w0u-diff-container"
+              className="css-1p5fn6o-diff-container"
             >
               <tbody>
                 <tr>
                   <td
-                    className="css-1rwygp7-title-block"
+                    className="css-1gyvngn-title-block"
                     colSpan={4}
                   >
                     <pre
@@ -11703,7 +11703,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -11711,7 +11711,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       1
                     </pre>
@@ -11747,7 +11747,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -11755,7 +11755,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       2
                     </pre>
@@ -11791,7 +11791,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -11799,7 +11799,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       3
                     </pre>
@@ -11835,7 +11835,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -11843,7 +11843,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       4
                     </pre>
@@ -11879,7 +11879,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -11887,7 +11887,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       5
                     </pre>
@@ -11923,7 +11923,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -11931,7 +11931,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       6
                     </pre>
@@ -11967,7 +11967,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -11975,7 +11975,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       7
                     </pre>
@@ -12011,7 +12011,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12019,7 +12019,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       8
                     </pre>
@@ -12055,7 +12055,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12063,7 +12063,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       9
                     </pre>
@@ -12099,7 +12099,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12107,7 +12107,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       10
                     </pre>
@@ -12143,7 +12143,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12151,7 +12151,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       11
                     </pre>
@@ -12187,7 +12187,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12195,7 +12195,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       12
                     </pre>
@@ -12231,7 +12231,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12239,7 +12239,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       13
                     </pre>
@@ -12275,7 +12275,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12283,7 +12283,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       14
                     </pre>
@@ -12319,7 +12319,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12327,7 +12327,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       15
                     </pre>
@@ -12363,7 +12363,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12371,7 +12371,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       16
                     </pre>
@@ -12407,7 +12407,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12415,7 +12415,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       17
                     </pre>
@@ -12451,7 +12451,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12459,7 +12459,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       18
                     </pre>
@@ -12495,7 +12495,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -12503,7 +12503,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       19
                     </pre>
@@ -13008,7 +13008,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
         className="descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordion-item"
+          className="bg-white mb-2 false accordionItem accordion-item"
         >
           <h2
             className="accordion-header"
@@ -13100,12 +13100,12 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
             className="diffView"
           >
             <table
-              className="css-b02w0u-diff-container"
+              className="css-1p5fn6o-diff-container"
             >
               <tbody>
                 <tr>
                   <td
-                    className="css-1rwygp7-title-block"
+                    className="css-1gyvngn-title-block"
                     colSpan={4}
                   >
                     <pre
@@ -13123,7 +13123,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13131,7 +13131,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       1
                     </pre>
@@ -13167,7 +13167,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13175,7 +13175,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       2
                     </pre>
@@ -13211,7 +13211,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13219,7 +13219,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       3
                     </pre>
@@ -13255,7 +13255,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13263,7 +13263,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       4
                     </pre>
@@ -13299,7 +13299,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13307,7 +13307,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       5
                     </pre>
@@ -13343,7 +13343,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13351,7 +13351,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       6
                     </pre>
@@ -13387,7 +13387,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13395,7 +13395,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       7
                     </pre>
@@ -13431,7 +13431,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13439,7 +13439,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       8
                     </pre>
@@ -13475,7 +13475,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13483,7 +13483,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       9
                     </pre>
@@ -13519,7 +13519,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13527,7 +13527,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       10
                     </pre>
@@ -13563,7 +13563,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13571,7 +13571,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       11
                     </pre>
@@ -13607,7 +13607,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13615,7 +13615,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       12
                     </pre>
@@ -13651,7 +13651,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13659,7 +13659,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       13
                     </pre>
@@ -13695,7 +13695,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13703,7 +13703,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       14
                     </pre>
@@ -13739,7 +13739,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13747,7 +13747,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       15
                     </pre>
@@ -13783,7 +13783,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13791,7 +13791,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       16
                     </pre>
@@ -13827,7 +13827,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13835,7 +13835,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       17
                     </pre>
@@ -13871,7 +13871,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13879,7 +13879,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       18
                     </pre>
@@ -13915,7 +13915,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -13923,7 +13923,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       19
                     </pre>
@@ -14426,7 +14426,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
         className="descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordion-item"
+          className="bg-white mb-2 false accordionItem accordion-item"
         >
           <h2
             className="accordion-header"
@@ -14518,12 +14518,12 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
             className="diffView"
           >
             <table
-              className="css-b02w0u-diff-container"
+              className="css-1p5fn6o-diff-container"
             >
               <tbody>
                 <tr>
                   <td
-                    className="css-1rwygp7-title-block"
+                    className="css-1gyvngn-title-block"
                     colSpan={4}
                   >
                     <pre
@@ -14541,7 +14541,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14549,7 +14549,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       1
                     </pre>
@@ -14585,7 +14585,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14593,7 +14593,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       2
                     </pre>
@@ -14629,7 +14629,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14637,7 +14637,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       3
                     </pre>
@@ -14673,7 +14673,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14681,7 +14681,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       4
                     </pre>
@@ -14717,7 +14717,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14725,7 +14725,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       5
                     </pre>
@@ -14761,7 +14761,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14769,7 +14769,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       6
                     </pre>
@@ -14805,7 +14805,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14813,7 +14813,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       7
                     </pre>
@@ -14849,7 +14849,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14857,7 +14857,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       8
                     </pre>
@@ -14893,7 +14893,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14901,7 +14901,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       9
                     </pre>
@@ -14937,7 +14937,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14945,7 +14945,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       10
                     </pre>
@@ -14981,7 +14981,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -14989,7 +14989,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       11
                     </pre>
@@ -15025,7 +15025,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15033,7 +15033,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       12
                     </pre>
@@ -15069,7 +15069,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15077,7 +15077,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       13
                     </pre>
@@ -15113,7 +15113,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15121,7 +15121,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       14
                     </pre>
@@ -15157,7 +15157,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15165,7 +15165,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       15
                     </pre>
@@ -15201,7 +15201,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15209,7 +15209,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       16
                     </pre>
@@ -15245,7 +15245,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15253,7 +15253,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       17
                     </pre>
@@ -15289,7 +15289,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15297,7 +15297,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       18
                     </pre>
@@ -15333,7 +15333,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15341,7 +15341,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       19
                     </pre>
@@ -15844,7 +15844,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
         className="descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordion-item"
+          className="bg-white mb-2 false accordionItem accordion-item"
         >
           <h2
             className="accordion-header"
@@ -15936,12 +15936,12 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
             className="diffView"
           >
             <table
-              className="css-b02w0u-diff-container"
+              className="css-1p5fn6o-diff-container"
             >
               <tbody>
                 <tr>
                   <td
-                    className="css-1rwygp7-title-block"
+                    className="css-1gyvngn-title-block"
                     colSpan={4}
                   >
                     <pre
@@ -15959,7 +15959,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -15967,7 +15967,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       1
                     </pre>
@@ -16003,7 +16003,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16011,7 +16011,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       2
                     </pre>
@@ -16047,7 +16047,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16055,7 +16055,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       3
                     </pre>
@@ -16091,7 +16091,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16099,7 +16099,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       4
                     </pre>
@@ -16135,7 +16135,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16143,7 +16143,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       5
                     </pre>
@@ -16179,7 +16179,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16187,7 +16187,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       6
                     </pre>
@@ -16223,7 +16223,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16231,7 +16231,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       7
                     </pre>
@@ -16267,7 +16267,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16275,7 +16275,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       8
                     </pre>
@@ -16311,7 +16311,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16319,7 +16319,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       9
                     </pre>
@@ -16355,7 +16355,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16363,7 +16363,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       10
                     </pre>
@@ -16399,7 +16399,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16407,7 +16407,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       11
                     </pre>
@@ -16443,7 +16443,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16451,7 +16451,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       12
                     </pre>
@@ -16487,7 +16487,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16495,7 +16495,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       13
                     </pre>
@@ -16531,7 +16531,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16539,7 +16539,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       14
                     </pre>
@@ -16575,7 +16575,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16583,7 +16583,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       15
                     </pre>
@@ -16619,7 +16619,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16627,7 +16627,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       16
                     </pre>
@@ -16663,7 +16663,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16671,7 +16671,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       17
                     </pre>
@@ -16707,7 +16707,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16715,7 +16715,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       18
                     </pre>
@@ -16751,7 +16751,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -16759,7 +16759,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       19
                     </pre>
@@ -17262,7 +17262,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
         className="descAccordion accordion"
       >
         <div
-          className="bg-white mb-2 false accordion-item"
+          className="bg-white mb-2 false accordionItem accordion-item"
         >
           <h2
             className="accordion-header"
@@ -17354,12 +17354,12 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
             className="diffView"
           >
             <table
-              className="css-b02w0u-diff-container"
+              className="css-1p5fn6o-diff-container"
             >
               <tbody>
                 <tr>
                   <td
-                    className="css-1rwygp7-title-block"
+                    className="css-1gyvngn-title-block"
                     colSpan={4}
                   >
                     <pre
@@ -17377,7 +17377,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17385,7 +17385,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       1
                     </pre>
@@ -17421,7 +17421,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17429,7 +17429,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       2
                     </pre>
@@ -17465,7 +17465,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17473,7 +17473,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       3
                     </pre>
@@ -17509,7 +17509,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17517,7 +17517,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       4
                     </pre>
@@ -17553,7 +17553,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17561,7 +17561,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       5
                     </pre>
@@ -17597,7 +17597,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17605,7 +17605,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       6
                     </pre>
@@ -17641,7 +17641,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17649,7 +17649,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       7
                     </pre>
@@ -17685,7 +17685,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17693,7 +17693,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       8
                     </pre>
@@ -17729,7 +17729,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17737,7 +17737,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       9
                     </pre>
@@ -17773,7 +17773,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17781,7 +17781,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       10
                     </pre>
@@ -17817,7 +17817,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17825,7 +17825,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       11
                     </pre>
@@ -17861,7 +17861,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17869,7 +17869,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       12
                     </pre>
@@ -17905,7 +17905,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17913,7 +17913,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       13
                     </pre>
@@ -17949,7 +17949,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -17957,7 +17957,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       14
                     </pre>
@@ -17993,7 +17993,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -18001,7 +18001,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       15
                     </pre>
@@ -18037,7 +18037,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -18045,7 +18045,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       16
                     </pre>
@@ -18081,7 +18081,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -18089,7 +18089,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       17
                     </pre>
@@ -18125,7 +18125,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -18133,7 +18133,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       18
                     </pre>
@@ -18169,7 +18169,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={null}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     />
                   </td>
                   <td
@@ -18177,7 +18177,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                     onClick={[Function]}
                   >
                     <pre
-                      className="css-14p8zw1-line-number"
+                      className="css-iepx6s-line-number"
                     >
                       19
                     </pre>

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -740,7 +740,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                   class="descAccordion accordion"
                 >
                   <div
-                    class="bg-white mb-2 false accordion-item"
+                    class="bg-white mb-2 false accordionItem accordion-item"
                   >
                     <h2
                       class="accordion-header"
@@ -819,12 +819,12 @@ exports[`Lesson Page Should render new submissions 1`] = `
                       class="diffView"
                     >
                       <table
-                        class="css-b02w0u-diff-container"
+                        class="css-1p5fn6o-diff-container"
                       >
                         <tbody>
                           <tr>
                             <td
-                              class="css-1rwygp7-title-block"
+                              class="css-1gyvngn-title-block"
                               colspan="4"
                             >
                               <pre
@@ -841,14 +841,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 1
                               </pre>
@@ -883,14 +883,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 2
                               </pre>
@@ -931,14 +931,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 3
                               </pre>
@@ -1015,14 +1015,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 4
                               </pre>
@@ -1051,14 +1051,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 5
                               </pre>
@@ -1122,14 +1122,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 6
                               </pre>
@@ -1169,14 +1169,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 7
                               </pre>
@@ -1205,14 +1205,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 8
                               </pre>
@@ -1279,14 +1279,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 9
                               </pre>
@@ -1315,14 +1315,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 10
                               </pre>
@@ -1389,14 +1389,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 11
                               </pre>
@@ -1425,14 +1425,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 12
                               </pre>
@@ -1482,14 +1482,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 13
                               </pre>
@@ -1562,14 +1562,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 14
                               </pre>
@@ -1631,14 +1631,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 15
                               </pre>
@@ -1679,14 +1679,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 16
                               </pre>
@@ -1759,14 +1759,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 17
                               </pre>
@@ -1857,14 +1857,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 18
                               </pre>
@@ -1965,14 +1965,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 19
                               </pre>
@@ -2034,14 +2034,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 20
                               </pre>
@@ -2087,14 +2087,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 21
                               </pre>
@@ -2140,14 +2140,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 22
                               </pre>
@@ -2176,14 +2176,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 23
                               </pre>
@@ -2235,14 +2235,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 24
                               </pre>
@@ -2315,14 +2315,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 25
                               </pre>
@@ -2407,14 +2407,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 26
                               </pre>
@@ -2548,14 +2548,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 27
                               </pre>
@@ -2621,14 +2621,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 28
                               </pre>
@@ -2669,14 +2669,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 29
                               </pre>
@@ -2749,14 +2749,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 30
                               </pre>
@@ -2856,14 +2856,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 31
                               </pre>
@@ -2909,14 +2909,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 32
                               </pre>
@@ -3009,12 +3009,12 @@ exports[`Lesson Page Should render new submissions 1`] = `
                       class="diffView"
                     >
                       <table
-                        class="css-b02w0u-diff-container"
+                        class="css-1p5fn6o-diff-container"
                       >
                         <tbody>
                           <tr>
                             <td
-                              class="css-1rwygp7-title-block"
+                              class="css-1gyvngn-title-block"
                               colspan="4"
                             >
                               <pre
@@ -3031,14 +3031,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 1
                               </pre>
@@ -3113,14 +3113,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 2
                               </pre>
@@ -3492,14 +3492,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 3
                               </pre>
@@ -3569,14 +3569,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 4
                               </pre>
@@ -3634,14 +3634,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 5
                               </pre>
@@ -3718,14 +3718,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 6
                               </pre>
@@ -3821,14 +3821,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 7
                               </pre>
@@ -3881,14 +3881,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 8
                               </pre>
@@ -3930,14 +3930,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 9
                               </pre>
@@ -3979,14 +3979,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 10
                               </pre>
@@ -4085,14 +4085,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 11
                               </pre>
@@ -4192,14 +4192,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 12
                               </pre>
@@ -4255,14 +4255,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 13
                               </pre>
@@ -4298,14 +4298,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 14
                               </pre>
@@ -4382,14 +4382,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 15
                               </pre>
@@ -4450,14 +4450,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 16
                               </pre>
@@ -4493,14 +4493,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 17
                               </pre>
@@ -4565,14 +4565,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 18
                               </pre>
@@ -4649,14 +4649,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 19
                               </pre>
@@ -4741,14 +4741,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 20
                               </pre>
@@ -4801,14 +4801,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 21
                               </pre>
@@ -4844,14 +4844,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 22
                               </pre>
@@ -4947,14 +4947,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 23
                               </pre>
@@ -5039,14 +5039,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 24
                               </pre>
@@ -5099,14 +5099,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 25
                               </pre>
@@ -5160,14 +5160,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 26
                               </pre>
@@ -5203,14 +5203,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 27
                               </pre>
@@ -5246,14 +5246,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 28
                               </pre>
@@ -5289,14 +5289,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 29
                               </pre>
@@ -5338,14 +5338,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 30
                               </pre>
@@ -5386,14 +5386,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 31
                               </pre>
@@ -5451,14 +5451,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 32
                               </pre>
@@ -5593,14 +5593,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 33
                               </pre>
@@ -5757,14 +5757,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 34
                               </pre>
@@ -5867,14 +5867,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 35
                               </pre>
@@ -5914,14 +5914,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 36
                               </pre>
@@ -5950,14 +5950,14 @@ exports[`Lesson Page Should render new submissions 1`] = `
                               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               />
                             </td>
                             <td
                               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                             >
                               <pre
-                                class="css-14p8zw1-line-number"
+                                class="css-iepx6s-line-number"
                               >
                                 37
                               </pre>

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -737,10 +737,10 @@ exports[`Lesson Page Should render new submissions 1`] = `
                 class="rounded-lg position-relative pt-5"
               >
                 <div
-                  class="descAccordion accordion"
+                  class="card__descAccordion accordion"
                 >
                   <div
-                    class="bg-white mb-2 false accordionItem accordion-item"
+                    class="bg-white mb-2 false accordion__item accordion-item"
                   >
                     <h2
                       class="accordion-header"

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -13,7 +13,7 @@ const prismLanguages = ['js', 'javascript', 'html', 'css', 'json', 'jsx']
 const styles: ReactDiffViewerStylesOverride = {
   lineNumber: {
     fontWeight: 'bold',
-    color: '#364d3b'
+    color: '#525252'
   },
   gutter: {
     background: '#cdffd8',
@@ -26,7 +26,15 @@ const styles: ReactDiffViewerStylesOverride = {
   },
   diffContainer: {
     display: 'block',
-    overflowX: 'auto'
+    overflowX: 'auto',
+    marginBottom: '14px',
+    borderBottomLeftRadius: '8px',
+    borderBottomRightRadius: '8px'
+  },
+  titleBlock: {
+    borderTopLeftRadius: '8px',
+    borderTopRightRadius: '8px',
+    border: '1px solid #eee'
   }
 }
 
@@ -132,7 +140,17 @@ const DiffView: React.FC<{
             renderContent={syntaxHighlight}
             splitView={false}
             leftTitle={`${newPath}`}
-            styles={styles}
+            styles={
+              viewableStates[fileIdx]
+                ? {
+                    ...styles,
+                    titleBlock: {
+                      border: '1px solid #eee',
+                      borderRadius: '8px'
+                    }
+                  }
+                : styles
+            }
             onLineNumberClick={(n: string) => {
               if (generalStatus !== SubmissionStatus.Open) return
               //number is a string in format of L-10, R-4 and etc (left-right split views)

--- a/components/ReviewCard.test.js
+++ b/components/ReviewCard.test.js
@@ -434,7 +434,7 @@ describe('ReviewCard Component', () => {
     const accordionHeader = getByText('Challenge Description')
     fireEvent.click(accordionHeader)
 
-    const accordionItem = container.querySelector('.accordionItem')
+    const accordionItem = container.querySelector('.accordion__item')
 
     expect(accordionItem).toBeVisible()
   })

--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -250,12 +250,12 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({ submissionData }) => {
           </div>
           <div className="card-body">
             <div className="rounded-lg position-relative pt-5">
-              <Accordion className={styles['descAccordion']}>
+              <Accordion className={styles.descAccordion}>
                 <Accordion.Item
                   eventKey="0"
                   className={`bg-white mb-2 ${
-                    showAccordion && styles['accordionItem']
-                  }`}
+                    showAccordion && styles.accordionItemShow
+                  } ${styles.accordionItem}`}
                 >
                   <Accordion.Header
                     onClick={() => setShowAccordion(prev => !prev)}

--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -250,12 +250,12 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({ submissionData }) => {
           </div>
           <div className="card-body">
             <div className="rounded-lg position-relative pt-5">
-              <Accordion className={styles.descAccordion}>
+              <Accordion className={styles['card__descAccordion']}>
                 <Accordion.Item
                   eventKey="0"
                   className={`bg-white mb-2 ${
-                    showAccordion && styles.accordionItemShow
-                  } ${styles.accordionItem}`}
+                    showAccordion && styles['accordion__accordionItem--show']
+                  } ${styles['accordion__item']}`}
                 >
                   <Accordion.Header
                     onClick={() => setShowAccordion(prev => !prev)}

--- a/components/ReviewCard.tsx
+++ b/components/ReviewCard.tsx
@@ -250,12 +250,12 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({ submissionData }) => {
           </div>
           <div className="card-body">
             <div className="rounded-lg position-relative pt-5">
-              <Accordion className={styles['card__descAccordion']}>
+              <Accordion className={styles.card__descAccordion}>
                 <Accordion.Item
                   eventKey="0"
                   className={`bg-white mb-2 ${
                     showAccordion && styles['accordion__accordionItem--show']
-                  } ${styles['accordion__item']}`}
+                  } ${styles.accordion__item}`}
                 >
                   <Accordion.Header
                     onClick={() => setShowAccordion(prev => !prev)}

--- a/components/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/__snapshots__/ChallengeMaterial.test.js.snap
@@ -222,12 +222,12 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                 class="diffView"
               >
                 <table
-                  class="css-b02w0u-diff-container"
+                  class="css-1p5fn6o-diff-container"
                 >
                   <tbody>
                     <tr>
                       <td
-                        class="css-1rwygp7-title-block"
+                        class="css-1gyvngn-title-block"
                         colspan="4"
                       >
                         <pre
@@ -244,14 +244,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                         class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         />
                       </td>
                       <td
                         class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         >
                           1
                         </pre>
@@ -292,14 +292,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                         class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         />
                       </td>
                       <td
                         class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         >
                           2
                         </pre>
@@ -328,14 +328,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                         class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         />
                       </td>
                       <td
                         class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         >
                           3
                         </pre>
@@ -422,14 +422,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                         class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         />
                       </td>
                       <td
                         class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         >
                           4
                         </pre>
@@ -483,14 +483,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                         class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         />
                       </td>
                       <td
                         class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         >
                           5
                         </pre>
@@ -530,14 +530,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                         class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         />
                       </td>
                       <td
                         class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         >
                           6
                         </pre>
@@ -566,14 +566,14 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                         class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         />
                       </td>
                       <td
                         class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                       >
                         <pre
-                          class="css-14p8zw1-line-number"
+                          class="css-iepx6s-line-number"
                         >
                           7
                         </pre>

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -52,12 +52,12 @@ exports[`DiffView component Should add comment box 1`] = `
       class="diffView"
     >
       <table
-        class="css-b02w0u-diff-container"
+        class="css-1p5fn6o-diff-container"
       >
         <tbody>
           <tr>
             <td
-              class="css-1rwygp7-title-block"
+              class="css-1gyvngn-title-block"
               colspan="4"
             >
               <pre
@@ -74,14 +74,14 @@ exports[`DiffView component Should add comment box 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 1
               </pre>
@@ -129,14 +129,14 @@ exports[`DiffView component Should add comment box 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 2
               </pre>
@@ -177,14 +177,14 @@ exports[`DiffView component Should add comment box 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 3
               </pre>
@@ -213,14 +213,14 @@ exports[`DiffView component Should add comment box 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 4
               </pre>
@@ -524,14 +524,14 @@ exports[`DiffView component Should add comment box 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 5
               </pre>
@@ -560,14 +560,14 @@ exports[`DiffView component Should add comment box 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 6
               </pre>
@@ -615,14 +615,14 @@ exports[`DiffView component Should add comment box 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 7
               </pre>
@@ -705,12 +705,12 @@ exports[`DiffView component Should render collapsed diff 1`] = `
       class="diffView"
     >
       <table
-        class="css-b02w0u-diff-container"
+        class="css-1p5fn6o-diff-container"
       >
         <tbody>
           <tr>
             <td
-              class="css-1rwygp7-title-block"
+              class="css-dfkv5k-title-block"
               colspan="4"
             >
               <pre
@@ -779,12 +779,12 @@ exports[`DiffView component Should render diff with comments 1`] = `
       class="diffView"
     >
       <table
-        class="css-b02w0u-diff-container"
+        class="css-1p5fn6o-diff-container"
       >
         <tbody>
           <tr>
             <td
-              class="css-1rwygp7-title-block"
+              class="css-1gyvngn-title-block"
               colspan="4"
             >
               <pre
@@ -801,14 +801,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 1
               </pre>
@@ -843,14 +843,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 2
               </pre>
@@ -891,14 +891,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 3
               </pre>
@@ -975,14 +975,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 4
               </pre>
@@ -1011,14 +1011,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 5
               </pre>
@@ -1082,14 +1082,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 6
               </pre>
@@ -1129,14 +1129,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 7
               </pre>
@@ -1165,14 +1165,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 8
               </pre>
@@ -1239,14 +1239,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 9
               </pre>
@@ -1275,14 +1275,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 10
               </pre>
@@ -1349,14 +1349,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 11
               </pre>
@@ -1385,14 +1385,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 12
               </pre>
@@ -1442,14 +1442,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 13
               </pre>
@@ -1522,14 +1522,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 14
               </pre>
@@ -1591,14 +1591,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 15
               </pre>
@@ -1639,14 +1639,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 16
               </pre>
@@ -1719,14 +1719,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 17
               </pre>
@@ -1817,14 +1817,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 18
               </pre>
@@ -1925,14 +1925,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 19
               </pre>
@@ -1994,14 +1994,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 20
               </pre>
@@ -2047,14 +2047,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 21
               </pre>
@@ -2100,14 +2100,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 22
               </pre>
@@ -2136,14 +2136,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 23
               </pre>
@@ -2195,14 +2195,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 24
               </pre>
@@ -2275,14 +2275,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 25
               </pre>
@@ -2367,14 +2367,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 26
               </pre>
@@ -2508,14 +2508,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 27
               </pre>
@@ -2581,14 +2581,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 28
               </pre>
@@ -2629,14 +2629,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 29
               </pre>
@@ -2709,14 +2709,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 30
               </pre>
@@ -2816,14 +2816,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 31
               </pre>
@@ -2869,14 +2869,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 32
               </pre>
@@ -2969,12 +2969,12 @@ exports[`DiffView component Should render diff with comments 1`] = `
       class="diffView"
     >
       <table
-        class="css-b02w0u-diff-container"
+        class="css-1p5fn6o-diff-container"
       >
         <tbody>
           <tr>
             <td
-              class="css-1rwygp7-title-block"
+              class="css-1gyvngn-title-block"
               colspan="4"
             >
               <pre
@@ -2991,14 +2991,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 1
               </pre>
@@ -3352,14 +3352,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 2
               </pre>
@@ -3674,14 +3674,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 3
               </pre>
@@ -3751,14 +3751,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 4
               </pre>
@@ -3816,14 +3816,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 5
               </pre>
@@ -3900,14 +3900,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 6
               </pre>
@@ -4003,14 +4003,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 7
               </pre>
@@ -4063,14 +4063,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 8
               </pre>
@@ -4112,14 +4112,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 9
               </pre>
@@ -4161,14 +4161,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 10
               </pre>
@@ -4267,14 +4267,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 11
               </pre>
@@ -4374,14 +4374,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 12
               </pre>
@@ -4437,14 +4437,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 13
               </pre>
@@ -4480,14 +4480,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 14
               </pre>
@@ -4564,14 +4564,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 15
               </pre>
@@ -4632,14 +4632,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 16
               </pre>
@@ -4675,14 +4675,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 17
               </pre>
@@ -4747,14 +4747,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 18
               </pre>
@@ -4831,14 +4831,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 19
               </pre>
@@ -4923,14 +4923,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 20
               </pre>
@@ -4983,14 +4983,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 21
               </pre>
@@ -5026,14 +5026,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 22
               </pre>
@@ -5129,14 +5129,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 23
               </pre>
@@ -5221,14 +5221,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 24
               </pre>
@@ -5281,14 +5281,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 25
               </pre>
@@ -5342,14 +5342,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 26
               </pre>
@@ -5385,14 +5385,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 27
               </pre>
@@ -5428,14 +5428,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 28
               </pre>
@@ -5471,14 +5471,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 29
               </pre>
@@ -5520,14 +5520,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 30
               </pre>
@@ -5568,14 +5568,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 31
               </pre>
@@ -5633,14 +5633,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 32
               </pre>
@@ -5775,14 +5775,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 33
               </pre>
@@ -5939,14 +5939,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 34
               </pre>
@@ -6049,14 +6049,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 35
               </pre>
@@ -6096,14 +6096,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 36
               </pre>
@@ -6132,14 +6132,14 @@ exports[`DiffView component Should render diff with comments 1`] = `
               class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               />
             </td>
             <td
               class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
             >
               <pre
-                class="css-14p8zw1-line-number"
+                class="css-iepx6s-line-number"
               >
                 37
               </pre>

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -58,10 +58,10 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
         class="rounded-lg position-relative pt-5"
       >
         <div
-          class="descAccordion accordion"
+          class="card__descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordionItem accordion-item"
+            class="bg-white mb-2 false accordion__item accordion-item"
           >
             <h2
               class="accordion-header"
@@ -911,10 +911,10 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
         class="rounded-lg position-relative pt-5"
       >
         <div
-          class="descAccordion accordion"
+          class="card__descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordionItem accordion-item"
+            class="bg-white mb-2 false accordion__item accordion-item"
           >
             <h2
               class="accordion-header"
@@ -1713,10 +1713,10 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
         class="rounded-lg position-relative pt-5"
       >
         <div
-          class="descAccordion accordion"
+          class="card__descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordionItem accordion-item"
+            class="bg-white mb-2 false accordion__item accordion-item"
           >
             <h2
               class="accordion-header"
@@ -2515,10 +2515,10 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
         class="rounded-lg position-relative pt-5"
       >
         <div
-          class="descAccordion accordion"
+          class="card__descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordionItem accordion-item"
+            class="bg-white mb-2 false accordion__item accordion-item"
           >
             <h2
               class="accordion-header"
@@ -4118,10 +4118,10 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
         class="rounded-lg position-relative pt-5"
       >
         <div
-          class="descAccordion accordion"
+          class="card__descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordionItem accordion-item"
+            class="bg-white mb-2 false accordion__item accordion-item"
           >
             <h2
               class="accordion-header"
@@ -5721,10 +5721,10 @@ exports[`ReviewCard Component Should render single path submission 1`] = `
         class="rounded-lg position-relative pt-5"
       >
         <div
-          class="descAccordion accordion"
+          class="card__descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordionItem accordion-item"
+            class="bg-white mb-2 false accordion__item accordion-item"
           >
             <h2
               class="accordion-header"
@@ -6096,10 +6096,10 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
         class="rounded-lg position-relative pt-5"
       >
         <div
-          class="descAccordion accordion"
+          class="card__descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordionItem accordion-item"
+            class="bg-white mb-2 false accordion__item accordion-item"
           >
             <h2
               class="accordion-header"

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -61,7 +61,7 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
           class="descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordion-item"
+            class="bg-white mb-2 false accordionItem accordion-item"
           >
             <h2
               class="accordion-header"
@@ -140,12 +140,12 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
               class="diffView"
             >
               <table
-                class="css-b02w0u-diff-container"
+                class="css-1p5fn6o-diff-container"
               >
                 <tbody>
                   <tr>
                     <td
-                      class="css-1rwygp7-title-block"
+                      class="css-1gyvngn-title-block"
                       colspan="4"
                     >
                       <pre
@@ -162,14 +162,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         1
                       </pre>
@@ -217,14 +217,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         2
                       </pre>
@@ -265,14 +265,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         3
                       </pre>
@@ -301,14 +301,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         4
                       </pre>
@@ -390,14 +390,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         5
                       </pre>
@@ -426,14 +426,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         6
                       </pre>
@@ -481,14 +481,14 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         7
                       </pre>
@@ -914,7 +914,7 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
           class="descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordion-item"
+            class="bg-white mb-2 false accordionItem accordion-item"
           >
             <h2
               class="accordion-header"
@@ -993,12 +993,12 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
               class="diffView"
             >
               <table
-                class="css-b02w0u-diff-container"
+                class="css-1p5fn6o-diff-container"
               >
                 <tbody>
                   <tr>
                     <td
-                      class="css-1rwygp7-title-block"
+                      class="css-1gyvngn-title-block"
                       colspan="4"
                     >
                       <pre
@@ -1015,14 +1015,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         1
                       </pre>
@@ -1070,14 +1070,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         2
                       </pre>
@@ -1118,14 +1118,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         3
                       </pre>
@@ -1154,14 +1154,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         4
                       </pre>
@@ -1243,14 +1243,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         5
                       </pre>
@@ -1279,14 +1279,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         6
                       </pre>
@@ -1334,14 +1334,14 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         7
                       </pre>
@@ -1716,7 +1716,7 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
           class="descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordion-item"
+            class="bg-white mb-2 false accordionItem accordion-item"
           >
             <h2
               class="accordion-header"
@@ -1795,12 +1795,12 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
               class="diffView"
             >
               <table
-                class="css-b02w0u-diff-container"
+                class="css-1p5fn6o-diff-container"
               >
                 <tbody>
                   <tr>
                     <td
-                      class="css-1rwygp7-title-block"
+                      class="css-1gyvngn-title-block"
                       colspan="4"
                     >
                       <pre
@@ -1817,14 +1817,14 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         1
                       </pre>
@@ -1872,14 +1872,14 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         2
                       </pre>
@@ -1920,14 +1920,14 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         3
                       </pre>
@@ -1956,14 +1956,14 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         4
                       </pre>
@@ -2045,14 +2045,14 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         5
                       </pre>
@@ -2081,14 +2081,14 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         6
                       </pre>
@@ -2136,14 +2136,14 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         7
                       </pre>
@@ -2518,7 +2518,7 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
           class="descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordion-item"
+            class="bg-white mb-2 false accordionItem accordion-item"
           >
             <h2
               class="accordion-header"
@@ -2597,12 +2597,12 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
               class="diffView"
             >
               <table
-                class="css-b02w0u-diff-container"
+                class="css-1p5fn6o-diff-container"
               >
                 <tbody>
                   <tr>
                     <td
-                      class="css-1rwygp7-title-block"
+                      class="css-1gyvngn-title-block"
                       colspan="4"
                     >
                       <pre
@@ -2619,14 +2619,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         1
                       </pre>
@@ -2696,14 +2696,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         2
                       </pre>
@@ -2761,14 +2761,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         3
                       </pre>
@@ -2816,14 +2816,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         4
                       </pre>
@@ -2904,14 +2904,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         5
                       </pre>
@@ -2981,14 +2981,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         6
                       </pre>
@@ -3045,14 +3045,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         7
                       </pre>
@@ -3094,14 +3094,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         8
                       </pre>
@@ -3142,14 +3142,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         9
                       </pre>
@@ -3219,14 +3219,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         10
                       </pre>
@@ -3286,14 +3286,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         11
                       </pre>
@@ -3365,14 +3365,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         12
                       </pre>
@@ -3408,14 +3408,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         13
                       </pre>
@@ -3456,14 +3456,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         14
                       </pre>
@@ -3528,14 +3528,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         15
                       </pre>
@@ -3591,14 +3591,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         16
                       </pre>
@@ -3639,14 +3639,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         17
                       </pre>
@@ -3686,14 +3686,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         18
                       </pre>
@@ -3722,14 +3722,14 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         19
                       </pre>
@@ -4121,7 +4121,7 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
           class="descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordion-item"
+            class="bg-white mb-2 false accordionItem accordion-item"
           >
             <h2
               class="accordion-header"
@@ -4200,12 +4200,12 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
               class="diffView"
             >
               <table
-                class="css-b02w0u-diff-container"
+                class="css-1p5fn6o-diff-container"
               >
                 <tbody>
                   <tr>
                     <td
-                      class="css-1rwygp7-title-block"
+                      class="css-1gyvngn-title-block"
                       colspan="4"
                     >
                       <pre
@@ -4222,14 +4222,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         1
                       </pre>
@@ -4299,14 +4299,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         2
                       </pre>
@@ -4364,14 +4364,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         3
                       </pre>
@@ -4419,14 +4419,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         4
                       </pre>
@@ -4507,14 +4507,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         5
                       </pre>
@@ -4584,14 +4584,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         6
                       </pre>
@@ -4648,14 +4648,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         7
                       </pre>
@@ -4697,14 +4697,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         8
                       </pre>
@@ -4745,14 +4745,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         9
                       </pre>
@@ -4822,14 +4822,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         10
                       </pre>
@@ -4889,14 +4889,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         11
                       </pre>
@@ -4968,14 +4968,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         12
                       </pre>
@@ -5011,14 +5011,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         13
                       </pre>
@@ -5059,14 +5059,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         14
                       </pre>
@@ -5131,14 +5131,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         15
                       </pre>
@@ -5194,14 +5194,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         16
                       </pre>
@@ -5242,14 +5242,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         17
                       </pre>
@@ -5289,14 +5289,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         18
                       </pre>
@@ -5325,14 +5325,14 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         19
                       </pre>
@@ -5724,7 +5724,7 @@ exports[`ReviewCard Component Should render single path submission 1`] = `
           class="descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordion-item"
+            class="bg-white mb-2 false accordionItem accordion-item"
           >
             <h2
               class="accordion-header"
@@ -6099,7 +6099,7 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
           class="descAccordion accordion"
         >
           <div
-            class="bg-white mb-2 false accordion-item"
+            class="bg-white mb-2 false accordionItem accordion-item"
           >
             <h2
               class="accordion-header"
@@ -6178,12 +6178,12 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
               class="diffView"
             >
               <table
-                class="css-b02w0u-diff-container"
+                class="css-1p5fn6o-diff-container"
               >
                 <tbody>
                   <tr>
                     <td
-                      class="css-1rwygp7-title-block"
+                      class="css-1gyvngn-title-block"
                       colspan="4"
                     >
                       <pre
@@ -6200,14 +6200,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         1
                       </pre>
@@ -6277,14 +6277,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         2
                       </pre>
@@ -6342,14 +6342,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         3
                       </pre>
@@ -6397,14 +6397,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         4
                       </pre>
@@ -6485,14 +6485,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         5
                       </pre>
@@ -6562,14 +6562,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         6
                       </pre>
@@ -6626,14 +6626,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         7
                       </pre>
@@ -6675,14 +6675,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         8
                       </pre>
@@ -6723,14 +6723,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         9
                       </pre>
@@ -6800,14 +6800,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         10
                       </pre>
@@ -6867,14 +6867,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         11
                       </pre>
@@ -6946,14 +6946,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         12
                       </pre>
@@ -6989,14 +6989,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         13
                       </pre>
@@ -7037,14 +7037,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         14
                       </pre>
@@ -7109,14 +7109,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         15
                       </pre>
@@ -7172,14 +7172,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         16
                       </pre>
@@ -7220,14 +7220,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         17
                       </pre>
@@ -7267,14 +7267,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         18
                       </pre>
@@ -7303,14 +7303,14 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                       class="css-1k5tuhz-gutter css-9w79dj-empty-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       />
                     </td>
                     <td
                       class="css-1k5tuhz-gutter css-cnnxkz-diff-added"
                     >
                       <pre
-                        class="css-14p8zw1-line-number"
+                        class="css-iepx6s-line-number"
                       >
                         19
                       </pre>

--- a/scss/reviewCard.module.scss
+++ b/scss/reviewCard.module.scss
@@ -1,16 +1,16 @@
-.descAccordion {
+.card__descAccordion {
   z-index: 3;
   top: 0;
   width: 100%;
   position: absolute;
 }
 
-.accordionItemShow {
+.accordion__accordionItem--show {
   box-shadow: 0px -3px 50px -6px #0f235a96;
   border-radius: 8px !important;
 }
 
-.accordionItem {
+.accordion__item {
   border-radius: 8px !important;
   border-color: #eee;
 }

--- a/scss/reviewCard.module.scss
+++ b/scss/reviewCard.module.scss
@@ -5,6 +5,12 @@
   position: absolute;
 }
 
-.accordionItem {
+.accordionItemShow {
   box-shadow: 0px -3px 50px -6px #0f235a96;
+  border-radius: 8px !important;
+}
+
+.accordionItem {
+  border-radius: 8px !important;
+  border-color: #eee;
 }


### PR DESCRIPTION
Closes #1576 

This PR will:

- Increase the borders radius
- Add margin between each file (diffview)
- Change the Accordion border color to make it similar to the DiffViewer header border (that has the file name)

Before:

![image](https://user-images.githubusercontent.com/35906419/158027301-884203ec-fb0e-4a9a-a624-47c549764083.png)

![image](https://user-images.githubusercontent.com/35906419/158027342-8eeaa041-6946-4587-a3c9-472aceb7e7e4.png)


After:

![image](https://user-images.githubusercontent.com/35906419/158027312-dd4cb322-dc83-4e7f-848a-7780a2bcd8d9.png)

![image](https://user-images.githubusercontent.com/35906419/158027332-b6f9a950-9a64-4b97-88b7-e7fdfa11f933.png)
