### PR TITLE
Changing Modal components from Modal.Body to ModalBody, Modal.Header to ModalHeader, etc.

### DIFF
--- a/components/SubmissionComments.tsx
+++ b/components/SubmissionComments.tsx
@@ -11,6 +11,12 @@ import { GlobalContext } from '../helpers/globalContext'
 import { MdInput } from './MdInput'
 import _ from 'lodash'
 import Modal from 'react-bootstrap/Modal'
+import {
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from 'react-bootstrap'
 
 export const SubmissionComments: React.FC<{
   comments: Comment[]
@@ -88,11 +94,11 @@ export const SubmissionComments: React.FC<{
   return (
     <>
       <Modal show={show} onHide={handleModalClose}>
-        <Modal.Header>
-          <Modal.Title>Error</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>{modalText}</Modal.Body>
-        <Modal.Footer>
+        <ModalHeader>
+          <ModalTitle>Error</ModalTitle>
+        </ModalHeader>
+        <ModalBody>{modalText}</ModalBody>
+        <ModalFooter>
           <Button
             onClick={handleModalClose}
             type="info"
@@ -101,7 +107,7 @@ export const SubmissionComments: React.FC<{
           >
             Close
           </Button>
-        </Modal.Footer>
+        </ModalFooter>
       </Modal>
       {submissionsComments.map((c, i) => (
         <div


### PR DESCRIPTION
**Description:** fix: This PR is to fix an error that was causing the 'Bump next from 12.2.4 to 12.3.0'(https://github.com/garageScript/c0d3-app/runs/8295638113?check_suite_focus=true) build to fail. 

Instead of using Modal.Body, Modal.Header, etc. from the `react-bootstrap/Modal` library, using ModalBody, ModalHeader from the  `react-bootstrap` library will fix the error.

Here is a screenshot of the error: 
![image](https://user-images.githubusercontent.com/77421872/189555909-9f162b2e-b12b-4b7c-a199-f050e29bb2a6.png)
