### PR TITLE
Add header and alerts and errors to the DOJO exercises page

### DIFF
--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  render,
-  waitFor,
-  screen,
-  waitForElementToBeRemoved
-} from '@testing-library/react'
+import { render, waitFor, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Exercises from '../../../pages/exercises/[lessonSlug]'
 import { useRouter } from 'next/router'
@@ -37,14 +32,14 @@ describe('Exercises page', () => {
       }
     ]
 
-    const { getByRole } = render(
+    render(
       <MockedProvider mocks={mocks} addTypename={false}>
         <Exercises />
       </MockedProvider>
     )
 
     await waitFor(() =>
-      getByRole('heading', { name: /Foundations of JavaScript/i })
+      screen.getByRole('heading', { name: /Foundations of JavaScript/i })
     )
   })
 
@@ -62,13 +57,13 @@ describe('Exercises page', () => {
       }
     ]
 
-    const { getByRole } = render(
+    render(
       <MockedProvider mocks={mocks} addTypename={false}>
         <Exercises />
       </MockedProvider>
     )
 
-    await waitFor(() => getByRole('heading', { name: /500 Error/i }))
+    await waitFor(() => screen.getByRole('heading', { name: /500 Error/i }))
   })
 
   test('Should render a 404 error page if the lesson is not found', async () => {
@@ -85,13 +80,13 @@ describe('Exercises page', () => {
       }
     ]
 
-    const { getByRole } = render(
+    render(
       <MockedProvider mocks={mocks} addTypename={false}>
         <Exercises />
       </MockedProvider>
     )
 
-    await waitFor(() => getByRole('heading', { name: /404 Error/i }))
+    await waitFor(() => screen.getByRole('heading', { name: /404 Error/i }))
   })
 
   test('Should render a loading spinner if useRouter is not ready', async () => {
@@ -117,6 +112,6 @@ describe('Exercises page', () => {
       </MockedProvider>
     )
 
-    await waitFor(() => screen.queryByText('Loading...'))
+    await waitFor(() => screen.getByText('Loading...'))
   })
 })

--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Exercises from '../../../pages/exercises/[lessonSlug]'
+
+describe('Exercises page', () => {
+  test('Should render correctly', async () => {
+    const { getByRole } = render(<Exercises />)
+
+    await waitFor(() =>
+      getByRole('heading', { name: /Foundations of JavaScript/i })
+    )
+  })
+})

--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -1,14 +1,122 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import {
+  render,
+  waitFor,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Exercises from '../../../pages/exercises/[lessonSlug]'
+import { useRouter } from 'next/router'
+import { MockedProvider } from '@apollo/client/testing'
+import dummyLessonData from '../../../__dummy__/lessonData'
+import dummySessionData from '../../../__dummy__/sessionData'
+import dummyAlertData from '../../../__dummy__/alertData'
+import GET_APP from '../../../graphql/queries/getApp'
+
+const session = {
+  ...dummySessionData,
+  submissions: [],
+  lessonStatus: []
+}
 
 describe('Exercises page', () => {
+  const { query } = useRouter()
+  query['lessonSlug'] = 'js0'
   test('Should render correctly', async () => {
-    const { getByRole } = render(<Exercises />)
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session,
+            lessons: dummyLessonData,
+            alerts: dummyAlertData
+          }
+        }
+      }
+    ]
+
+    const { getByRole } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Exercises />
+      </MockedProvider>
+    )
 
     await waitFor(() =>
       getByRole('heading', { name: /Foundations of JavaScript/i })
     )
+  })
+
+  test('Should render a 500 error page if the lesson data is null', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session,
+            lessons: null,
+            alerts: dummyAlertData
+          }
+        }
+      }
+    ]
+
+    const { getByRole } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Exercises />
+      </MockedProvider>
+    )
+
+    await waitFor(() => getByRole('heading', { name: /500 Error/i }))
+  })
+
+  test('Should render a 404 error page if the lesson is not found', async () => {
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session,
+            lessons: [],
+            alerts: dummyAlertData
+          }
+        }
+      }
+    ]
+
+    const { getByRole } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Exercises />
+      </MockedProvider>
+    )
+
+    await waitFor(() => getByRole('heading', { name: /404 Error/i }))
+  })
+
+  test('Should render a loading spinner if useRouter is not ready', async () => {
+    useRouter.mockImplementation(() => ({
+      isReady: false
+    }))
+    const mocks = [
+      {
+        request: { query: GET_APP },
+        result: {
+          data: {
+            session,
+            lessons: dummyLessonData,
+            alerts: dummyAlertData
+          }
+        }
+      }
+    ]
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Exercises />
+      </MockedProvider>
+    )
+
+    await waitFor(() => screen.queryByText('Loading...'))
   })
 })

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -1,7 +1,39 @@
+import { useRouter } from 'next/router'
 import React from 'react'
+import Layout from '../../components/Layout'
+import withQueryLoader, {
+  QueryDataProps
+} from '../../containers/withQueryLoader'
+import { GetAppQuery } from '../../graphql'
+import Error, { StatusCode } from '../../components/Error'
+import LoadingSpinner from '../../components/LoadingSpinner'
+import GET_APP from '../../graphql/queries/getApp'
+import AlertsDisplay from '../../components/AlertsDisplay'
 
-const Exercises: React.FC = () => {
-  return <h1>Foundations of JavaScript</h1>
+const Exercises: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
+  const { lessons, alerts } = queryData
+  const router = useRouter()
+  if (!router.isReady) return <LoadingSpinner />
+
+  const slug = router.query.lessonSlug as string
+  if (!lessons || !alerts)
+    return <Error code={StatusCode.INTERNAL_SERVER_ERROR} message="Bad data" />
+
+  const currentLesson = lessons.find(lesson => lesson.slug === slug)
+  if (!currentLesson)
+    return <Error code={StatusCode.NOT_FOUND} message="Lesson not found" />
+
+  return (
+    <Layout title={currentLesson.title}>
+      <h1>{currentLesson.title}</h1>
+      {alerts && <AlertsDisplay alerts={alerts} />}
+    </Layout>
+  )
 }
 
-export default Exercises
+export default withQueryLoader<GetAppQuery>(
+  {
+    query: GET_APP
+  },
+  Exercises
+)

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Exercises: React.FC = () => {
+  return <h1>Foundations of JavaScript</h1>
+}
+
+export default Exercises


### PR DESCRIPTION
This pull request adds the header to the top of the DOJO exercises page and handles errors and alerts. The header and title will change depending on the exercise you input.

How to test:
* Go to /exercises/js0 or /exercises/js1 and verify it displays the exercises title and header
* Go to /exercises/randomURL and verify it gives a 404 page

This pull request is a part of https://github.com/garageScript/c0d3-app/issues/2253