### PR TITLE
fix: storyshots snapshot keep regenerating components props

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -92,6 +92,318 @@ exports[`Storyshots Components/AdditionalResources Basic 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/AdminLessonNav Basic 1`] = `
+Array [
+  <div
+    className="lessons_tabsNav col"
+  >
+    <div
+      className="lessons__tabsNav__nav nav nav-pills"
+      onKeyDown={[Function]}
+      role="tablist"
+    >
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-introduction"
+          aria-selected={true}
+          className="lessons_tabsNav__nav__item active"
+          data-rr-ui-event-key="introduction"
+          disabled={false}
+          id="admin-nav-tabs-tab-introduction"
+          onClick={[Function]}
+          role="tab"
+        >
+          INTRODUCTION
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-modules"
+          className="lessons_tabsNav__nav__item--inactive"
+          data-rr-ui-event-key="modules"
+          disabled={false}
+          id="admin-nav-tabs-tab-modules"
+          onClick={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          MODULES
+        </a>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="lessons_tabs col"
+  >
+    <div
+      className="tab-content"
+    >
+      <div
+        aria-labelledby="admin-nav-tabs-tab-introduction"
+        className="fade tab-pane active show"
+        id="admin-nav-tabs-tabpane-introduction"
+        role="tabpanel"
+      >
+        <h1>
+          Some text
+        </h1>
+        <p>
+          Some paragraph that makes sense
+        </p>
+        <small>
+          Small text for the vibes
+        </small>
+      </div>
+      <div
+        aria-labelledby="admin-nav-tabs-tab-modules"
+        className="fade tab-pane"
+        id="admin-nav-tabs-tabpane-modules"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`Storyshots Components/AdminLessonNav With Many Items 1`] = `
+Array [
+  <div
+    className="lessons_tabsNav col"
+  >
+    <div
+      className="lessons__tabsNav__nav nav nav-pills"
+      onKeyDown={[Function]}
+      role="tablist"
+    >
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-introduction"
+          aria-selected={true}
+          className="lessons_tabsNav__nav__item active"
+          data-rr-ui-event-key="introduction"
+          disabled={false}
+          id="admin-nav-tabs-tab-introduction"
+          onClick={[Function]}
+          role="tab"
+        >
+          INTRODUCTION
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-Zaziuz"
+          className="lessons_tabsNav__nav__item--inactive"
+          data-rr-ui-event-key="Zaziuz"
+          disabled={false}
+          id="admin-nav-tabs-tab-Zaziuz"
+          onClick={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          ZAZIUZ
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-Vanvied"
+          className="lessons_tabsNav__nav__item--inactive"
+          data-rr-ui-event-key="Vanvied"
+          disabled={false}
+          id="admin-nav-tabs-tab-Vanvied"
+          onClick={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          VANVIED
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-Bovsoaca"
+          className="lessons_tabsNav__nav__item--inactive"
+          data-rr-ui-event-key="Bovsoaca"
+          disabled={false}
+          id="admin-nav-tabs-tab-Bovsoaca"
+          onClick={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          BOVSOACA
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-Evesific"
+          className="lessons_tabsNav__nav__item--inactive"
+          data-rr-ui-event-key="Evesific"
+          disabled={false}
+          id="admin-nav-tabs-tab-Evesific"
+          onClick={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          EVESIFIC
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-Tehocon"
+          className="lessons_tabsNav__nav__item--inactive"
+          data-rr-ui-event-key="Tehocon"
+          disabled={false}
+          id="admin-nav-tabs-tab-Tehocon"
+          onClick={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          TEHOCON
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-Malujo"
+          className="lessons_tabsNav__nav__item--inactive"
+          data-rr-ui-event-key="Malujo"
+          disabled={false}
+          id="admin-nav-tabs-tab-Malujo"
+          onClick={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          MALUJO
+        </a>
+      </div>
+      <div
+        className="nav-item"
+      >
+        <a
+          aria-controls="admin-nav-tabs-tabpane-Vicolki"
+          className="lessons_tabsNav__nav__item--inactive"
+          data-rr-ui-event-key="Vicolki"
+          disabled={false}
+          id="admin-nav-tabs-tab-Vicolki"
+          onClick={[Function]}
+          role="tab"
+          tabIndex={-1}
+        >
+          VICOLKI
+        </a>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="lessons_tabs col"
+  >
+    <div
+      className="tab-content"
+    >
+      <div
+        aria-labelledby="admin-nav-tabs-tab-introduction"
+        className="fade tab-pane active show"
+        id="admin-nav-tabs-tabpane-introduction"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+      <div
+        aria-labelledby="admin-nav-tabs-tab-Zaziuz"
+        className="fade tab-pane"
+        id="admin-nav-tabs-tabpane-Zaziuz"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+      <div
+        aria-labelledby="admin-nav-tabs-tab-Vanvied"
+        className="fade tab-pane"
+        id="admin-nav-tabs-tabpane-Vanvied"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+      <div
+        aria-labelledby="admin-nav-tabs-tab-Bovsoaca"
+        className="fade tab-pane"
+        id="admin-nav-tabs-tabpane-Bovsoaca"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+      <div
+        aria-labelledby="admin-nav-tabs-tab-Evesific"
+        className="fade tab-pane"
+        id="admin-nav-tabs-tabpane-Evesific"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+      <div
+        aria-labelledby="admin-nav-tabs-tab-Tehocon"
+        className="fade tab-pane"
+        id="admin-nav-tabs-tabpane-Tehocon"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+      <div
+        aria-labelledby="admin-nav-tabs-tab-Malujo"
+        className="fade tab-pane"
+        id="admin-nav-tabs-tabpane-Malujo"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+      <div
+        aria-labelledby="admin-nav-tabs-tab-Vicolki"
+        className="fade tab-pane"
+        id="admin-nav-tabs-tabpane-Vicolki"
+        role="tabpanel"
+      >
+        <p>
+          Modules with delete and add
+        </p>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`Storyshots Components/Alert Info 1`] = `
 <div
   className="alert d-flex justify-content-between mt-3 bg-primary text-white"

--- a/components/admin/lessons/AdminLessonNav.tsx
+++ b/components/admin/lessons/AdminLessonNav.tsx
@@ -55,7 +55,7 @@ const AdminLessonNav: React.FC<Props> = ({ panels }: Props) => {
   )
 
   return (
-    <Tab.Container activeKey={key!} onSelect={setKey}>
+    <Tab.Container id="admin-nav-tabs" activeKey={key!} onSelect={setKey}>
       <Col className={styles.lessons_tabsNav}>
         <Nav variant="pills" className={styles.lessons__tabsNav__nav}>
           {tabPanels.tabNavItems}


### PR DESCRIPTION
Closes #1707

The component [`Nav.Link`](https://react-bootstrap.github.io/components/navs/#nav-link-props) require its parent [`Tab.Container`](https://react-bootstrap.github.io/components/tabs/#tab-container-props) to be given ID for its props `id` and `aria-controls` could have a value based on it (e..g, `admin-tabs-<title>`). 

This PR adds an id to the `Tab.Container` component.