### PR TITLE
Remove full page load link from confirm/[token] page

### DIFF
--- a/__tests__/pages/__snapshots__/reset.test.js.snap
+++ b/__tests__/pages/__snapshots__/reset.test.js.snap
@@ -245,7 +245,6 @@ exports[`ResetPassword Page Should render confirm success on success 1`] = `
           <a
             class="btn btn-primary btn-lg mb-3"
             href="/curriculum"
-            role="button"
           >
             Continue to dashboard
           </a>

--- a/pages/confirm/[token].tsx
+++ b/pages/confirm/[token].tsx
@@ -2,6 +2,7 @@ import { useMutation } from '@apollo/client'
 import React from 'react'
 import { useRouter } from 'next/router'
 import { Formik, Form, Field } from 'formik'
+import Link from 'next/link'
 import UPDATE_PASSWORD from '../../graphql/queries/updatePassword'
 import NavLink from '../../components/NavLink'
 import Input from '../../components/Input'
@@ -16,9 +17,9 @@ const initialValues = {
 
 const ConfirmSuccess: React.FC = () => (
   <Card type="success" title="Password has been set!">
-    <a className="btn btn-primary btn-lg mb-3" role="button" href="/curriculum">
-      Continue to dashboard
-    </a>
+    <Link href="/curriculum">
+      <a className="btn btn-primary btn-lg mb-3">Continue to dashboard</a>
+    </Link>
   </Card>
 )
 


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-app/issues/2249

Before this change, there was a link that did a full page load on the confirm password change page (e.g. /confirm/123).
This change removes that full page load link and instead uses the Next.js Link component which improves performance by not doing a full page load (https://nextjs.org/docs/messages/no-html-link-for-pages).

How to test:
* Go to /confirm/123.
* Type in a new password twice and hit ENTER.
* Click the dashboard link and confirm that a full page load doesn't happen anymore and the page loads faster.
