### PR TITLE
fixed PTMono-Bold font file name

### DIFF
--- a/scss/fonts.scss
+++ b/scss/fonts.scss
@@ -6,7 +6,7 @@
 @font-face {
   font-family: 'PT Mono';
   font-weight: bold;
-  src: url('/fonts/PTMono-bold.woff') format('woff');
+  src: url('/fonts/PTMono-Bold.woff') format('woff');
 }
 
 // Used for code


### PR DESCRIPTION
This font was not loading correctly due to the wrong file name. Fixed it so it can load as expected.

![image](https://user-images.githubusercontent.com/16023489/170801448-306d3686-c866-405f-b3f3-b37ab6c6a42b.png)

This is what the navbar looked like with my default system font

![image](https://user-images.githubusercontent.com/16023489/170801475-14715625-4f8f-4f13-80cb-72339499d570.png)
