### PR TITLE
next-auth: Set req.user from the session in getSession

### DIFF
--- a/helpers/middleware/user.test.js
+++ b/helpers/middleware/user.test.js
@@ -3,10 +3,12 @@
  */
 
 jest.mock('../encoding.ts')
+jest.mock('next-auth/react')
 
 import prismaMock from '../../__tests__/utils/prismaMock'
 import userMiddleware from './user'
 import { decode } from '../encoding'
+import { getSession } from 'next-auth/react'
 
 const mockUserInfo = {
   id: 408,
@@ -144,5 +146,24 @@ describe('User Middleware', () => {
 
     await userMiddleware(req, res, next)
     expect(prismaMock.user.update).toBeCalledTimes(0)
+  })
+
+  test('Should set req.user to getSession if there is a session', async () => {
+    expect.assertions(1)
+
+    getSession.mockReturnValue({
+      user: {
+        userId: 'noob'
+      }
+    })
+
+    const req = {
+      user: null
+    }
+
+    await userMiddleware(req, res, next)
+    expect(req.user).toStrictEqual({
+      userId: 'noob'
+    })
   })
 })

--- a/helpers/middleware/user.ts
+++ b/helpers/middleware/user.ts
@@ -3,6 +3,8 @@ import { NextApiResponse } from 'next'
 import prisma from '../../prisma'
 import { decode } from '../encoding'
 import { CliToken } from '../../@types/user'
+import { getSession } from 'next-auth/react'
+import { User } from '@prisma/client'
 
 const userMiddleware = async (
   req: LoggedRequest,
@@ -11,8 +13,16 @@ const userMiddleware = async (
 ) => {
   req.user = null
 
+  const nextAuthSession = await getSession({ req })
+
+  if (nextAuthSession?.user) {
+    req.user = nextAuthSession.user as User
+    return next()
+  }
+
   const auth = req.headers.authorization
   const cliToken = auth && auth.split(' ')[1]
+
   if (cliToken) {
     const decodedCliData: CliToken = decode(cliToken)
 


### PR DESCRIPTION
Related to #1588 -- In specific, replacing login/signup with next-auth.

This PR populate the `req.user` with the session that's returned from `getSession` if it exists. By setting the session from `getSession`, our code will work the same and we won't have to replace graphQL session queries in the codebase; like the following:

https://github.com/garageScript/c0d3-app/blob/acee49f9275b2aa13282c19ef55fc8a7a2ad80cc/components/AppNav.tsx#L105