### PR TITLE
fix: Use act(...) for code that change state

### DIFF
--- a/components/CopyButton.test.js
+++ b/components/CopyButton.test.js
@@ -1,5 +1,6 @@
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 import CopyButton from './CopyButton'
 
 Object.defineProperty(navigator, 'clipboard', {
@@ -70,7 +71,7 @@ describe('Copy Button component', () => {
       expect(button.classList.contains('btn-outline-bg-success')).toBeTruthy()
     )
 
-    jest.advanceTimersByTime(2000)
+    act(() => jest.advanceTimersByTime(2000))
 
     await waitFor(() => {
       expect(button.classList.contains('btn-outline-bg-primary')).toBeTruthy()

--- a/components/DropdownMenu.test.js
+++ b/components/DropdownMenu.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent, screen } from '@testing-library/react'
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
 import { DropdownMenu } from './DropdownMenu'
 
 const dropdownMenuItems = [
@@ -24,14 +24,18 @@ describe('MdInput Component', () => {
 
   test('Should change value of testBtnOnClick upon click', () => {
     dropdownMenuItems[0].onClick = val => (testBtnOnClick = val)
+
     const { container } = render(
       <DropdownMenu title="Admin" items={dropdownMenuItems} />
     )
+
     const btn = screen.queryByText('Admin')
     fireEvent.click(btn, { button: 1 })
+
     const lessons = screen.queryAllByText('Lessons')[0]
     fireEvent.click(lessons, { button: 1 })
-    expect(testBtnOnClick).toEqual('Lessons')
+
+    waitFor(() => expect(testBtnOnClick).toEqual('Lessons'))
     expect(container).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Closes #1578 

This PR fixes the following issue: `When testing, code that causes React state updates should be wrapped into act(...)`