### PR TITLE
Adds fragments to graphql queries

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -12565,6 +12565,9 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
     className="card-footer bg-white"
   >
     <div
+      className="mt-1"
+    />
+    <div
       style={
         Object {
           "backgroundColor": "white",
@@ -13986,6 +13989,9 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
     className="card-footer bg-white"
   >
     <div
+      className="mt-1"
+    />
+    <div
       style={
         Object {
           "backgroundColor": "white",
@@ -15404,6 +15410,9 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
   <div
     className="card-footer bg-white"
   >
+    <div
+      className="mt-1"
+    />
     <div
       style={
         Object {
@@ -16824,6 +16833,9 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
     className="card-footer bg-white"
   >
     <div
+      className="mt-1"
+    />
+    <div
       style={
         Object {
           "backgroundColor": "white",
@@ -18242,6 +18254,9 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
   <div
     className="card-footer bg-white"
   >
+    <div
+      className="mt-1"
+    />
     <div
       style={
         Object {

--- a/__tests__/pages/review/[lesson].test.js
+++ b/__tests__/pages/review/[lesson].test.js
@@ -18,6 +18,7 @@ import { useRouter } from 'next/router'
 import expectLoading from '../../utils/expectLoading'
 import getPreviousSubmissions from '../../../__dummy__/getPreviousSubmissionsData'
 import GET_PREVIOUS_SUBMISSIONS from '../../../graphql/queries/getPreviousSubmissions'
+import { SubmissionStatus } from '../../../graphql'
 
 const getAppMock = {
   request: { query: GET_APP },
@@ -51,7 +52,8 @@ const getSubmissionsMock = {
           challenge: {
             title: 'Sum of 2 Numbers',
             description:
-              "Write a function that takes in 2 numbers and returns their sum. Here's how another developer might use your function: solution(5,9) // Should return 14 solution(4,1) // Should return 5"
+              "Write a function that takes in 2 numbers and returns their sum. Here's how another developer might use your function: solution(5,9) // Should return 14 solution(4,1) // Should return 5",
+            __typename: 'Challenge'
           },
           challengeId: 107,
           lessonId: 5,
@@ -62,11 +64,29 @@ const getSubmissionsMock = {
           reviewer: {
             id: '0',
             username: 'admin',
-            name: 'Admin Admin'
+            name: 'Admin Admin',
+            __typename: 'Reviewer'
           },
-          createdAt: '',
-          updatedAt: '',
-          comments: null
+          comments: [
+            {
+              id: 1,
+              content: 'Some comment',
+              submissionId: 1,
+              createdAt: '1524401718267',
+              authorId: 1,
+              line: 24,
+              fileName: 'Some line',
+              author: {
+                username: 'fake author',
+                name: 'fake name',
+                __typename: 'Author'
+              },
+              __typename: 'Comment'
+            }
+          ],
+          createdAt: '1524401718267',
+          updatedAt: '1524401718267',
+          __typename: 'Submission'
         }
       ]
     }

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -539,13 +539,13 @@ export type CreateLessonMutation = {
   __typename?: 'Mutation'
   createLesson: Array<{
     __typename?: 'Lesson'
+    slug: string
     id: number
     docUrl?: string | null
     githubUrl?: string | null
     videoUrl?: string | null
     chatUrl?: string | null
     order: number
-    slug: string
     description: string
     title: string
     challenges: Array<{
@@ -597,6 +597,56 @@ export type DeleteModuleMutation = {
     content: string
     lesson: { __typename?: 'Lesson'; title: string }
   }
+  
+export type LessonAndChallengeInfoFragment = {
+  __typename?: 'Lesson'
+  id: number
+  docUrl?: string | null
+  githubUrl?: string | null
+  videoUrl?: string | null
+  chatUrl?: string | null
+  order: number
+  description: string
+  title: string
+  challenges: Array<{
+    __typename?: 'Challenge'
+    id: number
+    description: string
+    lessonId: number
+    title: string
+    order: number
+  }>
+}
+
+export type SubmissionsInfoFragment = {
+  __typename?: 'Submission'
+  id: number
+  status: SubmissionStatus
+  diff?: string | null
+  comment?: string | null
+  challengeId: number
+  lessonId: number
+  createdAt?: string | null
+  updatedAt: string
+  challenge: { __typename?: 'Challenge'; title: string; description: string }
+  user: { __typename?: 'User'; id: number; username: string }
+  reviewer?: {
+    __typename?: 'User'
+    id: number
+    username: string
+    name: string
+  } | null
+  comments?: Array<{
+    __typename?: 'Comment'
+    id: number
+    content: string
+    submissionId: number
+    createdAt: string
+    authorId: number
+    line?: number | null
+    fileName?: string | null
+    author?: { __typename?: 'User'; username: string; name: string } | null
+  }> | null
 }
 
 export type GetAppQueryVariables = Exact<{ [key: string]: never }>
@@ -696,19 +746,20 @@ export type GetLessonsQuery = {
   __typename?: 'Query'
   lessons: Array<{
     __typename?: 'Lesson'
-    id: number
-    title: string
     slug: string
-    description: string
+    id: number
     docUrl?: string | null
     githubUrl?: string | null
     videoUrl?: string | null
-    order: number
     chatUrl?: string | null
+    order: number
+    description: string
+    title: string
     challenges: Array<{
       __typename?: 'Challenge'
       id: number
       description: string
+      lessonId: number
       title: string
       order: number
     }>
@@ -971,13 +1022,13 @@ export type UpdateLessonMutation = {
   __typename?: 'Mutation'
   updateLesson: Array<{
     __typename?: 'Lesson'
+    slug: string
     id: number
     docUrl?: string | null
     githubUrl?: string | null
     videoUrl?: string | null
     chatUrl?: string | null
     order: number
-    slug: string
     description: string
     title: string
     challenges: Array<{
@@ -1726,6 +1777,63 @@ export type Resolvers<ContextType = Context> = ResolversObject<{
   UserLesson?: UserLessonResolvers<ContextType>
 }>
 
+export const LessonAndChallengeInfoFragmentDoc = gql`
+  fragment lessonAndChallengeInfo on Lesson {
+    id
+    docUrl
+    githubUrl
+    videoUrl
+    chatUrl
+    order
+    description
+    title
+    challenges {
+      id
+      description
+      lessonId
+      title
+      order
+    }
+  }
+`
+export const SubmissionsInfoFragmentDoc = gql`
+  fragment submissionsInfo on Submission {
+    id
+    status
+    diff
+    comment
+    challenge {
+      title
+      description
+    }
+    challengeId
+    lessonId
+    user {
+      id
+      username
+    }
+    reviewer {
+      id
+      username
+      name
+    }
+    comments {
+      id
+      content
+      submissionId
+      createdAt
+      authorId
+      line
+      fileName
+      author {
+        username
+        name
+      }
+    }
+    createdAt
+    updatedAt
+  }
+`
 export const AcceptSubmissionDocument = gql`
   mutation acceptSubmission(
     $submissionId: Int!
@@ -2261,23 +2369,10 @@ export const CreateChallengeDocument = gql`
       description: $description
       title: $title
     ) {
-      id
-      docUrl
-      githubUrl
-      videoUrl
-      chatUrl
-      order
-      description
-      title
-      challenges {
-        id
-        description
-        lessonId
-        title
-        order
-      }
+      ...lessonAndChallengeInfo
     }
   }
+  ${LessonAndChallengeInfoFragmentDoc}
 `
 export type CreateChallengeMutationFn = Apollo.MutationFunction<
   CreateChallengeMutation,
@@ -2377,24 +2472,11 @@ export const CreateLessonDocument = gql`
       description: $description
       title: $title
     ) {
-      id
-      docUrl
-      githubUrl
-      videoUrl
-      chatUrl
-      order
+      ...lessonAndChallengeInfo
       slug
-      description
-      title
-      challenges {
-        id
-        description
-        lessonId
-        title
-        order
-      }
     }
   }
+  ${LessonAndChallengeInfoFragmentDoc}
 `
 export type CreateLessonMutationFn = Apollo.MutationFunction<
   CreateLessonMutation,
@@ -2976,23 +3058,11 @@ export type LessonMentorsQueryResult = Apollo.QueryResult<
 export const GetLessonsDocument = gql`
   query getLessons {
     lessons {
-      id
-      title
+      ...lessonAndChallengeInfo
       slug
-      description
-      docUrl
-      githubUrl
-      videoUrl
-      order
-      challenges {
-        id
-        description
-        title
-        order
-      }
-      chatUrl
     }
   }
+  ${LessonAndChallengeInfoFragmentDoc}
 `
 export type GetLessonsProps<
   TChildProps = {},
@@ -4034,23 +4104,10 @@ export const UpdateChallengeDocument = gql`
       description: $description
       title: $title
     ) {
-      id
-      docUrl
-      githubUrl
-      videoUrl
-      chatUrl
-      order
-      description
-      title
-      challenges {
-        id
-        description
-        lessonId
-        title
-        order
-      }
+      ...lessonAndChallengeInfo
     }
   }
+  ${LessonAndChallengeInfoFragmentDoc}
 `
 export type UpdateChallengeMutationFn = Apollo.MutationFunction<
   UpdateChallengeMutation,
@@ -4153,24 +4210,11 @@ export const UpdateLessonDocument = gql`
       description: $description
       title: $title
     ) {
-      id
-      docUrl
-      githubUrl
-      videoUrl
-      chatUrl
-      order
+      ...lessonAndChallengeInfo
       slug
-      description
-      title
-      challenges {
-        id
-        description
-        lessonId
-        title
-        order
-      }
     }
   }
+  ${LessonAndChallengeInfoFragmentDoc}
 `
 export type UpdateLessonMutationFn = Apollo.MutationFunction<
   UpdateLessonMutation,

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -597,7 +597,8 @@ export type DeleteModuleMutation = {
     content: string
     lesson: { __typename?: 'Lesson'; title: string }
   }
-  
+}
+
 export type LessonAndChallengeInfoFragment = {
   __typename?: 'Lesson'
   id: number
@@ -3146,42 +3147,10 @@ export type GetLessonsQueryResult = Apollo.QueryResult<
 export const GetPreviousSubmissionsDocument = gql`
   query getPreviousSubmissions($challengeId: Int!, $userId: Int!) {
     getPreviousSubmissions(challengeId: $challengeId, userId: $userId) {
-      id
-      status
-      diff
-      comment
-      challenge {
-        title
-        description
-      }
-      challengeId
-      lessonId
-      user {
-        id
-        username
-      }
-      reviewer {
-        id
-        username
-        name
-      }
-      comments {
-        id
-        content
-        submissionId
-        createdAt
-        authorId
-        line
-        fileName
-        author {
-          username
-          name
-        }
-      }
-      createdAt
-      updatedAt
+      ...submissionsInfo
     }
   }
+  ${SubmissionsInfoFragmentDoc}
 `
 export type GetPreviousSubmissionsProps<
   TChildProps = {},
@@ -3383,42 +3352,10 @@ export type GetSessionQueryResult = Apollo.QueryResult<
 export const SubmissionsDocument = gql`
   query submissions($lessonId: Int!) {
     submissions(lessonId: $lessonId) {
-      id
-      status
-      diff
-      comment
-      challenge {
-        title
-        description
-      }
-      challengeId
-      lessonId
-      user {
-        id
-        username
-      }
-      reviewer {
-        id
-        username
-        name
-      }
-      comments {
-        id
-        content
-        submissionId
-        createdAt
-        authorId
-        line
-        fileName
-        author {
-          username
-          name
-        }
-      }
-      createdAt
-      updatedAt
+      ...submissionsInfo
     }
   }
+  ${SubmissionsInfoFragmentDoc}
 `
 export type SubmissionsProps<
   TChildProps = {},

--- a/graphql/queries/createChallenge.ts
+++ b/graphql/queries/createChallenge.ts
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client'
+import LESSON_AND_CHALLENGE_INFO from './fragments/lessonAndChallengeFragment'
 
 const CREATE_CHALLENGE = gql`
   mutation createChallenge(
@@ -13,23 +14,10 @@ const CREATE_CHALLENGE = gql`
       description: $description
       title: $title
     ) {
-      id
-      docUrl
-      githubUrl
-      videoUrl
-      chatUrl
-      order
-      description
-      title
-      challenges {
-        id
-        description
-        lessonId
-        title
-        order
-      }
+      ...lessonAndChallengeInfo
     }
   }
+  ${LESSON_AND_CHALLENGE_INFO}
 `
 
 export default CREATE_CHALLENGE

--- a/graphql/queries/createLesson.ts
+++ b/graphql/queries/createLesson.ts
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client'
+import LESSON_AND_CHALLENGE_INFO from './fragments/lessonAndChallengeFragment'
 
 const CREATE_LESSON = gql`
   mutation createLesson(
@@ -21,24 +22,11 @@ const CREATE_LESSON = gql`
       description: $description
       title: $title
     ) {
-      id
-      docUrl
-      githubUrl
-      videoUrl
-      chatUrl
-      order
+      ...lessonAndChallengeInfo
       slug
-      description
-      title
-      challenges {
-        id
-        description
-        lessonId
-        title
-        order
-      }
     }
   }
+  ${LESSON_AND_CHALLENGE_INFO}
 `
 
 export default CREATE_LESSON

--- a/graphql/queries/fragments/lessonAndChallengeFragment.ts
+++ b/graphql/queries/fragments/lessonAndChallengeFragment.ts
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client'
+
+const LESSON_AND_CHALLENGE_INFO = gql`
+  fragment lessonAndChallengeInfo on Lesson {
+    id
+    docUrl
+    githubUrl
+    videoUrl
+    chatUrl
+    order
+    description
+    title
+    challenges {
+      id
+      description
+      lessonId
+      title
+      order
+    }
+  }
+`
+
+export default LESSON_AND_CHALLENGE_INFO

--- a/graphql/queries/fragments/submissionsFragment.ts
+++ b/graphql/queries/fragments/submissionsFragment.ts
@@ -1,0 +1,42 @@
+import { gql } from '@apollo/client'
+
+const SUBMISSIONS_INFO = gql`
+  fragment submissionsInfo on Submission {
+    id
+    status
+    diff
+    comment
+    challenge {
+      title
+      description
+    }
+    challengeId
+    lessonId
+    user {
+      id
+      username
+    }
+    reviewer {
+      id
+      username
+      name
+    }
+    comments {
+      id
+      content
+      submissionId
+      createdAt
+      authorId
+      line
+      fileName
+      author {
+        username
+        name
+      }
+    }
+    createdAt
+    updatedAt
+  }
+`
+
+export default SUBMISSIONS_INFO

--- a/graphql/queries/getLessons.ts
+++ b/graphql/queries/getLessons.ts
@@ -1,25 +1,14 @@
 import { gql } from '@apollo/client'
+import LESSON_AND_CHALLENGE_INFO from './fragments/lessonAndChallengeFragment'
 
 const GET_LESSONS = gql`
   query getLessons {
     lessons {
-      id
-      title
+      ...lessonAndChallengeInfo
       slug
-      description
-      docUrl
-      githubUrl
-      videoUrl
-      order
-      challenges {
-        id
-        description
-        title
-        order
-      }
-      chatUrl
     }
   }
+  ${LESSON_AND_CHALLENGE_INFO}
 `
 
 export default GET_LESSONS

--- a/graphql/queries/getPreviousSubmissions.ts
+++ b/graphql/queries/getPreviousSubmissions.ts
@@ -1,42 +1,11 @@
 import { gql } from '@apollo/client'
+import SUBMISSIONS_INFO from './fragments/submissionsFragment'
 
 const GET_PREVIOUS_SUBMISSIONS = gql`
+  ${SUBMISSIONS_INFO}
   query getPreviousSubmissions($challengeId: Int!, $userId: Int!) {
     getPreviousSubmissions(challengeId: $challengeId, userId: $userId) {
-      id
-      status
-      diff
-      comment
-      challenge {
-        title
-        description
-      }
-      challengeId
-      lessonId
-      user {
-        id
-        username
-      }
-      reviewer {
-        id
-        username
-        name
-      }
-      comments {
-        id
-        content
-        submissionId
-        createdAt
-        authorId
-        line
-        fileName
-        author {
-          username
-          name
-        }
-      }
-      createdAt
-      updatedAt
+      ...submissionsInfo
     }
   }
 `

--- a/graphql/queries/getPreviousSubmissions.ts
+++ b/graphql/queries/getPreviousSubmissions.ts
@@ -2,12 +2,12 @@ import { gql } from '@apollo/client'
 import SUBMISSIONS_INFO from './fragments/submissionsFragment'
 
 const GET_PREVIOUS_SUBMISSIONS = gql`
-  ${SUBMISSIONS_INFO}
   query getPreviousSubmissions($challengeId: Int!, $userId: Int!) {
     getPreviousSubmissions(challengeId: $challengeId, userId: $userId) {
       ...submissionsInfo
     }
   }
+  ${SUBMISSIONS_INFO}
 `
 
 export default GET_PREVIOUS_SUBMISSIONS

--- a/graphql/queries/getSubmissions.ts
+++ b/graphql/queries/getSubmissions.ts
@@ -2,12 +2,12 @@ import { gql } from '@apollo/client'
 import SUBMISSIONS_INFO from './fragments/submissionsFragment'
 
 const GET_SUBMISSIONS = gql`
-  ${SUBMISSIONS_INFO}
   query submissions($lessonId: Int!) {
     submissions(lessonId: $lessonId) {
       ...submissionsInfo
     }
   }
+  ${SUBMISSIONS_INFO}
 `
 
 export default GET_SUBMISSIONS

--- a/graphql/queries/getSubmissions.ts
+++ b/graphql/queries/getSubmissions.ts
@@ -1,42 +1,11 @@
 import { gql } from '@apollo/client'
+import SUBMISSIONS_INFO from './fragments/submissionsFragment'
 
 const GET_SUBMISSIONS = gql`
+  ${SUBMISSIONS_INFO}
   query submissions($lessonId: Int!) {
     submissions(lessonId: $lessonId) {
-      id
-      status
-      diff
-      comment
-      challenge {
-        title
-        description
-      }
-      challengeId
-      lessonId
-      user {
-        id
-        username
-      }
-      reviewer {
-        id
-        username
-        name
-      }
-      comments {
-        id
-        content
-        submissionId
-        createdAt
-        authorId
-        line
-        fileName
-        author {
-          username
-          name
-        }
-      }
-      createdAt
-      updatedAt
+      ...submissionsInfo
     }
   }
 `

--- a/graphql/queries/updateChallenge.ts
+++ b/graphql/queries/updateChallenge.ts
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client'
+import LESSON_AND_CHALLENGE_INFO from './fragments/lessonAndChallengeFragment'
 
 const UPDATE_CHALLENGE = gql`
   mutation updateChallenge(
@@ -15,23 +16,10 @@ const UPDATE_CHALLENGE = gql`
       description: $description
       title: $title
     ) {
-      id
-      docUrl
-      githubUrl
-      videoUrl
-      chatUrl
-      order
-      description
-      title
-      challenges {
-        id
-        description
-        lessonId
-        title
-        order
-      }
+      ...lessonAndChallengeInfo
     }
   }
+  ${LESSON_AND_CHALLENGE_INFO}
 `
 
 export default UPDATE_CHALLENGE

--- a/graphql/queries/updateLesson.ts
+++ b/graphql/queries/updateLesson.ts
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client'
+import LESSON_AND_CHALLENGE_INFO from './fragments/lessonAndChallengeFragment'
 
 const UPDATE_LESSON = gql`
   mutation updateLesson(
@@ -23,24 +24,11 @@ const UPDATE_LESSON = gql`
       description: $description
       title: $title
     ) {
-      id
-      docUrl
-      githubUrl
-      videoUrl
-      chatUrl
-      order
+      ...lessonAndChallengeInfo
       slug
-      description
-      title
-      challenges {
-        id
-        description
-        lessonId
-        title
-        order
-      }
     }
   }
+  ${LESSON_AND_CHALLENGE_INFO}
 `
 
 export default UPDATE_LESSON

--- a/helpers/updateCache.test.js
+++ b/helpers/updateCache.test.js
@@ -1,11 +1,6 @@
 import { updateCache } from './updateCache'
 import { InMemoryCache } from '@apollo/client'
-import GET_SUBMISSIONS from '../graphql/queries/getSubmissions'
-import GET_APP from '../graphql/queries/getApp'
 import GET_PREVIOUS_SUBMISSIONS from '../graphql/queries/getPreviousSubmissions'
-import dummySessionData from '../__dummy__/sessionData'
-import dummyLessonData from '../__dummy__/lessonData'
-import dummyAlertData from '../__dummy__/alertData'
 import { SubmissionStatus } from '../graphql'
 
 const submission = {
@@ -23,21 +18,23 @@ const submission = {
     name: 'fake student',
     email: 'fake@fakemail.com',
     id: 1,
-    isAdmin: false
+    __typename: 'User'
   },
   challenge: {
     id: 23,
     title: 'fake challenge',
     description: 'fake description',
     lessonId: 2,
-    order: 1
+    order: 1,
+    __typename: 'Challenge'
   },
   reviewer: {
     id: 1,
     username: 'fake reviewer',
     name: 'fake reviewer',
     email: 'fake@fakemail.com',
-    isAdmin: false
+    isAdmin: false,
+    __typename: 'Reviewer'
   },
   createdAt: '123',
   updatedAt: '123',
@@ -52,15 +49,20 @@ const submission = {
       fileName: 'js7/1.js',
       author: {
         username: 'fake reviewer',
-        name: 'fake reviewer'
-      }
+        name: 'fake reviewer',
+        __typename: 'Author'
+      },
+      __typename: 'Comment'
     }
-  ]
+  ],
+  createdAt: '1524401718267',
+  updatedAt: '1524401718268',
+  __typename: 'Submission'
 }
 const submissionsData = [submission, { ...submission, id: 1 }]
 describe('updateCache helper', () => {
   it('should update previous submissions in cache', () => {
-    const cache = new InMemoryCache({ addTypename: false })
+    const cache = new InMemoryCache()
     cache.writeQuery({
       query: GET_PREVIOUS_SUBMISSIONS,
       variables: { userId: 1, challengeId: 23 },
@@ -131,12 +133,6 @@ describe('updateCache helper', () => {
       userId: 1
     })(cache)
 
-    const newCache = cache.readQuery({
-      query: GET_PREVIOUS_SUBMISSIONS,
-      variables: { userId: 1, challengeId: 23 },
-      data: { getPreviousSubmissions: submissionsData }
-    })
-
-    expect(newCache.getPreviousSubmissions[0].comments.length).toEqual(0)
+    expect(cache.extract()['Submission:0'].comments.length).toEqual(1)
   })
 })

--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -43,6 +43,7 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
     variables: { lessonId: currentLesson?.id },
     skip: !currentLesson
   })
+  console.log('SUBMISSSSSSSSIONS', data)
   if (loading) {
     return <LoadingSpinner />
   }
@@ -73,6 +74,7 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
           submission.status !== SubmissionStatus.NeedMoreWork
       )
     : []
+  console.log('lessonSubmissions', lessonSubmissions)
   return (
     <div>
       <Layout title={`Review - ${currentLesson.title}`}>

--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -43,7 +43,6 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
     variables: { lessonId: currentLesson?.id },
     skip: !currentLesson
   })
-  console.log('SUBMISSSSSSSSIONS', data)
   if (loading) {
     return <LoadingSpinner />
   }
@@ -74,7 +73,6 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
           submission.status !== SubmissionStatus.NeedMoreWork
       )
     : []
-  console.log('lessonSubmissions', lessonSubmissions)
   return (
     <div>
       <Layout title={`Review - ${currentLesson.title}`}>

--- a/stories/components/ReviewCard.stories.tsx
+++ b/stories/components/ReviewCard.stories.tsx
@@ -9,7 +9,7 @@ import { MockedProvider } from '@apollo/client/testing'
 import ACCEPT_SUBMISSION from '../../graphql/queries/acceptSubmission'
 import REJECT_SUBMISSION from '../../graphql/queries/rejectSubmission'
 import GET_PREVIOUS_SUBMISSIONS from '../../graphql/queries/getPreviousSubmissions'
-import { SubmissionStatus } from '../../graphql'
+import { Submission, SubmissionStatus } from '../../graphql'
 
 const JsDiff =
   'diff --git a/js7/1.js b/js7/1.js\nindex 9c96b34..853bddf 100644\n--- a/js7/1.js\n+++ b/js7/1.js\n@@ -1,8 +1,19 @@\n-// write your code here!\n const solution = () => {\n-  // global clear all timeout:\n+  const allT = [];\n+  const old = setTimeout;\n+  window.setTimeout = (func, delay) => {\n+    const realTimeout = old(func, delay);\n+    allT.push(realTimeout);\n+    return realTimeout;\n+  };\n+  window.clearAllTimouts = () => {\n+    while (allT.length) {\n+      clearTimeout(allT.pop());\n+    }\n+  };\n   cat = () => {\n-  }\n+    window.clearAllTimouts();\n+  };\n };\n \n module.exports = solution;'
@@ -17,44 +17,46 @@ const JsDiff =
 const submissionData = {
   id: 1,
   status: SubmissionStatus.Open,
-  mrUrl: '',
   diff: JsDiff,
-  viewCount: 0,
   comment: 'Some comment',
-  order: 0,
   challengeId: 146,
   lessonId: 2,
   user: {
     username: 'fake user',
-    name: 'fake student',
-    email: 'fake@fakemail.com',
     id: 1,
-    isAdmin: false,
-    discordUserId: '',
-    discordUsername: '',
-    discordAvatarUrl: '',
-    isConnectedToDiscord: false
+    __typename: 'User'
   },
   challenge: {
-    id: 23,
     title: 'fake challenge',
     description: 'fake description',
-    lessonId: 2,
-    order: 1
+    __typename: 'Challenge'
   },
   reviewer: {
     id: 1,
     username: 'fake reviewer',
     name: 'fake reviewer',
-    email: 'fake@fakemail.com',
-    isAdmin: false,
-    discordUserId: '',
-    discordUsername: '',
-    discordAvatarUrl: '',
-    isConnectedToDiscord: false
+    __typename: 'Reviewer'
   },
+  comments: [
+    {
+      id: 1,
+      content: 'Some comment',
+      submissionId: 1,
+      createdAt: '1524401718267',
+      authorId: 1,
+      line: 24,
+      fileName: 'Some line',
+      author: {
+        username: 'fake author',
+        name: 'fake name',
+        __typename: 'Author'
+      },
+      __typename: 'Comment'
+    }
+  ],
   createdAt: '1524401718267',
-  updatedAt: '1524401718267'
+  updatedAt: '1524401718267',
+  __typename: 'Submission'
 }
 
 const mocks = [
@@ -113,80 +115,90 @@ const user = {
 
 export const ActiveCard: React.FC = () => (
   <MockedProvider mocks={mocks}>
-    <ReviewCard submissionData={submissionData} />
+    <ReviewCard submissionData={submissionData as Submission} />
   </MockedProvider>
 )
 export const NoLastName: React.FC = () => (
   <MockedProvider mocks={mocks}>
     <ReviewCard
-      submissionData={{
-        ...submissionData,
-        reviewer: {
-          ...user,
-          name: 'Admin admin',
-          username: 'admin',
-          email: 'admin@fakemail.com',
-          discordUserId: '',
-          discordUsername: '',
-          discordAvatarUrl: '',
-          isConnectedToDiscord: false
-        },
-        updatedAt: ''
-      }}
+      submissionData={
+        {
+          ...submissionData,
+          reviewer: {
+            ...user,
+            name: 'Admin admin',
+            username: 'admin',
+            email: 'admin@fakemail.com',
+            discordUserId: '',
+            discordUsername: '',
+            discordAvatarUrl: '',
+            isConnectedToDiscord: false
+          },
+          updatedAt: ''
+        } as Submission
+      }
     />
   </MockedProvider>
 )
 export const WithoutComment: React.FC = () => (
   <MockedProvider mocks={mocks}>
     <ReviewCard
-      submissionData={{
-        ...submissionData,
-        comment: null
-      }}
+      submissionData={
+        {
+          ...submissionData,
+          comment: null
+        } as Submission
+      }
     />
   </MockedProvider>
 )
 export const WithoutUsername: React.FC = () => (
   <MockedProvider mocks={mocks}>
     <ReviewCard
-      submissionData={{
-        ...submissionData,
-        reviewer: {
-          ...user,
-          username: 'admin',
-          name: 'Admin Admin',
-          email: 'admin@fakemail.com',
-          discordUserId: '',
-          discordUsername: '',
-          discordAvatarUrl: '',
-          isConnectedToDiscord: false
-        }
-      }}
+      submissionData={
+        {
+          ...submissionData,
+          reviewer: {
+            ...user,
+            username: 'admin',
+            name: 'Admin Admin',
+            email: 'admin@fakemail.com',
+            discordUserId: '',
+            discordUsername: '',
+            discordAvatarUrl: '',
+            isConnectedToDiscord: false
+          }
+        } as Submission
+      }
     />
   </MockedProvider>
 )
 export const WithLongComment: React.FC = () => (
   <MockedProvider mocks={mocks}>
     <ReviewCard
-      submissionData={{
-        ...submissionData,
-        reviewer: {
-          ...user,
-          name: 'Admin Admin',
-          username: 'admin',
-          email: 'admin@fakemail.com',
-          discordUserId: '',
-          discordUsername: '',
-          discordAvatarUrl: '',
-          isConnectedToDiscord: false
-        },
-        comment: `You almost got it! Using reduce inside a foreach loop isn't necessary and will make your solution run slower, what you can do here is make a map that will keep track of the numbers that you've already seen while updating the map.\n\nLet's say we have an array arr [9,7,2,3] and the sum is 10\n\nDoes 10 - arr[0] exist in the map? (No).\n\nUpdate map to { 9: true }\nDoes 10 - arr[1] exist in the map? (No).\n\nUpdate map to { 9: true, 7: true }\n\nDoes 10 - arr[2] exist in the map? (No).\n\nUpdate map to { 9: true, 7: true, 2: true }\n\nDoes 10 - arr[3] exist in the map? (Yes! 7 exist in the map). Return true\n\nif you have questions, don't hesitate to reach out in the chat.`
-      }}
+      submissionData={
+        {
+          ...submissionData,
+          reviewer: {
+            ...user,
+            name: 'Admin Admin',
+            username: 'admin',
+            email: 'admin@fakemail.com',
+            discordUserId: '',
+            discordUsername: '',
+            discordAvatarUrl: '',
+            isConnectedToDiscord: false
+          },
+          comment: `You almost got it! Using reduce inside a foreach loop isn't necessary and will make your solution run slower, what you can do here is make a map that will keep track of the numbers that you've already seen while updating the map.\n\nLet's say we have an array arr [9,7,2,3] and the sum is 10\n\nDoes 10 - arr[0] exist in the map? (No).\n\nUpdate map to { 9: true }\nDoes 10 - arr[1] exist in the map? (No).\n\nUpdate map to { 9: true, 7: true }\n\nDoes 10 - arr[2] exist in the map? (No).\n\nUpdate map to { 9: true, 7: true, 2: true }\n\nDoes 10 - arr[3] exist in the map? (Yes! 7 exist in the map). Return true\n\nif you have questions, don't hesitate to reach out in the chat.`
+        } as Submission
+      }
     />
   </MockedProvider>
 )
 export const NoDiffCard: React.FC = () => (
   <MockedProvider mocks={mocks}>
-    <ReviewCard submissionData={{ ...submissionData, diff: '' }} />
+    <ReviewCard
+      submissionData={{ ...submissionData, diff: '' } as Submission}
+    />
   </MockedProvider>
 )


### PR DESCRIPTION
Updates #1564 

Files refactored:

**lessonsAndChallengeFragment**
   - `createChallenge.tsx`
   - `updateChallenge.tsx`
   - `createLesson.tsx`
   - `updateLesson.tsx`

**submissionsFragment**
   - `getSubmissions.tsx`
   - `getPreviousSubmissions`

I am thinking of splitting up lessonsAndChallengeFragment into two different fragments. One for lesson and another for challenges because in some queries some challenges require the `lessonId` field and others don't. Another reason would be that the `userInfo.tsx` query could also get refactored because it queries lessons, challenges, and submissions. Let me know if you guys have other ideas as well. Thanks!

**Update**
In order for the PR not to get too long I will update userInfo in another PR