### PR TITLE
fix: Low accessibility metrics

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -27393,11 +27393,11 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
           src="/assets/landing/choose-01.svg"
           width="163"
         />
-        <h4
-          className="mt-3 fw-bold"
+        <p
+          className="mt-3 fw-bold h3"
         >
           Modern Curriculum
-        </h4>
+        </p>
         <p
           className="mt-4 fw-light"
         >
@@ -27415,11 +27415,11 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
           src="/assets/landing/choose-02.svg"
           width="259"
         />
-        <h4
-          className="mt-3 fw-bold"
+        <p
+          className="mt-3 fw-bold h3"
         >
           Support
-        </h4>
+        </p>
         <p
           className="mt-4 fw-light"
         >
@@ -27437,11 +27437,11 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
           src="/assets/landing/choose-03.svg"
           width="93"
         />
-        <h4
-          className="mt-3 fw-bold"
+        <p
+          className="mt-3 fw-bold h3"
         >
           Work Experience
-        </h4>
+        </p>
         <p
           className="mt-4 fw-light"
         >
@@ -27547,7 +27547,7 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
             Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spending a penny. The exercises and challenges are designed to be difficult to force you to ask questions. Students who have passed the lessons are available in the chatrooms to help you with your questions.
              
             <span
-              className="fw-light text-warning"
+              className="fw-bold"
             >
               (Meetups are currently unavailable due to COVID-19)
             </span>

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -171,11 +171,11 @@ exports[`Index Page Should render index page 1`] = `
             src="/assets/landing/choose-01.svg"
             width="163"
           />
-          <h4
-            class="mt-3 fw-bold"
+          <p
+            class="mt-3 fw-bold h3"
           >
             Modern Curriculum
-          </h4>
+          </p>
           <p
             class="mt-4 fw-light"
           >
@@ -192,11 +192,11 @@ exports[`Index Page Should render index page 1`] = `
             src="/assets/landing/choose-02.svg"
             width="259"
           />
-          <h4
-            class="mt-3 fw-bold"
+          <p
+            class="mt-3 fw-bold h3"
           >
             Support
-          </h4>
+          </p>
           <p
             class="mt-4 fw-light"
           >
@@ -213,11 +213,11 @@ exports[`Index Page Should render index page 1`] = `
             src="/assets/landing/choose-03.svg"
             width="93"
           />
-          <h4
-            class="mt-3 fw-bold"
+          <p
+            class="mt-3 fw-bold h3"
           >
             Work Experience
-          </h4>
+          </p>
           <p
             class="mt-4 fw-light"
           >
@@ -304,7 +304,7 @@ exports[`Index Page Should render index page 1`] = `
               Each lesson in our curriculum is designed to be hands on and you will learn by working through the exercises in the curriculum. All hosting will be provided for you so you can proudly share your accomplishments with the world without spending a penny. The exercises and challenges are designed to be difficult to force you to ask questions. Students who have passed the lessons are available in the chatrooms to help you with your questions.
                
               <span
-                class="fw-light text-warning"
+                class="fw-bold"
               >
                 (Meetups are currently unavailable due to COVID-19)
               </span>

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -66,7 +66,7 @@ const LandingPage: React.FC = () => {
               alt="Modern curriculum"
               width="163"
             />
-            <h4 className="mt-3 fw-bold">Modern Curriculum</h4>
+            <p className="mt-3 fw-bold h3">Modern Curriculum</p>
             <p className="mt-4 fw-light">
               First the curriculum will help you achieve mastery in JavaScript.
               Using JavaScript, you will learn about different branches of
@@ -82,7 +82,7 @@ const LandingPage: React.FC = () => {
               alt="Support"
               width="259"
             />
-            <h4 className="mt-3 fw-bold">Support</h4>
+            <p className="mt-3 fw-bold h3">Support</p>
             <p className="mt-4 fw-light">
               One of the most important skills in a challenging workplace is
               knowing how to ask for help. Our curriculum is intentionally
@@ -98,7 +98,7 @@ const LandingPage: React.FC = () => {
               alt="Work Experience"
               layout="fixed"
             />
-            <h4 className="mt-3 fw-bold">Work Experience</h4>
+            <p className="mt-3 fw-bold h3">Work Experience</p>
             <p className="mt-4 fw-light">
               Once you have completed our curriculum and learned to communicate
               effectively, you will be invited to contribute to this open-source
@@ -165,7 +165,7 @@ const LandingPage: React.FC = () => {
                 The exercises and challenges are designed to be difficult to
                 force you to ask questions. Students who have passed the lessons
                 are available in the chatrooms to help you with your questions.{' '}
-                <span className="fw-light text-warning">
+                <span className="fw-bold">
                   (Meetups are currently unavailable due to COVID-19)
                 </span>
               </p>

--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,10 @@ const moduleExports = {
   pageExtensions: ['tsx', 'js', 'jsx', 'mdx', 'ts'],
   images: {
     domains: ['cdn.discordapp.com']
+  },
+  i18n: {
+    locales: ['en'],
+    defaultLocale: 'en'
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-app/issues/1891

This PR replaces `h3` headings with a `p` element and set the lang attribute to the `html` element as `en`.

The reason behind these changes can be found here:

- https://www.w3.org/WAI/tutorials/page-structure/headings/
- https://dequeuniversity.com/rules/axe/3.5/html-has-lang

Before:

![image](https://user-images.githubusercontent.com/35906419/170589601-bb552906-9959-42a5-ad22-9fa5a6bda58d.png)

After:

![image](https://user-images.githubusercontent.com/35906419/170589648-088b0b11-57dd-49a8-9101-c0cfabd54751.png)
