### PR TITLE
Create unlinkDiscord resolver

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -137,6 +137,7 @@ export type Mutation = {
   reqPwReset: SuccessResponse
   setStar: SuccessResponse
   signup?: Maybe<AuthResponse>
+  unlinkDiscord?: Maybe<User>
   updateChallenge?: Maybe<Array<Maybe<Lesson>>>
   updateExercise: Exercise
   updateLesson: Array<Lesson>
@@ -1059,6 +1060,13 @@ export type SignupMutation = {
   } | null
 }
 
+export type UnlinkDiscordMutationVariables = Exact<{ [key: string]: never }>
+
+export type UnlinkDiscordMutation = {
+  __typename?: 'Mutation'
+  unlinkDiscord?: { __typename?: 'User'; id: number } | null
+}
+
 export type UpdateChallengeMutationVariables = Exact<{
   lessonId: Scalars['Int']
   order: Scalars['Int']
@@ -1653,6 +1661,11 @@ export type MutationResolvers<
       MutationSignupArgs,
       'email' | 'firstName' | 'lastName' | 'password' | 'username'
     >
+  >
+  unlinkDiscord?: Resolver<
+    Maybe<ResolversTypes['User']>,
+    ParentType,
+    ContextType
   >
   updateChallenge?: Resolver<
     Maybe<Array<Maybe<ResolversTypes['Lesson']>>>,
@@ -4588,6 +4601,86 @@ export type SignupMutationOptions = Apollo.BaseMutationOptions<
   SignupMutation,
   SignupMutationVariables
 >
+export const UnlinkDiscordDocument = gql`
+  mutation unlinkDiscord {
+    unlinkDiscord {
+      id
+    }
+  }
+`
+export type UnlinkDiscordMutationFn = Apollo.MutationFunction<
+  UnlinkDiscordMutation,
+  UnlinkDiscordMutationVariables
+>
+export type UnlinkDiscordProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: Apollo.MutationFunction<
+    UnlinkDiscordMutation,
+    UnlinkDiscordMutationVariables
+  >
+} & TChildProps
+export function withUnlinkDiscord<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UnlinkDiscordMutation,
+    UnlinkDiscordMutationVariables,
+    UnlinkDiscordProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    UnlinkDiscordMutation,
+    UnlinkDiscordMutationVariables,
+    UnlinkDiscordProps<TChildProps, TDataName>
+  >(UnlinkDiscordDocument, {
+    alias: 'unlinkDiscord',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useUnlinkDiscordMutation__
+ *
+ * To run a mutation, you first call `useUnlinkDiscordMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUnlinkDiscordMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [unlinkDiscordMutation, { data, loading, error }] = useUnlinkDiscordMutation({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useUnlinkDiscordMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UnlinkDiscordMutation,
+    UnlinkDiscordMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
+    UnlinkDiscordMutation,
+    UnlinkDiscordMutationVariables
+  >(UnlinkDiscordDocument, options)
+}
+export type UnlinkDiscordMutationHookResult = ReturnType<
+  typeof useUnlinkDiscordMutation
+>
+export type UnlinkDiscordMutationResult =
+  Apollo.MutationResult<UnlinkDiscordMutation>
+export type UnlinkDiscordMutationOptions = Apollo.BaseMutationOptions<
+  UnlinkDiscordMutation,
+  UnlinkDiscordMutationVariables
+>
 export const UpdateChallengeDocument = gql`
   mutation updateChallenge(
     $lessonId: Int!
@@ -5281,6 +5374,7 @@ export type MutationKeySpecifier = (
   | 'reqPwReset'
   | 'setStar'
   | 'signup'
+  | 'unlinkDiscord'
   | 'updateChallenge'
   | 'updateExercise'
   | 'updateLesson'
@@ -5310,6 +5404,7 @@ export type MutationFieldPolicy = {
   reqPwReset?: FieldPolicy<any> | FieldReadFunction<any>
   setStar?: FieldPolicy<any> | FieldReadFunction<any>
   signup?: FieldPolicy<any> | FieldReadFunction<any>
+  unlinkDiscord?: FieldPolicy<any> | FieldReadFunction<any>
   updateChallenge?: FieldPolicy<any> | FieldReadFunction<any>
   updateExercise?: FieldPolicy<any> | FieldReadFunction<any>
   updateLesson?: FieldPolicy<any> | FieldReadFunction<any>

--- a/graphql/queries/unlinkDiscord.ts
+++ b/graphql/queries/unlinkDiscord.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export const UNLINK_DISCORD = gql`
-  mutation {
+  mutation unlinkDiscord {
     unlinkDiscord {
       id
     }

--- a/graphql/queries/unlinkDiscord.ts
+++ b/graphql/queries/unlinkDiscord.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client'
+
+export const UNLINK_DISCORD = gql`
+  mutation {
+    unlinkDiscord {
+      id
+    }
+  }
+`

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -23,6 +23,7 @@ import { changeAdminRights } from './resolvers/adminController'
 import { createLesson, updateLesson } from './resolvers/lessonsController'
 import { getPreviousSubmissions } from './resolvers/getPreviousSubmissions'
 import { deleteComment } from './resolvers/deleteComment'
+import { unlinkDiscord } from './resolvers/unlinkDiscord'
 import {
   addModule,
   modules,
@@ -78,6 +79,7 @@ export default {
     addComment,
     deleteComment,
     flagExercise,
-    removeExerciseFlag
+    removeExerciseFlag,
+    unlinkDiscord
   }
 }

--- a/graphql/resolvers/unlinkDiscord.test.js
+++ b/graphql/resolvers/unlinkDiscord.test.js
@@ -1,0 +1,26 @@
+import prismaMock from '../../__tests__/utils/prismaMock'
+import { unlinkDiscord } from './unlinkDiscord'
+
+const mockUser = {
+  username: 'noob',
+  id: 1
+}
+
+const ctx = { req: { user: { id: 1 } } }
+const ctxWithError = { req: { user: { id: null } } }
+
+describe('unlinkDiscord resolver', () => {
+  it('should unlink discord successfully', async () => {
+    prismaMock.user.update.mockResolvedValue(mockUser)
+
+    expect(unlinkDiscord(null, null, ctx)).resolves.toStrictEqual(mockUser)
+  })
+
+  it('should throw error', async () => {
+    prismaMock.user.update.mockResolvedValue(mockUser)
+
+    expect(unlinkDiscord(null, null, ctxWithError)).rejects.toThrow(
+      'Invalid user'
+    )
+  })
+})

--- a/graphql/resolvers/unlinkDiscord.ts
+++ b/graphql/resolvers/unlinkDiscord.ts
@@ -1,0 +1,20 @@
+import prisma from '../../prisma'
+import { Context } from '../../@types/helpers'
+
+export const unlinkDiscord = async (_parent: void, _: any, ctx: Context) => {
+  const userId = ctx.req.user?.id
+
+  if (!userId) throw new Error('Invalid user')
+
+  return await prisma.user.update({
+    where: {
+      id: userId
+    },
+    data: {
+      discordAccessToken: '',
+      discordAccessTokenExpires: null,
+      discordId: '',
+      discordRefreshToken: ''
+    }
+  })
+}

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -122,6 +122,7 @@ export default gql`
       title: String!
       id: Int!
     ): [Lesson]
+    unlinkDiscord: User
   }
 
   type AuthResponse {


### PR DESCRIPTION
Related to #2243 

This PR adds a resolver that'll be used to unlink the discord account by setting the values `discordAccessToken`, `discordAccessTokenExpires`, `discordId`, and `discordRefreshToken` to empty strings (and one null).

In a following PR, it'll be used in the user profile page to unlink discord.