### PR TITLE
feat: Update exercise flaggedAt property

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -264,6 +264,7 @@ export type MutationUpdateExerciseArgs = {
   answer: Scalars['String']
   description: Scalars['String']
   explanation?: InputMaybe<Scalars['String']>
+  flaggedAt?: InputMaybe<Scalars['String']>
   id: Scalars['Int']
   moduleId: Scalars['Int']
   testStr?: InputMaybe<Scalars['String']>

--- a/graphql/resolvers/exerciseCrud.ts
+++ b/graphql/resolvers/exerciseCrud.ts
@@ -41,7 +41,8 @@ export const updateExercise = async (
 ): Promise<Exercise> => {
   const authorId = req.user?.id
   if (!authorId) throw new Error('No user')
-  const { id, testStr, description, answer, moduleId, explanation } = args
+  const { id, testStr, description, answer, moduleId, explanation, flaggedAt } =
+    args
   const exercise = await prisma.exercise.findUnique({
     where: {
       id
@@ -58,7 +59,7 @@ export const updateExercise = async (
     where: {
       id
     },
-    data: { explanation, testStr, description, answer, moduleId },
+    data: { explanation, testStr, description, answer, moduleId, flaggedAt },
     include: {
       author: true,
       module: true

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -84,6 +84,7 @@ export default gql`
       answer: String!
       testStr: String
       explanation: String
+      flaggedAt: String
     ): Exercise!
     deleteExercise(id: Int!): Exercise!
     createLesson(


### PR DESCRIPTION
Closes #1999 

By merging this PR, the `updateExercise` resolver will take an optional `flaggedAt` argument that will specify if an exercise is flagged or not.