### PR TITLE
Update Iprops Interface on _app.tsx prior to bump Next

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,12 +12,16 @@ import Head from 'next/head'
 import '../scss/index.scss'
 import { useApollo } from '../helpers/apolloClient'
 import { ContextProvider } from '../helpers/globalContext'
+import { Session } from 'next-auth'
 import { SessionProvider } from 'next-auth/react'
 import type { NextPageWithLayout } from '../@types/page'
-interface IProps extends AppProps {
+interface IProps<P = Record<string, unknown>> extends AppProps {
   err: any
   apollo: ApolloClient<NormalizedCacheObject>
   Component: NextPageWithLayout
+  pageProps: P & {
+    session?: Session
+  }
 }
 
 function MyApp({


### PR DESCRIPTION
**Description**: bug : related to #2280

While running the build for #2280. We encountered the following issue:
![image](https://user-images.githubusercontent.com/77421872/189712447-42537b0d-6169-43d2-a028-974586408cfd.png)

According to this stackoverflow: https://stackoverflow.com/questions/73668032/nextauth-type-error-property-session-does-not-exist-on-type

The changes in this PR should fix the above error. 