### PR TITLE
Fix AppNav discord user image styling

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -12330,7 +12330,7 @@ exports[`Storyshots Components/ProfileImageInfo Profile Image Info 1`] = `
     className="ms-auto me-auto mt-4 profile_image_container"
   >
     <div
-      className="jsx-3123111835 ms-auto me-auto mt-4"
+      className="jsx-3123111835 ms-auto me-auto undefined"
     >
       <img
         className="img-fluid"
@@ -12341,7 +12341,7 @@ exports[`Storyshots Components/ProfileImageInfo Profile Image Info 1`] = `
     </div>
   </div>
   <h2
-    className="text-center mt-4"
+    className="text-center mt-2"
   >
     Rahul Kalra
   </h2>
@@ -21843,7 +21843,7 @@ exports[`Storyshots Components/UserInfoImage User Info Image 1`] = `
   }
 >
   <div
-    className="jsx-3123111835 ms-auto me-auto mt-4"
+    className="jsx-3123111835 ms-auto me-auto undefined"
   >
     <img
       className="img-fluid"

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -3283,7 +3283,7 @@ exports[`Storyshots Components/ContributorCard Basic 1`] = `
     className="ms-auto me-auto mt-4 contributorCard__avatarContainer"
   >
     <div
-      className="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+      className="text-uppercase bg-primary rounded-circle text-light user_info_image "
     >
       AO
     </div>
@@ -21307,7 +21307,7 @@ exports[`Storyshots Components/SubmissionCard Multiple Cards 1`] = `
             className="submissioncard_user_info_image_container"
           >
             <div
-              className="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              className="text-uppercase bg-primary rounded-circle text-light user_info_image "
             >
               RK
             </div>
@@ -21374,7 +21374,7 @@ exports[`Storyshots Components/SubmissionCard Multiple Cards 1`] = `
             className="submissioncard_user_info_image_container"
           >
             <div
-              className="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              className="text-uppercase bg-primary rounded-circle text-light user_info_image "
             >
               RK
             </div>
@@ -21441,7 +21441,7 @@ exports[`Storyshots Components/SubmissionCard Multiple Cards 1`] = `
             className="submissioncard_user_info_image_container"
           >
             <div
-              className="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              className="text-uppercase bg-primary rounded-circle text-light user_info_image "
             >
               RK
             </div>
@@ -21512,7 +21512,7 @@ exports[`Storyshots Components/SubmissionCard Pending Submission 1`] = `
           className="submissioncard_user_info_image_container"
         >
           <div
-            className="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+            className="text-uppercase bg-primary rounded-circle text-light user_info_image "
           >
             RK
           </div>
@@ -21843,7 +21843,7 @@ exports[`Storyshots Components/UserInfoImage User Info Image 1`] = `
   }
 >
   <div
-    className="jsx-3123111835 ms-auto me-auto undefined"
+    className="jsx-3123111835 ms-auto me-auto "
   >
     <img
       className="img-fluid"
@@ -21947,7 +21947,7 @@ Array [
             className="ms-auto me-auto mt-4 contributorCard__avatarContainer"
           >
             <div
-              className="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              className="text-uppercase bg-primary rounded-circle text-light user_info_image "
             >
               AO
             </div>

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -12330,7 +12330,7 @@ exports[`Storyshots Components/ProfileImageInfo Profile Image Info 1`] = `
     className="ms-auto me-auto mt-4 profile_image_container"
   >
     <div
-      className="jsx-3123111835 ms-auto me-auto undefined"
+      className="jsx-3123111835 ms-auto me-auto mt-4"
     >
       <img
         className="img-fluid"
@@ -12341,7 +12341,7 @@ exports[`Storyshots Components/ProfileImageInfo Profile Image Info 1`] = `
     </div>
   </div>
   <h2
-    className="text-center mt-2"
+    className="text-center mt-4"
   >
     Rahul Kalra
   </h2>

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -109,6 +109,11 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="progress-card__container card shadow-sm mt-3 bg-primary text-white px-3 px-xl-4 py-4 border-0"
           >
+            <h4
+              class="progress-card__title mt-4 text-center "
+            >
+              Join C0D3 now and start your software engineering journey!
+            </h4>
             <div
               class="mt-3 text-center"
             >
@@ -1283,6 +1288,11 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="progress-card__container card shadow-sm mt-3 bg-primary text-white px-3 px-xl-4 py-4 border-0"
           >
+            <h4
+              class="progress-card__title mt-4 text-center "
+            >
+              Join C0D3 now and start your software engineering journey!
+            </h4>
             <div
               class="mt-3 text-center"
             >

--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -109,11 +109,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="progress-card__container card shadow-sm mt-3 bg-primary text-white px-3 px-xl-4 py-4 border-0"
           >
-            <h4
-              class="progress-card__title mt-4 text-center "
-            >
-              Join C0D3 now and start your software engineering journey!
-            </h4>
             <div
               class="mt-3 text-center"
             >
@@ -1288,11 +1283,6 @@ exports[`Curriculum Page Should render curriculum with no session 1`] = `
           <div
             class="progress-card__container card shadow-sm mt-3 bg-primary text-white px-3 px-xl-4 py-4 border-0"
           >
-            <h4
-              class="progress-card__title mt-4 text-center "
-            >
-              Join C0D3 now and start your software engineering journey!
-            </h4>
             <div
               class="mt-3 text-center"
             >

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -184,7 +184,7 @@ exports[`user profile test Should render anonymous users 1`] = `
             </div>
           </div>
           <h2
-            class="text-center mt-4"
+            class="text-center mt-2"
           >
             A  
           </h2>
@@ -1053,7 +1053,7 @@ exports[`user profile test Should render if no stars received 1`] = `
             </div>
           </div>
           <h2
-            class="text-center mt-4"
+            class="text-center mt-2"
           >
             fake user
           </h2>
@@ -1927,7 +1927,7 @@ exports[`user profile test Should render nulled challenges 1`] = `
             </div>
           </div>
           <h2
-            class="text-center mt-4"
+            class="text-center mt-2"
           >
             fake user
           </h2>
@@ -2837,7 +2837,7 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
             </div>
           </div>
           <h2
-            class="text-center mt-4"
+            class="text-center mt-2"
           >
             fake user
           </h2>
@@ -3706,7 +3706,7 @@ exports[`user profile test Should render profile 1`] = `
             </div>
           </div>
           <h2
-            class="text-center mt-4"
+            class="text-center mt-2"
           >
             fake user
           </h2>
@@ -4745,10 +4745,10 @@ exports[`user profile test should render discord avatar and username if user con
             class="ms-auto me-auto mt-4 profile_image_container"
           >
             <div
-              class="jsx-3123111835 ms-auto me-auto mt-4"
+              class="jsx-3123111835 ms-auto me-auto undefined"
             >
               <img
-                class="avatar undefined"
+                class="avatar"
                 height="60"
                 src="https://placeimg.com/640/480/any"
                 width="60"
@@ -4756,7 +4756,7 @@ exports[`user profile test should render discord avatar and username if user con
             </div>
           </div>
           <h2
-            class="text-center mt-4"
+            class="text-center mt-2"
           >
             fake user
           </h2>

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -178,13 +178,13 @@ exports[`user profile test Should render anonymous users 1`] = `
             class="ms-auto me-auto mt-4 profile_image_container"
           >
             <div
-              class="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image mt-4"
             >
               A 
             </div>
           </div>
           <h2
-            class="text-center mt-2"
+            class="text-center mt-4"
           >
             A  
           </h2>
@@ -1047,13 +1047,13 @@ exports[`user profile test Should render if no stars received 1`] = `
             class="ms-auto me-auto mt-4 profile_image_container"
           >
             <div
-              class="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image mt-4"
             >
               fu
             </div>
           </div>
           <h2
-            class="text-center mt-2"
+            class="text-center mt-4"
           >
             fake user
           </h2>
@@ -1921,13 +1921,13 @@ exports[`user profile test Should render nulled challenges 1`] = `
             class="ms-auto me-auto mt-4 profile_image_container"
           >
             <div
-              class="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image mt-4"
             >
               fu
             </div>
           </div>
           <h2
-            class="text-center mt-2"
+            class="text-center mt-4"
           >
             fake user
           </h2>
@@ -2831,13 +2831,13 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
             class="ms-auto me-auto mt-4 profile_image_container"
           >
             <div
-              class="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image mt-4"
             >
               fu
             </div>
           </div>
           <h2
-            class="text-center mt-2"
+            class="text-center mt-4"
           >
             fake user
           </h2>
@@ -3700,13 +3700,13 @@ exports[`user profile test Should render profile 1`] = `
             class="ms-auto me-auto mt-4 profile_image_container"
           >
             <div
-              class="text-uppercase bg-primary rounded-circle text-light user_info_image undefined"
+              class="text-uppercase bg-primary rounded-circle text-light user_info_image mt-4"
             >
               fu
             </div>
           </div>
           <h2
-            class="text-center mt-2"
+            class="text-center mt-4"
           >
             fake user
           </h2>
@@ -4745,7 +4745,7 @@ exports[`user profile test should render discord avatar and username if user con
             class="ms-auto me-auto mt-4 profile_image_container"
           >
             <div
-              class="jsx-3123111835 ms-auto me-auto undefined"
+              class="jsx-3123111835 ms-auto me-auto mt-4"
             >
               <img
                 class="avatar"
@@ -4756,7 +4756,7 @@ exports[`user profile test should render discord avatar and username if user con
             </div>
           </div>
           <h2
-            class="text-center mt-2"
+            class="text-center mt-4"
           >
             fake user
           </h2>

--- a/components/ProfileImageInfo.tsx
+++ b/components/ProfileImageInfo.tsx
@@ -16,7 +16,7 @@ const ProfileImageInfo: React.FC<ProfileImageInfoProps> = ({ user }) => {
       >
         <UserInfoImage user={user} />
       </div>
-      <h2 className="text-center mt-4">
+      <h2 className="text-center mt-2">
         {`${user.firstName} ${user.lastName}`}
       </h2>
       <div className="d-flex justify-content-center">

--- a/components/ProfileImageInfo.tsx
+++ b/components/ProfileImageInfo.tsx
@@ -14,9 +14,9 @@ const ProfileImageInfo: React.FC<ProfileImageInfoProps> = ({ user }) => {
       <div
         className={`ms-auto me-auto mt-4 ${styles['profile_image_container']}`}
       >
-        <UserInfoImage user={user} />
+        <UserInfoImage user={user} className="mt-4" />
       </div>
-      <h2 className="text-center mt-2">
+      <h2 className="text-center mt-4">
         {`${user.firstName} ${user.lastName}`}
       </h2>
       <div className="d-flex justify-content-center">

--- a/components/UserInfoImage.tsx
+++ b/components/UserInfoImage.tsx
@@ -10,7 +10,7 @@ type UserProps = {
 export const DiscordAvatar: React.FC<UserProps> = ({ user, className }) => {
   return (
     <>
-      <div className={`ms-auto me-auto ${className}`}>
+      <div className={`ms-auto me-auto ${className ? className : ''}`}>
         <Image
           className={`avatar`}
           src={user.discordAvatarUrl}
@@ -36,7 +36,9 @@ const UserInfoImage: React.FC<UserProps> = ({ user, className }) => {
         <DiscordAvatar user={user} className={className} />
       ) : (
         <div
-          className={`text-uppercase bg-primary rounded-circle text-light ${styles['user_info_image']} ${className}`}
+          className={`text-uppercase bg-primary rounded-circle text-light ${
+            styles['user_info_image']
+          } ${className ? className : ''}`}
         >
           {user.firstName[0] + user.lastName[0]}
         </div>

--- a/components/UserInfoImage.tsx
+++ b/components/UserInfoImage.tsx
@@ -10,9 +10,9 @@ type UserProps = {
 export const DiscordAvatar: React.FC<UserProps> = ({ user, className }) => {
   return (
     <>
-      <div className="ms-auto me-auto mt-4">
+      <div className={`ms-auto me-auto ${className}`}>
         <Image
-          className={`avatar ${className}`}
+          className={`avatar`}
           src={user.discordAvatarUrl}
           width={60}
           height={60}
@@ -33,7 +33,7 @@ const UserInfoImage: React.FC<UserProps> = ({ user, className }) => {
   return (
     <>
       {user.discordUserId ? (
-        <DiscordAvatar user={user} />
+        <DiscordAvatar user={user} className={className} />
       ) : (
         <div
           className={`text-uppercase bg-primary rounded-circle text-light ${styles['user_info_image']} ${className}`}


### PR DESCRIPTION
This PR fixes the discord user image size and margins on the AppNav.

Before
![Screen Shot 2022-04-24 at 16 56 35](https://user-images.githubusercontent.com/1410462/164985097-96860228-3414-4c6f-b11b-6445e86f8181.png)
After
![Screen Shot 2022-04-24 at 16 59 40](https://user-images.githubusercontent.com/1410462/164985196-ed8007c5-24a2-45a0-951c-70afb565e473.png)
