### PR TITLE
feat(helpers): update signupValidation to validate password

### DIFF
--- a/helpers/formValidation.tsx
+++ b/helpers/formValidation.tsx
@@ -60,7 +60,10 @@ const signupValidation = Yup.object({
     .min(TEXT_MIN, `Must be at least ${TEXT_MIN} characters`)
     .max(TEXT_MAX, `Must be ${TEXT_MAX} characters or less`)
     .trim('Leading and trailing value must be alphanumeric character')
-    .required('Required')
+    .required('Required'),
+  password: Yup.string()
+    .min(PASSWORD_MIN, `Must be at least ${PASSWORD_MIN} characters`)
+    .max(TEXT_MAX, `Must be ${TEXT_MAX} characters or less`)
 })
 
 const loginValidation = Yup.object({


### PR DESCRIPTION
Related to #1550 

This PR update `signupValidation` to also validate password. The `signup` resolver will be used to set the user password and ultimately create an account with needing to redirect the user to `/confirm/[token]` page (where the user is asked to set a new password for their account).