### PR TITLE
fix: `Do not assign to the variable 'module'`

### DIFF
--- a/graphql/resolvers/moduleCrud.test.js
+++ b/graphql/resolvers/moduleCrud.test.js
@@ -85,15 +85,15 @@ describe('It should add modules', () => {
 
 describe('It should update a module', () => {
   test('should update a module ', async () => {
-    const module = {
+    const moduleObj = {
       lessonId: 1,
       name: 'Math',
       content: 'Teaches Math'
     }
 
-    prismaMock.module.update.mockResolvedValue(module)
+    prismaMock.module.update.mockResolvedValue(moduleObj)
 
-    await expect(updateModule({}, module, ctx)).resolves.toEqual({
+    await expect(updateModule({}, moduleObj, ctx)).resolves.toEqual({
       lessonId: 1,
       name: 'Math',
       content: 'Teaches Math'


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-app/issues/1839

This PR rename the variable from `module` to `moduleObj`