### PR TITLE
doc: update setup page broken link

### DIFF
--- a/content/docs/setup.mdx
+++ b/content/docs/setup.mdx
@@ -298,4 +298,4 @@ steps ([video instructions](https://www.youtube.com/watch?v=jzZqwUXIc00)):
 Congratulations! You have written your first JavaScript program and you know how
 to run code directly in the browser. Now you are ready to start your journey.
 
-[JS 0 - Foundations](https://www.notion.so/JS-0-Foundations-a43ca620e54945b2b620bcda5f3cf672)
+[JS 0 - Foundations](https://www.c0d3.com/curriculum/js0/primitive_data_and_operators)


### PR DESCRIPTION
Closes #1684 

This PR updates the link that redirects to JS1 from notion doc to our [self-hosted lesson](https://www.c0d3.com/curriculum/js0/primitive_data_and_operators)