### PR TITLE
Update AppNav test

### DIFF
--- a/components/AppNav.test.js
+++ b/components/AppNav.test.js
@@ -47,7 +47,7 @@ describe('AppNav Component', () => {
       await waitFor(() => getByText('A'))
       fireEvent.click(getByText('A'))
       await waitFor(() => getAllByText('Logout'))
-      fireEvent.click(getAllByText('Logout')[0])
+      fireEvent.click(getAllByText('Logout')[0].closest('span'))
     })
 
     await waitFor(() => expect(global.window.location.pathname).toEqual('/'))


### PR DESCRIPTION
This PR will update the test to click on the logout link container instead of the <a> link.

The previous test was only testing the links (getByText) and not the whole menu item. 
The issue itself was fixed in this pr #1775.