### PR TITLE
fix: Each react child in a list must have a key

### DIFF
--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -99,7 +99,7 @@ const DiffView: React.FC<{
     }
 
     return (
-      <div className="position-relative">
+      <div className="position-relative" key={fileIdx}>
         <div className="position-absolute w-100 d-flex flex-row justify-content-end p-1">
           <div
             className={`${scssStyles.checkBoxBorder} form-check pe-2 mt-2 me-2 border rounded`}


### PR DESCRIPTION
Related to #1578 

This PR fixes the following error: `Warning: Each child in a list should have a unique "key" prop` and update the `diffView` render to give each element a key.