### PR TITLE
Fix Typo in JS0 lesson

### DIFF
--- a/content/lessons/js0/sublesson/functions_and_execution_context.mdx
+++ b/content/lessons/js0/sublesson/functions_and_execution_context.mdx
@@ -969,7 +969,7 @@ const nick = charlie(9, 2) // nick is 6, because charlie(9,2) returns 6
 
 ```jsx
 const massiveOrSmall = (a, b) => {
-  if (a + b > 100) return 'big'
+  if (a + b > 100) return 'massive'
   return 'small'
 }
 ```


### PR DESCRIPTION
This PR fixes a Typo in JS0 Part 2 lesson