### PR TITLE
Fix missing `<Spoiler>` tag in JS3 Objects page

### DIFF
--- a/content/lessons/js3/sublesson/objects.mdx
+++ b/content/lessons/js3/sublesson/objects.mdx
@@ -2400,6 +2400,8 @@ to save the old one into a variable first so you can keep using its
 functionality.
 	
 </Spoiler>
+	
+<Spoiler>
 
 1. **Tests**
 


### PR DESCRIPTION
This PR fixes the missing <Spoiler> tag that was making the CI fail.