### PR TITLE
feat: Add flag columns to Exercise

### DIFF
--- a/prisma/migrations/20220616205126_exercise_flag/migration.sql
+++ b/prisma/migrations/20220616205126_exercise_flag/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "exercises" ADD COLUMN     "flagReason" TEXT,
+ADD COLUMN     "flagged" BOOLEAN;

--- a/prisma/migrations/20220617182137_exercise_flag_2/migration.sql
+++ b/prisma/migrations/20220617182137_exercise_flag_2/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `flagged` on the `exercises` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "exercises" DROP COLUMN "flagged",
+ADD COLUMN     "flaggedAt" TIMESTAMP(3);

--- a/prisma/migrations/20220618063820_exercise_flag_3/migration.sql
+++ b/prisma/migrations/20220618063820_exercise_flag_3/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "exercises" ADD COLUMN     "flaggedById" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "exercises" ADD FOREIGN KEY ("flaggedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -176,18 +176,18 @@ model Module {
 }
 
 model Exercise {
-  id          Int      @id @default(autoincrement())
-  createdAt   DateTime @default(now()) @db.Timestamptz(6)
-  updatedAt   DateTime @updatedAt @db.Timestamptz(6)
-  author      User     @relation(fields: [authorId], references: [id])
+  id          Int       @id @default(autoincrement())
+  createdAt   DateTime  @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime  @updatedAt @db.Timestamptz(6)
+  author      User      @relation(fields: [authorId], references: [id])
   authorId    Int
-  module      Module   @relation(fields: [moduleId], references: [id])
+  module      Module    @relation(fields: [moduleId], references: [id])
   moduleId    Int
   description String
   answer      String
   testStr     String?
   explanation String?
-  flagged     Boolean?
+  flaggedAt   DateTime?
   flagReason  String?
 
   @@map("exercises")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,7 +156,7 @@ model User {
   modules                   Module[]
   exercises                 Exercise[]
 
-  Exercise Exercise[] @relation("flaggedBy")
+  Exercise Exercise[] @relation("flaggedExercises")
   @@map("users")
 }
 
@@ -190,7 +190,7 @@ model Exercise {
   explanation String?
   flaggedAt   DateTime?
   flagReason  String?
-  flaggedBy   User?     @relation("flaggedBy", fields: [flaggedById], references: [id])
+  flaggedBy   User?     @relation("flaggedExercises", fields: [flaggedById], references: [id])
   flaggedById Int?
 
   @@map("exercises")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,8 @@ model Exercise {
   answer      String
   testStr     String?
   explanation String?
+  flagged     Boolean?
+  flagReason  String?
 
   @@map("exercises")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,6 +156,7 @@ model User {
   modules                   Module[]
   exercises                 Exercise[]
 
+  Exercise Exercise[] @relation("flaggedBy")
   @@map("users")
 }
 
@@ -189,6 +190,8 @@ model Exercise {
   explanation String?
   flaggedAt   DateTime?
   flagReason  String?
+  flaggedBy   User?     @relation("flaggedBy", fields: [flaggedById], references: [id])
+  flaggedById Int?
 
   @@map("exercises")
 }


### PR DESCRIPTION
Related to #1990

This PR adds the `flagged`, `flaggedBy`, and `flaggedReason`. `flagged` refers to exercises that were flagged by students or mentors to be reviewed by the Admin. `flaggedReason` is the reason for the flag. `flaggedBy` is the user who flagged it.