### PR TITLE
Revert "build(deps-dev): Bump sass-loader from 10.2.1 to 13.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "remark-gfm": "^3.0.1",
     "remark-slug": "^7.0.1",
     "remark-toc": "^8.0.1",
-    "sass-loader": "^13.0.0",
+    "sass-loader": "^10.2.1",
     "storybook-addon-next-router": "^4.0.0",
     "svgo": "^2.8.0",
     "ts-node": "^10.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15642,13 +15642,16 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sass-loader@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.0.0.tgz#0b4bff0289951ed21240bca54453eca3dbda1713"
-  integrity sha512-IHCFecI+rbPvXE2zO/mqdVFe8MU7ElGrwga9hh2H65Ru4iaBJAMRteum1c4Gsxi9Cq1FOtTEDd6+/AEYuQDM4Q==
+sass-loader@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.2.1.tgz#17e51df313f1a7a203889ce8ff91be362651276e"
+  integrity sha512-RRvWl+3K2LSMezIsd008ErK4rk6CulIMSwrcc2aZvjymUgKo/vjXGp1rSWmfTUX7bblEOz8tst4wBwWtCGBqKA==
   dependencies:
     klona "^2.0.4"
+    loader-utils "^2.0.0"
     neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    semver "^7.3.2"
 
 sass@^1.52.1:
   version "1.52.1"


### PR DESCRIPTION
Reverts garageScript/c0d3-app#1883

sass-loader v13.0.0 unable to build storybook. The issue is tracked in https://github.com/garageScript/c0d3-app/issues/1906