### PR TITLE
Bootstrap 5.2.1 Upgrade

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -281,7 +281,7 @@ exports[`Storyshots Components/AdminLessonExerciseCard Basic 1`] = `
           noob@c0d3.com
         </span>
         <button
-          className="btn borderless btn-outline-primary onFocusBgFix btn-outline-bg-primary"
+          className="btn borderless btn-outline-primary onFocusBgFix btnOutlineInfoBgFix-primary btn-outline-bg-primary"
           onClick={[Function]}
           style={
             Object {
@@ -320,7 +320,7 @@ exports[`Storyshots Components/AdminLessonExerciseCard Basic 1`] = `
           noob#123
         </span>
         <button
-          className="btn borderless btn-outline-primary onFocusBgFix btn-outline-bg-primary"
+          className="btn borderless btn-outline-primary onFocusBgFix btnOutlineInfoBgFix-primary btn-outline-bg-primary"
           onClick={[Function]}
           style={
             Object {
@@ -1873,7 +1873,7 @@ exports[`Storyshots Components/ChallengeMaterial With Comments 1`] = `
                         </label>
                       </div>
                       <button
-                        className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                        className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                         onClick={[Function]}
                         style={
                           Object {
@@ -2742,7 +2742,7 @@ exports[`Storyshots Components/ChallengeMaterial With Diff 1`] = `
                         </label>
                       </div>
                       <button
-                        className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                        className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                         onClick={[Function]}
                         style={
                           Object {
@@ -4017,7 +4017,7 @@ exports[`Storyshots Components/ContributorCard Basic 1`] = `
 
 exports[`Storyshots Components/CopyButton Basic 1`] = `
 <button
-  className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+  className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
   onClick={[Function]}
   style={
     Object {
@@ -4096,7 +4096,7 @@ exports[`Storyshots Components/DiffView Closed 1`] = `
               </label>
             </div>
             <button
-              className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+              className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
               onClick={[Function]}
               style={
                 Object {
@@ -4489,7 +4489,7 @@ exports[`Storyshots Components/DiffView Default 1`] = `
               </label>
             </div>
             <button
-              className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+              className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
               onClick={[Function]}
               style={
                 Object {
@@ -12408,7 +12408,7 @@ exports[`Storyshots Components/ProfileImageInfo Profile Image Info 1`] = `
       </span>
     </div>
     <button
-      className="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger"
+      className="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger"
       onClick={[Function]}
       style={
         Object {
@@ -14048,7 +14048,7 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
                       </label>
                     </div>
                     <button
-                      className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                      className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       onClick={[Function]}
                       style={
                         Object {
@@ -15474,7 +15474,7 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
                       </label>
                     </div>
                     <button
-                      className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                      className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       onClick={[Function]}
                       style={
                         Object {
@@ -16898,7 +16898,7 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
                       </label>
                     </div>
                     <button
-                      className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                      className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       onClick={[Function]}
                       style={
                         Object {
@@ -18322,7 +18322,7 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
                       </label>
                     </div>
                     <button
-                      className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                      className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       onClick={[Function]}
                       style={
                         Object {
@@ -19746,7 +19746,7 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
                       </label>
                     </div>
                     <button
-                      className="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                      className="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       onClick={[Function]}
                       style={
                         Object {
@@ -21691,7 +21691,7 @@ Array [
       </div>
       <div>
         <button
-          className="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+          className="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
           onClick={[Function]}
           style={
             Object {
@@ -21723,7 +21723,7 @@ Array [
           />
         </button>
         <button
-          className="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+          className="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
           onClick={[Function]}
           style={
             Object {
@@ -21793,7 +21793,7 @@ Array [
       </div>
       <div>
         <button
-          className="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+          className="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
           onClick={[Function]}
           style={
             Object {
@@ -21825,7 +21825,7 @@ Array [
           />
         </button>
         <button
-          className="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+          className="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
           onClick={[Function]}
           style={
             Object {
@@ -21895,7 +21895,7 @@ Array [
       </div>
       <div>
         <button
-          className="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+          className="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
           onClick={[Function]}
           style={
             Object {
@@ -21927,7 +21927,7 @@ Array [
           />
         </button>
         <button
-          className="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+          className="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
           onClick={[Function]}
           style={
             Object {
@@ -28714,7 +28714,7 @@ exports[`Storyshots Theme/Button Margined Button 1`] = `
 exports[`Storyshots Theme/Button Outlined Button 1`] = `
 Array [
   <button
-    className="btn borderless btn-outline-primary onFocusBgFix btn-outline-bg-primary"
+    className="btn borderless btn-outline-primary onFocusBgFix btnOutlineInfoBgFix-primary btn-outline-bg-primary"
     onClick={[Function]}
     style={
       Object {
@@ -28725,7 +28725,7 @@ Array [
     Outlined Primary Button
   </button>,
   <button
-    className="btn borderless btn-outline-success onFocusBgFix btn-outline-bg-success"
+    className="btn borderless btn-outline-success onFocusBgFix btnOutlineInfoBgFix-success btn-outline-bg-success"
     onClick={[Function]}
     style={
       Object {
@@ -28736,7 +28736,7 @@ Array [
     Outlined Success Button
   </button>,
   <button
-    className="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger"
+    className="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger"
     onClick={[Function]}
     style={
       Object {
@@ -28752,7 +28752,7 @@ Array [
 exports[`Storyshots Theme/Button Outlined With Border Button 1`] = `
 Array [
   <button
-    className="btn btn-outline-primary onFocusBgFix btn-outline-bg-primary"
+    className="btn btn-outline-primary onFocusBgFix btnOutlineInfoBgFix-primary btn-outline-bg-primary"
     onClick={[Function]}
     style={
       Object {
@@ -28763,7 +28763,7 @@ Array [
     Outlined Primary Button
   </button>,
   <button
-    className="btn btn-outline-success onFocusBgFix btn-outline-bg-success"
+    className="btn btn-outline-success onFocusBgFix btnOutlineInfoBgFix-success btn-outline-bg-success"
     onClick={[Function]}
     style={
       Object {
@@ -28774,7 +28774,7 @@ Array [
     Outlined Success Button
   </button>,
   <button
-    className="btn btn-outline-danger onFocusBgFix btn-outline-bg-danger"
+    className="btn btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger"
     onClick={[Function]}
     style={
       Object {

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -4816,7 +4816,7 @@ exports[`user profile test should render discord avatar and username if user con
               </span>
             </div>
             <button
-              class="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger"
+              class="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger"
             >
               Unlink Discord
             </button>

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -858,7 +858,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                                 </label>
                               </div>
                               <button
-                                class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                                class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3050,7 +3050,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                                 </label>
                               </div>
                               <button
-                                class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                                class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                               >
                                 <svg
                                   aria-hidden="true"
@@ -3240,7 +3240,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                                       </div>
                                       <div>
                                         <button
-                                          class="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+                                          class="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
                                         >
                                           <svg
                                             aria-hidden="true"
@@ -3259,7 +3259,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                                           </svg>
                                         </button>
                                         <button
-                                          class="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+                                          class="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
                                         >
                                           <svg
                                             aria-hidden="true"
@@ -3316,7 +3316,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                                       </div>
                                       <div>
                                         <button
-                                          class="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+                                          class="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
                                         >
                                           <svg
                                             aria-hidden="true"
@@ -3335,7 +3335,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                                           </svg>
                                         </button>
                                         <button
-                                          class="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+                                          class="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
                                         >
                                           <svg
                                             aria-hidden="true"

--- a/components/ChallengeMaterial/__snapshots__/ChallengeMaterial.test.js.snap
+++ b/components/ChallengeMaterial/__snapshots__/ChallengeMaterial.test.js.snap
@@ -215,7 +215,7 @@ exports[`Curriculum challenge page Should render first challenge that is not pas
                           </label>
                         </div>
                         <button
-                          class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                          class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                         >
                           <svg
                             aria-hidden="true"

--- a/components/__snapshots__/CopyButton.test.js.snap
+++ b/components/__snapshots__/CopyButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Copy Button component Should render correctly 1`] = `
 <div>
   <button
-    class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+    class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
   >
     <svg
       aria-hidden="true"

--- a/components/__snapshots__/DiffView.test.js.snap
+++ b/components/__snapshots__/DiffView.test.js.snap
@@ -45,7 +45,7 @@ exports[`DiffView component Should add comment box 1`] = `
                 </label>
               </div>
               <button
-                class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
               >
                 <svg
                   aria-hidden="true"
@@ -701,7 +701,7 @@ exports[`DiffView component Should render collapsed diff 1`] = `
                 </label>
               </div>
               <button
-                class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
               >
                 <svg
                   aria-hidden="true"
@@ -777,7 +777,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
                 </label>
               </div>
               <button
-                class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
               >
                 <svg
                   aria-hidden="true"
@@ -2969,7 +2969,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
                 </label>
               </div>
               <button
-                class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
               >
                 <svg
                   aria-hidden="true"
@@ -3116,7 +3116,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
                       </div>
                       <div>
                         <button
-                          class="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+                          class="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
                         >
                           <svg
                             aria-hidden="true"
@@ -3135,7 +3135,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
                           </svg>
                         </button>
                         <button
-                          class="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+                          class="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
                         >
                           <svg
                             aria-hidden="true"
@@ -3457,7 +3457,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
                       </div>
                       <div>
                         <button
-                          class="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+                          class="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
                         >
                           <svg
                             aria-hidden="true"
@@ -3476,7 +3476,7 @@ exports[`DiffView component Should render diff with comments 1`] = `
                           </svg>
                         </button>
                         <button
-                          class="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+                          class="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
                         >
                           <svg
                             aria-hidden="true"

--- a/components/__snapshots__/ReviewCard.test.js.snap
+++ b/components/__snapshots__/ReviewCard.test.js.snap
@@ -133,7 +133,7 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
                         </label>
                       </div>
                       <button
-                        class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                        class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       >
                         <svg
                           aria-hidden="true"
@@ -988,7 +988,7 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
                         </label>
                       </div>
                       <button
-                        class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                        class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       >
                         <svg
                           aria-hidden="true"
@@ -1792,7 +1792,7 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
                         </label>
                       </div>
                       <button
-                        class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                        class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       >
                         <svg
                           aria-hidden="true"
@@ -2596,7 +2596,7 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
                         </label>
                       </div>
                       <button
-                        class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                        class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       >
                         <svg
                           aria-hidden="true"
@@ -4201,7 +4201,7 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
                         </label>
                       </div>
                       <button
-                        class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                        class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       >
                         <svg
                           aria-hidden="true"
@@ -6181,7 +6181,7 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
                         </label>
                       </div>
                       <button
-                        class="btn borderless btn-outline-mute onFocusBgFix btn-outline-bg-mute"
+                        class="btn borderless btn-outline-mute onFocusBgFix btnOutlineInfoBgFix-mute btn-outline-bg-mute"
                       >
                         <svg
                           aria-hidden="true"

--- a/components/__snapshots__/SubmissionComments.test.js.snap
+++ b/components/__snapshots__/SubmissionComments.test.js.snap
@@ -38,7 +38,7 @@ exports[`Test SubmissionComments Component Should render correctly 1`] = `
       </div>
       <div>
         <button
-          class="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+          class="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
         >
           <svg
             aria-hidden="true"
@@ -57,7 +57,7 @@ exports[`Test SubmissionComments Component Should render correctly 1`] = `
           </svg>
         </button>
         <button
-          class="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+          class="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
         >
           <svg
             aria-hidden="true"
@@ -114,7 +114,7 @@ exports[`Test SubmissionComments Component Should render correctly 1`] = `
       </div>
       <div>
         <button
-          class="btn borderless btn-outline-info onFocusBgFix btn-outline-bg-info btn-sm"
+          class="btn borderless btn-outline-info onFocusBgFix btnOutlineInfoBgFix-info btn-outline-bg-info btn-sm"
         >
           <svg
             aria-hidden="true"
@@ -133,7 +133,7 @@ exports[`Test SubmissionComments Component Should render correctly 1`] = `
           </svg>
         </button>
         <button
-          class="btn borderless btn-outline-danger onFocusBgFix btn-outline-bg-danger btn-sm"
+          class="btn borderless btn-outline-danger onFocusBgFix btnOutlineInfoBgFix-danger btn-outline-bg-danger btn-sm"
         >
           <svg
             aria-hidden="true"

--- a/components/theme/Button.tsx
+++ b/components/theme/Button.tsx
@@ -31,13 +31,13 @@ export const Button: React.FC<ButtonProps> = ({
   if (border && !outline) classes.push('border')
   if (!border) classes.push(styles.borderless)
   if (type) {
-    if (outline)
+    if (outline) {
       classes.push(
         `btn-outline-${type} ${styles.onFocusBgFix} ${
-          styles[`btn-outline-bg-${type}`]
-        }`
+          styles[`btnOutlineInfoBgFix-${type}`]
+        } ${styles[`btn-outline-bg-${type}`]}`
       )
-    else classes.push(`btn-${type}`)
+    } else classes.push(`btn-${type}`)
   }
   if (m) classes.push(`m-${m}`)
   if (ml) classes.push(`ms-${ml}`)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "apollo-server-micro": "^2.26.0",
     "apollo3-cache-persist": "^0.14.1",
     "bcrypt": "5.0.0",
-    "bootstrap": "5.2.0",
+    "bootstrap": "5.2.1",
     "c0d3-diff": "^0.0.9",
     "dayjs": "^1.11.5",
     "discord.js": "^12.5.3",

--- a/scss/button.module.scss
+++ b/scss/button.module.scss
@@ -16,4 +16,10 @@
   .btn-outline-bg-#{$name}:hover {
     background-color: rgba($color, 0.2);
   }
+
+  .btnOutlineInfoBgFix-#{$name} {
+    &:hover {
+      background-color: rgba($color, 0.2) !important;
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6949,10 +6949,10 @@ boom@7.x.x:
   dependencies:
     hoek "6.x.x"
 
-bootstrap@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.0.tgz#838727fb60f1630db370fe57c63cbcf2962bb3d3"
-  integrity sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==
+bootstrap@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.1.tgz#45f97ff05cbe828bad807b014d8425f3aeb8ec3a"
+  integrity sha512-UQi3v2NpVPEi1n35dmRRzBJFlgvWHYwyem6yHhuT6afYF+sziEt46McRbT//kVXZ7b1YUYEVGdXEH74Nx3xzGA==
 
 boxen@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
**Description**: related to #2266 

This PR upgrades bootstrap to the latest version. While fixing some of the styling issues that made certain buttons opaque instead of transparent(the correct way):
![image](https://user-images.githubusercontent.com/77421872/190215072-17df39c8-d6a3-4e29-a7fd-993d62f7100e.png)

![image](https://user-images.githubusercontent.com/77421872/190215105-7d556840-8904-49cc-9941-09897ddef8f6.png)

To test:

1. Login as the dummy Admin and go to `review/js0`
2. Hover over the edit(pencil icon) and delete(trash icon) comment buttons to see that they are now transparent on hover.