### PR TITLE
remove unused lodash from withAdminContainer

### DIFF
--- a/containers/withAdminContainer.ts
+++ b/containers/withAdminContainer.ts
@@ -1,7 +1,6 @@
 import { Context } from '../@types/helpers'
 import { isAdmin } from '../helpers/isAdmin'
 import { withUserContainer } from './withUserContainer'
-import _ from 'lodash'
 
 //use when only checking if user is admin
 export const withAdminContainer =
@@ -19,9 +18,9 @@ export const withAdminContainer =
     return resolver(_parent, args, ctx)
   }
 
-export function withAdminUserContainer<Type, ArgsType>(
+export const withAdminUserContainer = <Type, ArgsType>(
   resolver: (_parent: void, args: ArgsType, ctx: Context) => Type,
   errorMessage?: string
-) {
+) => {
   return withUserContainer(withAdminContainer(resolver, errorMessage))
 }


### PR DESCRIPTION
**Title**: fix : withAdminContainer

**Description:** This is just a quick fix to remove unused lodash from imports on withAdminContainer. Related to PR #2219 

