### PR TITLE
next-auth: Create auth.d.ts

### DIFF
--- a/@types/auth.d.ts
+++ b/@types/auth.d.ts
@@ -1,0 +1,47 @@
+import { Submission } from '@prisma/client'
+import { DefaultSession } from 'next-auth'
+import { SessionContextValue } from 'next-auth/react'
+import { Session as SessionOri } from 'next-auth/core'
+
+type SignInReturn = {
+  error: string
+  ok: boolean
+  status: number
+  url: string
+}
+
+export interface Session extends DefaultSession {
+  lessonStatus: {
+    starGiven: string
+    passedAt: Date | null
+    lessonId: number
+  }[]
+  user: {
+    id: number
+    username: string
+    name: string
+    isAdmin: boolean
+    isConnectedToDiscord: boolean
+  }
+  submissions: Submission[]
+}
+
+export declare type SessionContext<R extends boolean = false> = R extends true
+  ?
+      | {
+          data: Session
+          status: 'authenticated'
+        }
+      | {
+          data: null
+          status: 'loading'
+        }
+  :
+      | {
+          data: Session
+          status: 'authenticated'
+        }
+      | {
+          data: null
+          status: 'unauthenticated' | 'loading'
+        }

--- a/@types/auth.d.ts
+++ b/@types/auth.d.ts
@@ -1,7 +1,6 @@
 import { Submission } from '@prisma/client'
 import { DefaultSession } from 'next-auth'
 import { SessionContextValue } from 'next-auth/react'
-import { Session as SessionOri } from 'next-auth/core'
 
 type SignInReturn = {
   error: string


### PR DESCRIPTION
Related to #1589 

This PR create the types for the following:

- What `signIn` returns
- `getSession` return type
- `useSession` type