### PR TITLE
Next-Auth: Add JWT and Session callbacks

### DIFF
--- a/__tests__/pages/api/auth/[...nextauth].test.js
+++ b/__tests__/pages/api/auth/[...nextauth].test.js
@@ -4,7 +4,7 @@
 
 jest.mock('next-auth')
 jest.mock('../../../../helpers/nextAuth.ts')
-import { providers, signIn } from '../../../../helpers/nextAuth'
+import { providers, signIn, jwt, session } from '../../../../helpers/nextAuth'
 import nextAuthMiddleware from '../../../../pages/api/auth/[...nextauth]'
 import NextAuth from 'next-auth'
 
@@ -22,7 +22,9 @@ describe('next-auth middleware', () => {
     const options = {
       providers,
       callbacks: {
-        signIn: signIn(req, res)
+        signIn: signIn(req, res),
+        jwt,
+        session
       },
       secret: process.env.SESSION_SECRET
     }

--- a/helpers/nextAuth.test.js
+++ b/helpers/nextAuth.test.js
@@ -172,6 +172,23 @@ describe('JWT callback', () => {
 
     expect(value.user.id).toBe(1)
   })
+
+  it('Should not set user in token if there is no user', () => {
+    expect.assertions(1)
+
+    const options = {
+      token: {
+        user: null
+      },
+      user: {
+        id: 1
+      }
+    }
+
+    const value = jwt({ ...options, user: null })
+
+    expect(value.user).toBeFalsy()
+  })
 })
 
 describe('Session callback', () => {

--- a/helpers/nextAuth.test.js
+++ b/helpers/nextAuth.test.js
@@ -4,7 +4,7 @@ jest.mock('./middleware/session')
 jest.mock('./middleware/logger')
 import { updateRefreshandAccessTokens } from './discordAuth'
 import prismaMock from '../__tests__/utils/prismaMock'
-import { signIn } from './nextAuth'
+import { jwt, session, signIn } from './nextAuth'
 import loggingMiddleware from './middleware/logger'
 import sessionMiddleware from './middleware/session'
 import userMiddleware from './middleware/user'
@@ -152,5 +152,45 @@ describe('Signin callback', () => {
 
       expect(c0d3User).toBe(null)
     })
+  })
+})
+
+describe('JWT callback', () => {
+  it('Should set user in token', () => {
+    expect.assertions(1)
+
+    const options = {
+      token: {
+        user: null
+      },
+      user: {
+        id: 1
+      }
+    }
+
+    const value = jwt(options)
+
+    expect(value.user.id).toBe(1)
+  })
+})
+
+describe('Session callback', () => {
+  it('Should set session.user to token.user', async () => {
+    expect.assertions(1)
+
+    const options = {
+      token: {
+        user: {
+          id: 1
+        }
+      },
+      session: {
+        user: null
+      }
+    }
+
+    const value = await session(options)
+
+    expect(value.user.id).toBe(1)
   })
 })

--- a/helpers/nextAuth.ts
+++ b/helpers/nextAuth.ts
@@ -1,11 +1,12 @@
 import { updateRefreshandAccessTokens } from './discordAuth'
-import { Account, User } from 'next-auth'
+import { Account, DefaultSession, Session, User } from 'next-auth'
 import { LoggedRequest } from '../@types/helpers'
 import { Request, Response } from 'express'
 import { NextApiResponse } from 'next'
 import DiscordProvider from 'next-auth/providers/discord'
 import { getUserSession } from './getUserSession'
 import prisma from '../prisma'
+import { JWT } from 'next-auth/jwt'
 
 export const providers = [
   DiscordProvider({
@@ -56,3 +57,20 @@ export const signIn =
 
     return true
   }
+
+// jwt callback is first called then session callback
+export const jwt = ({ token, user }: { token: JWT; user?: User }) => {
+  if (user) token.user = user
+  return token
+}
+
+export const session = async ({
+  session,
+  token
+}: {
+  session: Session
+  token: JWT
+}) => {
+  session.user = token.user as DefaultSession['user']
+  return session
+}

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -2,7 +2,7 @@ import NextAuth from 'next-auth'
 import { NextApiResponse } from 'next'
 import { LoggedRequest } from '../../../@types/helpers'
 import { Request, Response } from 'express'
-import { signIn, providers } from '../../../helpers/nextAuth'
+import { signIn, providers, jwt, session } from '../../../helpers/nextAuth'
 
 export default (
   req: LoggedRequest & Request,
@@ -11,7 +11,9 @@ export default (
   NextAuth(req, res, {
     providers,
     callbacks: {
-      signIn: signIn(req, res)
+      signIn: signIn(req, res),
+      jwt,
+      session
     },
     secret: process.env.SESSION_SECRET
   })


### PR DESCRIPTION
Related to #1550. In specific, the first action item, replace signup/login with next-auth

This PR adds JWT and Session callbacks that will help us set the user object into the session. After merging this PR, the user object will be accessable through `useSession` or `getSession`.

Next, the authControllers and login/signup pages will be updated to use next-auth.