### PR TITLE
refactor: Export diff-view toolbar to a function

### DIFF
--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -104,37 +104,39 @@ const DiffView: React.FC<{
       )
     }
 
+    const toolbar = () => (
+      <>
+        <div
+          className={`${scssStyles.checkBoxBorder} form-check pe-2 me-2 border rounded`}
+        >
+          <input
+            className="form-check-input"
+            type="checkbox"
+            value=""
+            id={`checkBox-${id}-${fileIdx}`}
+            checked={viewableStates[fileIdx]}
+            onChange={() => {
+              const newViewableStates = [...viewableStates]
+              newViewableStates[fileIdx] = !newViewableStates[fileIdx]
+              setViewableStates(newViewableStates)
+            }}
+          />
+          <label
+            className="form-check-label text-muted"
+            htmlFor={`checkBox-${id}-${fileIdx}`}
+          >
+            Viewed
+          </label>
+        </div>
+        <CopyButton value={newValue.join('\n')} />
+      </>
+    )
+
     return (
       <div className="position-relative" key={fileIdx}>
         <div className={scssStyles.diffView}>
           <ReactDiffViewer
-            toolbar={() => (
-              <>
-                <div
-                  className={`${scssStyles.checkBoxBorder} form-check pe-2 me-2 border rounded`}
-                >
-                  <input
-                    className="form-check-input"
-                    type="checkbox"
-                    value=""
-                    id={`checkBox-${id}-${fileIdx}`}
-                    checked={viewableStates[fileIdx]}
-                    onChange={() => {
-                      const newViewableStates = [...viewableStates]
-                      newViewableStates[fileIdx] = !newViewableStates[fileIdx]
-                      setViewableStates(newViewableStates)
-                    }}
-                  />
-                  <label
-                    className="form-check-label text-muted"
-                    htmlFor={`checkBox-${id}-${fileIdx}`}
-                  >
-                    Viewed
-                  </label>
-                </div>
-                <CopyButton value={newValue.join('\n')} />
-              </>
-            )}
+            toolbar={toolbar}
             key={_.uniqueId()}
             newValue={!viewableStates[fileIdx] ? newValue.join('\n') : ''}
             renderContent={syntaxHighlight}


### PR DESCRIPTION
Closes #1767 

This PR moves the toolbar JSX from the prop to a function and then references it in the prop.


From:

```tsx
toolbar={
  () => { ... }
}
```

To:

```tsx
const toolbar = () => { ... }

toolbar={toolbar}
```