### PR TITLE
build(deps): Bump @sentry/nextjs from 6.19.7 to 7.0.0

### DIFF
--- a/helpers/apolloLogPlugin.ts
+++ b/helpers/apolloLogPlugin.ts
@@ -5,6 +5,10 @@ import {
 } from 'apollo-server-plugin-base'
 
 import * as Sentry from '@sentry/nextjs'
+import { SeverityLevel } from '@sentry/types'
+import { BaseContext } from 'next/dist/shared/lib/utils'
+
+const levelDebug: SeverityLevel = 'debug'
 
 /**
  * Plugin to capture errors during apollo transaction and send a copy to sentry/logflare
@@ -12,7 +16,7 @@ import * as Sentry from '@sentry/nextjs'
 export const apolloLogPlugin: ApolloServerPlugin = {
   requestDidStart<TContext>(
     _: GraphQLRequestContext<TContext>
-  ): GraphQLRequestListener<TContext> {
+  ): GraphQLRequestListener<BaseContext> {
     return {
       didEncounterErrors(ctx) {
         for (const err of ctx.errors) {
@@ -25,7 +29,7 @@ export const apolloLogPlugin: ApolloServerPlugin = {
               scope.addBreadcrumb({
                 category: 'query-path',
                 message: err.path.join(' > '),
-                level: Sentry.Severity.Debug
+                level: levelDebug
               })
             }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@primer/octicons-react": "^17.2.0",
     "@prisma/client": "^2.29.1",
     "@quixo3/prisma-session-store": "^3.1.5",
-    "@sentry/nextjs": "^6.19.7",
+    "@sentry/nextjs": "^7.0.0",
     "apollo-server-micro": "^2.25.4",
     "apollo3-cache-persist": "^0.14.0",
     "bcrypt": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,20 +2789,20 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sentry/browser@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.19.7.tgz#a40b6b72d911b5f1ed70ed3b4e7d4d4e625c0b5f"
-  integrity sha512-oDbklp4O3MtAM4mtuwyZLrgO1qDVYIujzNJQzXmi9YzymJCuzMLSRDvhY83NNDCRxf0pds4DShgYeZdbSyKraA==
+"@sentry/browser@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.0.0.tgz#c26517d9e88215494cf3a196903eafe64170f494"
+  integrity sha512-XJeQA/CIocrmShpfVcccJ2RvZbWZy+OustSbgLP5Vk+ZnzbqKQo1zQ92jO/dUoVIsl5dWpUaOKfT6gXmORf4vQ==
   dependencies:
-    "@sentry/core" "6.19.7"
-    "@sentry/types" "6.19.7"
-    "@sentry/utils" "6.19.7"
+    "@sentry/core" "7.0.0"
+    "@sentry/types" "7.0.0"
+    "@sentry/utils" "7.0.0"
     tslib "^1.9.3"
 
-"@sentry/cli@^1.73.0":
-  version "1.73.0"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.73.0.tgz#0d0bce913e0060ae192741c6693c57e50078c886"
-  integrity sha512-n4YINqmoncGUkLEpd4WuW+oD+aoUyQPhRbSBSYkbCFxPPmopn1VExCB2Vvzwj7vjXYRRGkix6keBMS0LLs3A3Q==
+"@sentry/cli@^1.74.4":
+  version "1.74.4"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.74.4.tgz#7df82f68045a155e1885bfcbb5d303e5259eb18e"
+  integrity sha512-BMfzYiedbModsNBJlKeBOLVYUtwSi99LJ8gxxE4Bp5N8hyjNIN0WVrozAVZ27mqzAuy6151Za3dpmOLO86YlGw==
   dependencies:
     https-proxy-agent "^5.0.0"
     mkdirp "^0.5.5"
@@ -2810,117 +2810,112 @@
     npmlog "^4.1.2"
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
+    which "^2.0.2"
 
-"@sentry/core@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.19.7.tgz#156aaa56dd7fad8c89c145be6ad7a4f7209f9785"
-  integrity sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==
+"@sentry/core@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.0.0.tgz#8514aad3ad81ce018e1d4a956407530a8c1286d0"
+  integrity sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==
   dependencies:
-    "@sentry/hub" "6.19.7"
-    "@sentry/minimal" "6.19.7"
-    "@sentry/types" "6.19.7"
-    "@sentry/utils" "6.19.7"
+    "@sentry/hub" "7.0.0"
+    "@sentry/types" "7.0.0"
+    "@sentry/utils" "7.0.0"
     tslib "^1.9.3"
 
-"@sentry/hub@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.19.7.tgz#58ad7776bbd31e9596a8ec46365b45cd8b9cfd11"
-  integrity sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==
+"@sentry/hub@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.0.0.tgz#9ffcea4ae497d9e8440683bdc72eb4b30f20d24d"
+  integrity sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==
   dependencies:
-    "@sentry/types" "6.19.7"
-    "@sentry/utils" "6.19.7"
+    "@sentry/types" "7.0.0"
+    "@sentry/utils" "7.0.0"
     tslib "^1.9.3"
 
-"@sentry/integrations@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.19.7.tgz#e6e126b692077c8731644224c754012bed65b425"
-  integrity sha512-yNeeFyuygJaV7Mdc5qWuDa13xVj5mVdECaaw2Xs4pfeHaXmRfRzZY17N8ypWFegKWxKBHynyQRMD10W5pBwJvA==
+"@sentry/integrations@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.0.0.tgz#89e5008b474c0221ab75f0ad4fbc24f56204c8a1"
+  integrity sha512-5/JqYIBpe6lxMqxjsBr2NB2oWPe+46xolcXYSvgUYI7vryIiyW+jhXINma1hEPxXDHntiYN9aT4xzFgdNv1MHA==
   dependencies:
-    "@sentry/types" "6.19.7"
-    "@sentry/utils" "6.19.7"
+    "@sentry/types" "7.0.0"
+    "@sentry/utils" "7.0.0"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/minimal@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.19.7.tgz#b3ee46d6abef9ef3dd4837ebcb6bdfd01b9aa7b4"
-  integrity sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==
+"@sentry/nextjs@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/nextjs/-/nextjs-7.0.0.tgz#d9ea708028bc71b4b0b86a0141fee4c4887174a0"
+  integrity sha512-H0cV1rnippq3jBqnIF22wZLOaJzyPS/N2FrNxuvNLn+pY38mmtPF8kNpdTweDoM/RD7V7z+LuFE/uD8V75zZKQ==
   dependencies:
-    "@sentry/hub" "6.19.7"
-    "@sentry/types" "6.19.7"
+    "@sentry/core" "7.0.0"
+    "@sentry/hub" "7.0.0"
+    "@sentry/integrations" "7.0.0"
+    "@sentry/node" "7.0.0"
+    "@sentry/react" "7.0.0"
+    "@sentry/tracing" "7.0.0"
+    "@sentry/types" "7.0.0"
+    "@sentry/utils" "7.0.0"
+    "@sentry/webpack-plugin" "1.18.9"
     tslib "^1.9.3"
 
-"@sentry/nextjs@^6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/nextjs/-/nextjs-6.19.7.tgz#2c40692d89a99ec1382189f11702b1498c91fb77"
-  integrity sha512-029gpqhR6gHF7zfE9oxFOf3Zm68CShDu8/6azC8mwfIfJtyLC9dqztJJi48j0Uxs+sR1TEkN5Dw3wZbfWtFd8g==
+"@sentry/node@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.0.0.tgz#771169162b5ab021ea691f329a80aaf980d5b265"
+  integrity sha512-YfmPldRH2oO3OCsu5kqnzVbeMa2Tr9Qf4t8iy7AuYKPok5ossIeZCBzjTBRw/g0wJL+I5WsxHVrt2YUuLGYBSQ==
   dependencies:
-    "@sentry/core" "6.19.7"
-    "@sentry/hub" "6.19.7"
-    "@sentry/integrations" "6.19.7"
-    "@sentry/node" "6.19.7"
-    "@sentry/react" "6.19.7"
-    "@sentry/tracing" "6.19.7"
-    "@sentry/utils" "6.19.7"
-    "@sentry/webpack-plugin" "1.18.8"
-    tslib "^1.9.3"
-
-"@sentry/node@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.19.7.tgz#32963b36b48daebbd559e6f13b1deb2415448592"
-  integrity sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==
-  dependencies:
-    "@sentry/core" "6.19.7"
-    "@sentry/hub" "6.19.7"
-    "@sentry/types" "6.19.7"
-    "@sentry/utils" "6.19.7"
+    "@sentry/core" "7.0.0"
+    "@sentry/hub" "7.0.0"
+    "@sentry/types" "7.0.0"
+    "@sentry/utils" "7.0.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/react@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.19.7.tgz#58cc2d6da20f7d3b0df40638dfbbbc86c9c85caf"
-  integrity sha512-VzJeBg/v41jfxUYPkH2WYrKjWc4YiMLzDX0f4Zf6WkJ4v3IlDDSkX6DfmWekjTKBho6wiMkSNy2hJ1dHfGZ9jA==
+"@sentry/react@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.0.0.tgz#186a8cf7625b51372b8653450d6f73698d2a6425"
+  integrity sha512-zF/fUjyWXAjycS6WEv4BntKpp/CzHr7Qv0qB1n1EITvdMAYWfJTOhXdIKF/U9Rq/OmM0Gd8SthFWaEAJWzCgZQ==
   dependencies:
-    "@sentry/browser" "6.19.7"
-    "@sentry/minimal" "6.19.7"
-    "@sentry/types" "6.19.7"
-    "@sentry/utils" "6.19.7"
+    "@sentry/browser" "7.0.0"
+    "@sentry/types" "7.0.0"
+    "@sentry/utils" "7.0.0"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/tracing@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.19.7.tgz#54bb99ed5705931cd33caf71da347af769f02a4c"
-  integrity sha512-ol4TupNnv9Zd+bZei7B6Ygnr9N3Gp1PUrNI761QSlHtPC25xXC5ssSD3GMhBgyQrcvpuRcCFHVNNM97tN5cZiA==
+"@sentry/tracing@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.0.0.tgz#17e3fac487edef63fbe8b1bbfb202118952b2956"
+  integrity sha512-eUHER2RWzm9OtFKQZIr5EwTGM3IU0xJ7l60rnAEbgW5b1bzWC0k/J6EeXeBBfGq7wric/BjH0WKQOnixtXUBpw==
   dependencies:
-    "@sentry/hub" "6.19.7"
-    "@sentry/minimal" "6.19.7"
-    "@sentry/types" "6.19.7"
-    "@sentry/utils" "6.19.7"
+    "@sentry/hub" "7.0.0"
+    "@sentry/types" "7.0.0"
+    "@sentry/utils" "7.0.0"
     tslib "^1.9.3"
 
-"@sentry/types@6.19.7", "@sentry/types@^6.11.0":
+"@sentry/types@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.0.0.tgz#a564b9762a8f5573ad17259093988da09be1db23"
+  integrity sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA==
+
+"@sentry/types@^6.11.0":
   version "6.19.7"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
   integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
 
-"@sentry/utils@6.19.7":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.19.7.tgz#6edd739f8185fd71afe49cbe351c1bbf5e7b7c79"
-  integrity sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==
+"@sentry/utils@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.0.0.tgz#c83d0535f58457067a4156e5558223afd256b747"
+  integrity sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==
   dependencies:
-    "@sentry/types" "6.19.7"
+    "@sentry/types" "7.0.0"
     tslib "^1.9.3"
 
-"@sentry/webpack-plugin@1.18.8":
-  version "1.18.8"
-  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.18.8.tgz#247a73a0aa9e28099a736bbe89ca0d35cbac7636"
-  integrity sha512-PtKr0NL62b5L3kPFGjwSNbIUwwcW5E5G6bQxAYZGpkgL1MFPnS4ND0SAsySuX0byQJRFFium5A19LpzyvQZSlQ==
+"@sentry/webpack-plugin@1.18.9":
+  version "1.18.9"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.18.9.tgz#acb48c0f96fdb9e73f1e1db374ea31ded6d883a8"
+  integrity sha512-+TrenJrgFM0QTOwBnw0ZXWMvc0PiOebp6GN5EbGEx3JPCQqXOfXFzCaEjBtASKRgcNCL7zGly41S25YR6Hm+jw==
   dependencies:
-    "@sentry/cli" "^1.73.0"
+    "@sentry/cli" "^1.74.4"
 
 "@sinclair/typebox@^0.23.3":
   version "0.23.4"
@@ -18025,7 +18020,7 @@ which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
Fixes https://github.com/garageScript/c0d3-app/pull/1915

Bumps [@sentry/nextjs](https://github.com/getsentry/sentry-javascript) from 6.19.7 to 7.0.0.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/getsentry/sentry-javascript/releases"><code>@​sentry/nextjs</code>'s releases</a>.</em></p>
<blockquote>
<h2>7.0.0</h2>
<p>Version 7 of the Sentry JavaScript SDK brings a variety of features and fixes including bundle size and performance improvements, brand new integrations, support for the attachments API, and key bug fixes.</p>
<p>This release does not change or remove any top level public API methods (<code>captureException</code>, <code>captureMessage</code>), and only requires changes to certain configuration options or custom clients/integrations/transports.</p>
<p><strong>Note: The v7 version of the JavaScript SDK requires a self-hosted version of Sentry 20.6.0 or higher. If you are using a version of <a href="https://develop.sentry.dev/self-hosted/">self-hosted Sentry</a> (aka onpremise) older than <code>20.6.0</code> then you will need to <a href="https://develop.sentry.dev/self-hosted/releases/">upgrade</a>.</strong></p>
<p>For detailed overview of all the changes, please see our <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#upgrading-from-6x-to-7x">v7 migration guide</a>.</p>
<h3>Breaking Changes</h3>
<p>If you are a regular consumer of the Sentry JavaScript SDK you only need to focus on the general items. The internal breaking changes are aimed at libraries that build on top of and extend the JavaScript SDK (like <a href="https://github.com/getsentry/sentry-electron/"><code>@sentry/electron</code></a> or <a href="https://github.com/getsentry/sentry-react-native/"><code>@sentry/react-native</code></a>).</p>
<h4>General</h4>
<ul>
<li><a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#moving-to-es6-for-commonjs-files">Updated CommonJS distributions to use ES6 by default</a>. If you need to support Internet Explorer 11 or old Node.js versions, we recommend using a preprocessing tool like <a href="https://babeljs.io/">Babel</a> to convert Sentry packages to ES5. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5005">#5005</a>)</li>
<li>Default <code>bundle.min.js</code> to ES6 instead of ES5. <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#renaming-of-cdn-bundles">ES5 bundles are still available at <code>bundle.es5.min.js</code></a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4958">#4958</a>)</li>
<li>Updated build system to use TypeScript 3.8.3 (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4895">#4895</a>)</li>
<li>Deprecated <code>Severity</code> enum for bundle size reasons. <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#severity-severitylevel-and-severitylevels">Please use string literals instead</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4926">#4926</a>)</li>
<li>Removed <code>critical</code> Severity level. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5032">#5032</a>)</li>
<li><code>whitelistUrls</code> and <code>blacklistUrls</code> have been renamed to <code>allowUrls</code> and <code>denyUrls</code> in the <code>Sentry.init()</code> options. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4850">#4850</a>)</li>
<li><code>BaseClient</code> and it's child classes now require <code>transport</code>, <code>stackParser</code>, and <code>integrations</code> to be <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#explicit-client-options">explicitly passed in</a>. This was done to improve tree-shakability. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4927">#4927</a>)</li>
<li>Updated package distribution structure and stopped distributing CDN bundles through <code>@sentry/*</code> npm packages. <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#restructuring-of-package-content">See details in our migration docs</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4900">#4900</a>) (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4901">#4901</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#transport-changes">Simplified <code>Transport</code> API</a>. This means <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#custom-transports">custom transports will have to be adjusted accordingly</a>.</li>
<li>Updated how <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#node-transport-changes">Node Transport Options are passed down</a>.</li>
<li>Start propogating <a href="https://www.w3.org/TR/baggage/"><code>baggage</code> HTTP header</a> alongside <code>sentry-trace</code> header to <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#propagation-of-baggage-header">propogate additional tracing related information</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5133">#5133</a>)</li>
<li>Renamed <code>registerRequestInstrumentation</code> export to <code>instrumentOutgoingRequests</code> in <code>@sentry/tracing</code>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4859">#4859</a>)</li>
<li>Renamed <code>UserAgent</code> integration to <code>HttpContext</code>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5027">#5027</a>)</li>
<li>Replaced <code>BrowserTracing</code> integration's <code>maxTransactionDuration</code> option with <code>finalTimeout</code> option in the <code>@sentry/tracing</code> package and reset <code>idleTimeout</code> based on activities count. This should improve accuracy of web-vitals like LCP by 20-30%. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5044">#5044</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#sentry-angular-sdk-changes">Updated <code>@sentry/angular</code> to be compiled by the angular compiler</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4641">#4641</a>)</li>
<li>Made tracing package treeshakable (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5166">#5166</a>)</li>
<li>Removed support for <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#dropping-support-for-nodejs-v6">Node v6</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4851">#4851</a>)</li>
<li>Removed <code>@sentry/minimal</code> package in favour of using <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#removal-of-sentryminimal"><code>@sentry/hub</code></a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4971">#4971</a>)</li>
<li>Removed support for Opera browser pre v15 (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4923">#4923</a>)</li>
<li>Removed <code>ignoreSentryErrors</code> option from AWS lambda SDK. Errors originating from the SDK will now <em>always</em> be caught internally. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4994">#4994</a>)</li>
<li>Removed <code>Integrations.BrowserTracing</code> export from <code>@sentry/nextjs</code>. Please import <code>BrowserTracing</code> from <code>@sentry/nextjs</code> directly.</li>
<li>Removed static <code>id</code> property from <code>BrowserTracing</code> integration.</li>
<li>Removed <code>SDK_NAME</code> export from <code>@sentry/browser</code>, <code>@sentry/node</code>, <code>@sentry/tracing</code> and <code>@sentry/vue</code> packages. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5040">#5040</a>)</li>
<li>Removed <code>Angular</code>, <code>Ember</code>, and <code>Vue</code> integrations from <code>@sentry/integrations</code> <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#removal-of-old-platform-integrations-from-sentryintegrations-package">in favour of the explicit framework packages: <code>@sentry/angular</code>, <code>@sentry/ember</code>, and <code>@sentry/vue</code></a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4893">#4893</a>)</li>
<li>Removed <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#removed-enums">enums <code>Status</code>, <code>RequestSessionStatus</code>, and <code>SessionStatus</code></a>. Deprecated <a href="https://github.com/getsentry/sentry-javascript/blob/HEAD/MIGRATION.md#deprecated-enums">enums <code>SpanStatus</code> and <code>Severity</code></a>. This was done to save on bundle size. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4891">#4891</a>) (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4889">#4889</a>) (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4890">#4890</a>)</li>
<li>Removed support for deprecated <code>@sentry/apm</code> package. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4845">#4845</a>)</li>
<li>Removed deprecated <code>user</code> field from DSN interface. <code>publicKey</code> should be used instead. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4864">#4864</a>)</li>
<li>Removed deprecated <code>getActiveDomain</code> method and <code>DomainAsCarrier</code> type from <code>@sentry/hub</code>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4858">#4858</a>)</li>
<li>Removed <code>eventStatusFromHttpCode</code> to save on bundle size.</li>
<li>Removed usage of deprecated <code>event.stacktrace</code> field. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4885">#4885</a>)</li>
<li>Removed raven-node backward-compat code (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4942">#4942</a>)</li>
<li>Removed <code>showReportDialog</code> method on <code>BrowserClient</code> (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4973">#4973</a>)</li>
<li>Removed deprecated <code>startSpan</code> and <code>child</code> methods (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4849">#4849</a>)</li>
<li>Removed deprecated <code>frameContextLines</code> options (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4884">#4884</a>)</li>
<li>Removed <code>Sentry</code> from window in the Gatsby SDK (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4857">#4857</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/getsentry/sentry-javascript/blob/master/CHANGELOG.md"><code>@​sentry/nextjs</code>'s changelog</a>.</em></p>
<blockquote>
<h2>7.0.0</h2>
<p>Version 7 of the Sentry JavaScript SDK brings a variety of features and fixes including bundle size and performance improvements, brand new integrations, support for the attachments API, and key bug fixes.</p>
<p>This release does not change or remove any top level public API methods (<code>captureException</code>, <code>captureMessage</code>), and only requires changes to certain configuration options or custom clients/integrations/transports.</p>
<p><strong>Note: The v7 version of the JavaScript SDK requires a self-hosted version of Sentry 20.6.0 or higher. If you are using a version of <a href="https://develop.sentry.dev/self-hosted/">self-hosted Sentry</a> (aka onpremise) older than <code>20.6.0</code> then you will need to <a href="https://develop.sentry.dev/self-hosted/releases/">upgrade</a>.</strong></p>
<p>For detailed overview of all the changes, please see our <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#upgrading-from-6x-to-7x">v7 migration guide</a>.</p>
<h3>Breaking Changes</h3>
<p>If you are a regular consumer of the Sentry JavaScript SDK you only need to focus on the general items. The internal breaking changes are aimed at libraries that build on top of and extend the JavaScript SDK (like <a href="https://github.com/getsentry/sentry-electron/"><code>@sentry/electron</code></a> or <a href="https://github.com/getsentry/sentry-react-native/"><code>@sentry/react-native</code></a>).</p>
<h4>General</h4>
<ul>
<li><a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#moving-to-es6-for-commonjs-files">Updated CommonJS distributions to use ES6 by default</a>. If you need to support Internet Explorer 11 or old Node.js versions, we recommend using a preprocessing tool like <a href="https://babeljs.io/">Babel</a> to convert Sentry packages to ES5. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5005">#5005</a>)</li>
<li>Default <code>bundle.min.js</code> to ES6 instead of ES5. <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#renaming-of-cdn-bundles">ES5 bundles are still available at <code>bundle.es5.min.js</code></a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4958">#4958</a>)</li>
<li>Updated build system to use TypeScript 3.8.3 (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4895">#4895</a>)</li>
<li>Deprecated <code>Severity</code> enum for bundle size reasons. <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#severity-severitylevel-and-severitylevels">Please use string literals instead</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4926">#4926</a>)</li>
<li>Removed <code>critical</code> Severity level. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5032">#5032</a>)</li>
<li><code>whitelistUrls</code> and <code>blacklistUrls</code> have been renamed to <code>allowUrls</code> and <code>denyUrls</code> in the <code>Sentry.init()</code> options. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4850">#4850</a>)</li>
<li><code>BaseClient</code> and it's child classes now require <code>transport</code>, <code>stackParser</code>, and <code>integrations</code> to be <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#explicit-client-options">explicitly passed in</a>. This was done to improve tree-shakability. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4927">#4927</a>)</li>
<li>Updated package distribution structure and stopped distributing CDN bundles through <code>@sentry/*</code> npm packages. <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#restructuring-of-package-content">See details in our migration docs.</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4900">#4900</a>) (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4901">#4901</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#transport-changes">Simplified <code>Transport</code> API</a>. This means <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#custom-transports">custom transports will have to be adjusted accordingly.</a>.</li>
<li>Updated how <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#node-transport-changes">Node Transport Options are passed down</a>.</li>
<li>Start propogating <a href="https://www.w3.org/TR/baggage/"><code>baggage</code> HTTP header</a> alongside <code>sentry-trace</code> header to <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#propagation-of-baggage-header">propogate additional tracing related information.</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5133">#5133</a>)</li>
<li>Renamed <code>registerRequestInstrumentation</code> export to <code>instrumentOutgoingRequests</code> in <code>@sentry/tracing</code>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4859">#4859</a>)</li>
<li>Renamed <code>UserAgent</code> integration to <code>HttpContext</code>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5027">#5027</a>)</li>
<li>Replaced <code>BrowserTracing</code> integration's <code>maxTransactionDuration</code> option with <code>finalTimeout</code> option in the <code>@sentry/tracing</code> package and reset <code>idleTimeout</code> based on activities count. This should improve accuracy of web-vitals like LCP by 20-30%. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5044">#5044</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#sentry-angular-sdk-changes">Updated <code>@sentry/angular</code> to be compiled by the angular compiler</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4641">#4641</a>)</li>
<li>Made tracing package treeshakable (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5166">#5166</a>)</li>
<li>Removed support for <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#dropping-support-for-nodejs-v6">Node v6</a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4851">#4851</a>)</li>
<li>Removed <code>@sentry/minimal</code> package in favour of using <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#removal-of-sentryminimal"><code>@sentry/hub</code></a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4971">#4971</a>)</li>
<li>Removed support for Opera browser pre v15 (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4923">#4923</a>)</li>
<li>Removed <code>ignoreSentryErrors</code> option from AWS lambda SDK. Errors originating from the SDK will now <em>always</em> be caught internally. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4994">#4994</a>)</li>
<li>Removed <code>Integrations.BrowserTracing</code> export from <code>@sentry/nextjs</code>. Please import <code>BrowserTracing</code> from <code>@sentry/nextjs</code> directly.</li>
<li>Removed static <code>id</code> property from <code>BrowserTracing</code> integration.</li>
<li>Removed <code>SDK_NAME</code> export from <code>@sentry/browser</code>, <code>@sentry/node</code>, <code>@sentry/tracing</code> and <code>@sentry/vue</code> packages. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5040">#5040</a>)</li>
<li>Removed <code>Angular</code>, <code>Ember</code>, and <code>Vue</code> integrations from <code>@sentry/integrations</code> <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#removal-of-old-platform-integrations-from-sentryintegrations-package">in favour of the explicit framework packages: <code>@sentry/angular</code>, <code>@sentry/ember</code>, and <code>@sentry/vue</code></a>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4893">#4893</a>)</li>
<li>Removed <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#removed-enums">enums <code>Status</code>, <code>RequestSessionStatus</code>, and <code>SessionStatus</code>.</a>. Deprecated <a href="https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#deprecated-enums">enums <code>SpanStatus</code> and <code>Severity</code></a>. This was done to save on bundle size. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4891">#4891</a>) (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4889">#4889</a>) (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4890">#4890</a>)</li>
<li>Removed support for deprecated <code>@sentry/apm</code> package. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4845">#4845</a>)</li>
<li>Removed deprecated <code>user</code> field from DSN interface. <code>publicKey</code> should be used instead. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4864">#4864</a>)</li>
<li>Removed deprecated <code>getActiveDomain</code> method and <code>DomainAsCarrier</code> type from <code>@sentry/hub</code>. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4858">#4858</a>)</li>
<li>Removed <code>eventStatusFromHttpCode</code> to save on bundle size.</li>
<li>Removed usage of deprecated <code>event.stacktrace</code> field. (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4885">#4885</a>)</li>
<li>Removed raven-node backward-compat code (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4942">#4942</a>)</li>
<li>Removed <code>showReportDialog</code> method on <code>BrowserClient</code> (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4973">#4973</a>)</li>
<li>Removed deprecated <code>startSpan</code> and <code>child</code> methods (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4849">#4849</a>)</li>
<li>Removed deprecated <code>frameContextLines</code> options (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/4884">#4884</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/4cc07f6637a611d95d76121bf24152f6b38c51ab"><code>4cc07f6</code></a> release: 7.0.0</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/ca31aa34a8764865adc4037a8c7854b57f4c7d83"><code>ca31aa3</code></a> meta: 7.0.0 CHANGELOG (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5177">#5177</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/31be2befe66f43333902d7b257fe08b9ef8c9a7d"><code>31be2be</code></a> ref(node): Allow node stack parser to work in browser context  (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5135">#5135</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/8fcf3ffc9bd41ca58a994e21d49045b4ac6b6c71"><code>8fcf3ff</code></a> release: 7.0.0-rc.0</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/c946b2348a1e712273d40f46389bf0ccb52ffa1b"><code>c946b23</code></a> meta: Update 7.0.0-rc.0 CHANGELOG (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5165">#5165</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/0e1f578c60dc39926bc93394e07e77fc6a3f6922"><code>0e1f578</code></a> feat(nextjs): Make tracing package treeshakable (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5166">#5166</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/e76c2479de9e3ad9d235d09f870e98701fe2f58e"><code>e76c247</code></a> ref(build): Use rollup to build AWS lambda layer (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5146">#5146</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/9b23ef3d01409d85f9776fab2653000560ac2ddb"><code>9b23ef3</code></a> ref(core): Test mutation of attachments in hint (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5140">#5140</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/918d4707c25249e27c5f8b030672d9b98dbffb34"><code>918d470</code></a> fix(utils): Fix infinite recursion in <code>dropUndefinedKeys</code> (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5163">#5163</a>)</li>
<li><a href="https://github.com/getsentry/sentry-javascript/commit/bc73dc0cacbc97a0874504ab1eff5ccc830bea7a"><code>bc73dc0</code></a> ref(core): Make hint callback argument non-optional (<a href="https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/5141">#5141</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/getsentry/sentry-javascript/compare/6.19.7...7.0.0">compare view</a></li>
</ul>
</details>
<br />