### PR TITLE
Correct review link to use lesson slug instead of lesson id in challenge end card

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1603,7 +1603,7 @@ exports[`Storyshots Components/ChallengeMaterial Final Challenge 1`] = `
           they have in the lesson and
           <a
             className="fw-bold mx-1 noUnderline"
-            href="https://www.c0d3.com/review/5"
+            href="https://www.c0d3.com/review/js0"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/components/ChallengeMaterial.test.js
+++ b/components/ChallengeMaterial.test.js
@@ -233,6 +233,7 @@ const getMockedProps = () => {
     userSubmissions: _.cloneDeep(userSubmissions),
     chatUrl: 'https://chat.c0d3.com/c0d3/channels/js0-foundations',
     lessonId: '5',
+    lessonSlug: 'js0',
     setShow: jest.fn()
   }
 }

--- a/components/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial.tsx
@@ -326,6 +326,7 @@ type ChallengeMaterialProps = {
   lessonStatus: UserLesson
   chatUrl: string
   lessonId: number
+  lessonSlug: string
   show: boolean
   setShow: React.Dispatch<React.SetStateAction<boolean>>
 }
@@ -336,6 +337,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   lessonStatus,
   chatUrl,
   lessonId,
+  lessonSlug,
   show,
   setShow
 }) => {
@@ -445,7 +447,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
             starGiven={lessonStatus.starGiven || ''}
             imageSrc="icon-challenge-complete.jpg"
             chatUrl={chatUrl}
-            reviewUrl={`https://www.c0d3.com/review/${lessonId}`}
+            reviewUrl={`https://www.c0d3.com/review/${lessonSlug}`}
           />
         )}
       </div>

--- a/pages/curriculum/[lessonSlug].tsx
+++ b/pages/curriculum/[lessonSlug].tsx
@@ -74,6 +74,7 @@ const Challenges: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
                 userSubmissions={userSubmissions}
                 lessonStatus={currentLessonStatus}
                 lessonId={currentLesson.id}
+                lessonSlug={currentLesson.slug}
                 chatUrl={currentLesson.chatUrl!}
                 show={show}
                 setShow={setShow}

--- a/stories/components/ChallengeMaterial.stories.tsx
+++ b/stories/components/ChallengeMaterial.stories.tsx
@@ -60,6 +60,7 @@ export const Basic: React.FC = () => (
       lessonStatus={lessonStatus}
       chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
       lessonId={5}
+      lessonSlug={'js0'}
       show={false}
       setShow={() => {}}
     />
@@ -137,6 +138,7 @@ export const WithDiff: React.FC = () => (
       lessonStatus={lessonStatus}
       chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
       lessonId={5}
+      lessonSlug={'js0'}
       show={false}
       setShow={() => {}}
     />
@@ -225,6 +227,7 @@ export const WithComments: React.FC = () => (
       lessonStatus={lessonStatus}
       chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
       lessonId={5}
+      lessonSlug={'js0'}
       show={false}
       setShow={() => {}}
     />
@@ -238,6 +241,7 @@ export const NoChallenges: React.FC = () => (
     lessonStatus={lessonStatus}
     chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
     lessonId={5}
+    lessonSlug={'js0'}
     show={false}
     setShow={() => {}}
   />
@@ -325,6 +329,7 @@ export const FinalChallenge: React.FC = () => (
       lessonStatus={{ ...lessonStatus, passedAt: 'aef' }}
       chatUrl="https://chat.c0d3.com/c0d3/channels/js0-foundations"
       lessonId={5}
+      lessonSlug={'js0'}
       show={false}
       setShow={() => {}}
     />


### PR DESCRIPTION
Correct review link to use lesson slug instead of lesson id in challenge end card. Previously lessons used id's for routing but we have since moved to slugs base on lesson name. The end card currently uses the old way which results in incorrect review link.
![image](https://user-images.githubusercontent.com/20666236/178239053-7ba20e3d-a700-4018-8b56-6d3b4abf07ce.png)
