### PR TITLE
Edit Comments GraphQL query and resolver 

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -128,6 +128,7 @@ export type Mutation = {
   deleteComment?: Maybe<Comment>
   deleteExercise: Exercise
   deleteModule: Module
+  editComment?: Maybe<Comment>
   flagExercise?: Maybe<Exercise>
   login?: Maybe<AuthResponse>
   logout?: Maybe<AuthResponse>
@@ -223,6 +224,11 @@ export type MutationDeleteExerciseArgs = {
 }
 
 export type MutationDeleteModuleArgs = {
+  id: Scalars['Int']
+}
+
+export type MutationEditCommentArgs = {
+  content: Scalars['String']
   id: Scalars['Int']
 }
 
@@ -419,6 +425,57 @@ export type UserLesson = {
   starGiven?: Maybe<Scalars['String']>
   starsReceived?: Maybe<Array<Maybe<Star>>>
   userId?: Maybe<Scalars['String']>
+}
+
+export type LessonAndChallengeInfoFragment = {
+  __typename?: 'Lesson'
+  id: number
+  docUrl?: string | null
+  githubUrl?: string | null
+  videoUrl?: string | null
+  chatUrl?: string | null
+  order: number
+  description: string
+  title: string
+  challenges: Array<{
+    __typename?: 'Challenge'
+    id: number
+    description: string
+    lessonId: number
+    title: string
+    order: number
+  }>
+}
+
+export type SubmissionsInfoFragment = {
+  __typename?: 'Submission'
+  id: number
+  status: SubmissionStatus
+  diff?: string | null
+  comment?: string | null
+  challengeId: number
+  lessonId: number
+  createdAt?: string | null
+  updatedAt: string
+  challenge: { __typename?: 'Challenge'; title: string; description: string }
+  user: { __typename?: 'User'; id: number; username: string }
+  reviewer?: {
+    __typename?: 'User'
+    id: number
+    username: string
+    name: string
+  } | null
+  comments?: Array<{
+    __typename?: 'Comment'
+    id: number
+    content: string
+    submissionId: number
+    createdAt: string
+    authorId: number
+    line?: number | null
+    fileName?: string | null
+    author?: { __typename?: 'User'; username: string; name: string } | null
+  }> | null
 }
 
 export type AcceptSubmissionMutationVariables = Exact<{
@@ -657,57 +714,6 @@ export type FlagExerciseMutationVariables = Exact<{
 export type FlagExerciseMutation = {
   __typename?: 'Mutation'
   flagExercise?: { __typename?: 'Exercise'; id: number } | null
-}
-
-export type LessonAndChallengeInfoFragment = {
-  __typename?: 'Lesson'
-  id: number
-  docUrl?: string | null
-  githubUrl?: string | null
-  videoUrl?: string | null
-  chatUrl?: string | null
-  order: number
-  description: string
-  title: string
-  challenges: Array<{
-    __typename?: 'Challenge'
-    id: number
-    description: string
-    lessonId: number
-    title: string
-    order: number
-  }>
-}
-
-export type SubmissionsInfoFragment = {
-  __typename?: 'Submission'
-  id: number
-  status: SubmissionStatus
-  diff?: string | null
-  comment?: string | null
-  challengeId: number
-  lessonId: number
-  createdAt?: string | null
-  updatedAt: string
-  challenge: { __typename?: 'Challenge'; title: string; description: string }
-  user: { __typename?: 'User'; id: number; username: string }
-  reviewer?: {
-    __typename?: 'User'
-    id: number
-    username: string
-    name: string
-  } | null
-  comments?: Array<{
-    __typename?: 'Comment'
-    id: number
-    content: string
-    submissionId: number
-    createdAt: string
-    authorId: number
-    line?: number | null
-    fileName?: string | null
-    author?: { __typename?: 'User'; username: string; name: string } | null
-  }> | null
 }
 
 export type GetAppQueryVariables = Exact<{ [key: string]: never }>
@@ -1229,6 +1235,16 @@ export type UserInfoQuery = {
   } | null
 }
 
+export type EditCommentMutationVariables = Exact<{
+  id: Scalars['Int']
+  content: Scalars['String']
+}>
+
+export type EditCommentMutation = {
+  __typename?: 'Mutation'
+  editComment?: { __typename?: 'Comment'; id: number; content: string } | null
+}
+
 export type WithIndex<TObject> = TObject & Record<string, any>
 export type ResolversObject<TObject> = WithIndex<TObject>
 
@@ -1605,6 +1621,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationDeleteModuleArgs, 'id'>
+  >
+  editComment?: Resolver<
+    Maybe<ResolversTypes['Comment']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationEditCommentArgs, 'content' | 'id'>
   >
   flagExercise?: Resolver<
     Maybe<ResolversTypes['Exercise']>,
@@ -5212,6 +5234,89 @@ export type UserInfoQueryResult = Apollo.QueryResult<
   UserInfoQuery,
   UserInfoQueryVariables
 >
+export const EditCommentDocument = gql`
+  mutation editComment($id: Int!, $content: String!) {
+    editComment(id: $id, content: $content) {
+      id
+      content
+    }
+  }
+`
+export type EditCommentMutationFn = Apollo.MutationFunction<
+  EditCommentMutation,
+  EditCommentMutationVariables
+>
+export type EditCommentProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: Apollo.MutationFunction<
+    EditCommentMutation,
+    EditCommentMutationVariables
+  >
+} & TChildProps
+export function withEditComment<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    EditCommentMutation,
+    EditCommentMutationVariables,
+    EditCommentProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    EditCommentMutation,
+    EditCommentMutationVariables,
+    EditCommentProps<TChildProps, TDataName>
+  >(EditCommentDocument, {
+    alias: 'editComment',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useEditCommentMutation__
+ *
+ * To run a mutation, you first call `useEditCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useEditCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [editCommentMutation, { data, loading, error }] = useEditCommentMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      content: // value for 'content'
+ *   },
+ * });
+ */
+export function useEditCommentMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    EditCommentMutation,
+    EditCommentMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<EditCommentMutation, EditCommentMutationVariables>(
+    EditCommentDocument,
+    options
+  )
+}
+export type EditCommentMutationHookResult = ReturnType<
+  typeof useEditCommentMutation
+>
+export type EditCommentMutationResult =
+  Apollo.MutationResult<EditCommentMutation>
+export type EditCommentMutationOptions = Apollo.BaseMutationOptions<
+  EditCommentMutation,
+  EditCommentMutationVariables
+>
 export type AlertKeySpecifier = (
   | 'id'
   | 'text'
@@ -5365,6 +5470,7 @@ export type MutationKeySpecifier = (
   | 'deleteComment'
   | 'deleteExercise'
   | 'deleteModule'
+  | 'editComment'
   | 'flagExercise'
   | 'login'
   | 'logout'
@@ -5395,6 +5501,7 @@ export type MutationFieldPolicy = {
   deleteComment?: FieldPolicy<any> | FieldReadFunction<any>
   deleteExercise?: FieldPolicy<any> | FieldReadFunction<any>
   deleteModule?: FieldPolicy<any> | FieldReadFunction<any>
+  editComment?: FieldPolicy<any> | FieldReadFunction<any>
   flagExercise?: FieldPolicy<any> | FieldReadFunction<any>
   login?: FieldPolicy<any> | FieldReadFunction<any>
   logout?: FieldPolicy<any> | FieldReadFunction<any>

--- a/graphql/queries/editComment.ts
+++ b/graphql/queries/editComment.ts
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client'
+
+const EDIT_COMMENT = gql`
+  mutation editComment($id: Int!, $content: String!) {
+    editComment(id: $id, content: $content) {
+      id
+      content
+    }
+  }
+`
+
+export default EDIT_COMMENT

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -24,6 +24,7 @@ import { createLesson, updateLesson } from './resolvers/lessonsController'
 import { getPreviousSubmissions } from './resolvers/getPreviousSubmissions'
 import { deleteComment } from './resolvers/deleteComment'
 import { unlinkDiscord } from './resolvers/unlinkDiscord'
+import { editComment } from './resolvers/editComment'
 import {
   addModule,
   modules,
@@ -77,6 +78,7 @@ export default {
     updateModule,
     deleteModule,
     addComment,
+    editComment,
     deleteComment,
     flagExercise,
     removeExerciseFlag,

--- a/graphql/resolvers/editComment.test.js
+++ b/graphql/resolvers/editComment.test.js
@@ -1,4 +1,3 @@
-import { resolveRequestDocument } from 'graphql-request'
 import prismaMock from '../../__tests__/utils/prismaMock'
 import { editComment } from './editComment'
 
@@ -8,7 +7,8 @@ const mockEditComment = {
 }
 
 describe('Edit comments resolver', () => {
-  test('should invoke prismaMock update', async () => {
+  test('should invoke prismaMock update', () => {
+    expect.assertions(1)
     prismaMock.comment.update.mockResolvedValue({
       id: 2,
       authorId: 1
@@ -16,7 +16,7 @@ describe('Edit comments resolver', () => {
     prismaMock.comment.findUnique.mockResolvedValue({
       authorId: 1
     })
-    await expect(
+    expect(
       editComment({}, mockEditComment, { req: { user: { id: 1 } } })
     ).resolves.toEqual({
       authorId: 1,
@@ -24,14 +24,16 @@ describe('Edit comments resolver', () => {
     })
   })
 
-  test('should throw error if no user.id in context', async () => {
-    await expect(editComment({}, mockEditComment, { req: {} })).rejects.toThrow(
+  test('should throw error if no user.id in context', () => {
+    expect.assertions(1)
+    expect(editComment({}, mockEditComment, { req: {} })).rejects.toThrow(
       'No user'
     )
   })
 
-  test('should throw error if user.id does not match author.id', async () => {
-    await expect(
+  test('should throw error if user.id does not match author.id', () => {
+    expect.assertions(1)
+    expect(
       editComment(
         {},
         {

--- a/graphql/resolvers/editComment.test.js
+++ b/graphql/resolvers/editComment.test.js
@@ -1,0 +1,44 @@
+import { resolveRequestDocument } from 'graphql-request'
+import prismaMock from '../../__tests__/utils/prismaMock'
+import { editComment } from './editComment'
+
+const mockEditComment = {
+  id: 2,
+  content: 'i edited this comment'
+}
+
+describe('Edit comments resolver', () => {
+  test('should invoke prismaMock update', async () => {
+    prismaMock.comment.update.mockResolvedValue({
+      id: 2,
+      authorId: 1
+    })
+    prismaMock.comment.findUnique.mockResolvedValue({
+      authorId: 1
+    })
+    await expect(
+      editComment({}, mockEditComment, { req: { user: { id: 1 } } })
+    ).resolves.toEqual({
+      authorId: 1,
+      id: 2
+    })
+  })
+
+  test('should throw error if no user.id in context', async () => {
+    await expect(editComment({}, mockEditComment, { req: {} })).rejects.toThrow(
+      'No user'
+    )
+  })
+
+  test('should throw error if user.id does not match author.id', async () => {
+    await expect(
+      editComment(
+        {},
+        {
+          authorId: 2
+        },
+        { req: { user: { id: 1 } } }
+      )
+    ).rejects.toThrow('Comment is not by the user')
+  })
+})

--- a/graphql/resolvers/editComment.ts
+++ b/graphql/resolvers/editComment.ts
@@ -1,0 +1,31 @@
+import prisma from '../../prisma'
+import { MutationEditCommentArgs } from '../index'
+import { Context } from '../../@types/helpers'
+import type { Comment } from '@prisma/client'
+import { withUserContainer } from '../../containers/withUserContainer'
+import _ from 'lodash'
+
+export const editComment = withUserContainer<
+  Promise<Comment>,
+  MutationEditCommentArgs
+>(async (_parent: void, args: MutationEditCommentArgs, ctx: Context) => {
+  const { id, content } = args
+  const { req } = ctx
+  const authorId = _.get(req, 'user.id')
+
+  const comment = await prisma.comment.findUnique({
+    where: {
+      id
+    }
+  })
+
+  if (_.get(comment, 'authorId') !== authorId)
+    throw new Error('Comment is not by the user')
+
+  return prisma.comment.update({
+    where: {
+      id
+    },
+    data: { content }
+  })
+})

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -56,6 +56,7 @@ export default gql`
       content: String!
     ): Comment
     deleteComment(id: Int!): Comment
+    editComment(id: Int!, content: String!): Comment
     addModule(
       lessonId: Int!
       name: String!


### PR DESCRIPTION
**Title:** enhancement : adds ability to edit comments on a submission

**Description:** relates to #893 

As of now, we can only add and delete comments. This PR adds the query and resolver for editing comments in the backend. After approval/merging of this PR, a separate PR will handle the frontend functionality to edit comments.