### PR TITLE
Revert "build(deps): Bump bootstrap from 5.2.0 to 5.2.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "apollo-server-micro": "^2.26.0",
     "apollo3-cache-persist": "^0.14.1",
     "bcrypt": "5.0.0",
-    "bootstrap": "5.2.1",
+    "bootstrap": "5.2.0",
     "c0d3-diff": "^0.0.9",
     "dayjs": "^1.11.5",
     "discord.js": "^12.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6949,10 +6949,10 @@ boom@7.x.x:
   dependencies:
     hoek "6.x.x"
 
-bootstrap@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.1.tgz#45f97ff05cbe828bad807b014d8425f3aeb8ec3a"
-  integrity sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==
+bootstrap@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.0.tgz#838727fb60f1630db370fe57c63cbcf2962bb3d3"
+  integrity sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==
 
 boxen@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
Reverts garageScript/c0d3-app#2266

We will look into some breaking changes on the styling before upgrading to 5.2.1.