### PR TITLE
Fix user dropdown-menu accessibility

### DIFF
--- a/__tests__/pages/__snapshots__/curriculum.test.js.snap
+++ b/__tests__/pages/__snapshots__/curriculum.test.js.snap
@@ -72,11 +72,12 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -102,7 +103,7 @@ exports[`Curriculum Page Should render with basic dummy data 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -1764,11 +1765,12 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -1794,7 +1796,7 @@ exports[`Curriculum Page Should render with lessonStatus data 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"

--- a/__tests__/pages/__snapshots__/forgotpassword.test.js.snap
+++ b/__tests__/pages/__snapshots__/forgotpassword.test.js.snap
@@ -72,11 +72,12 @@ exports[`ForgotPassword Page Should render invalid user/email form on error 1`] 
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -102,7 +103,7 @@ exports[`ForgotPassword Page Should render invalid user/email form on error 1`] 
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -270,11 +271,12 @@ exports[`ForgotPassword Page Should render password reset instructions on succes
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -300,7 +302,7 @@ exports[`ForgotPassword Page Should render password reset instructions on succes
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"

--- a/__tests__/pages/admin/__snapshots__/users.test.js.snap
+++ b/__tests__/pages/admin/__snapshots__/users.test.js.snap
@@ -72,11 +72,12 @@ exports[`Users test Should be able to switch search options 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -102,7 +103,7 @@ exports[`Users test Should be able to switch search options 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -453,11 +454,12 @@ exports[`Users test Should be able to switch search options 2`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -483,7 +485,7 @@ exports[`Users test Should be able to switch search options 2`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -834,11 +836,12 @@ exports[`Users test Should be able to switch search options 3`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -864,7 +867,7 @@ exports[`Users test Should be able to switch search options 3`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -1215,11 +1218,12 @@ exports[`Users test Should be able to switch search options 4`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -1245,7 +1249,7 @@ exports[`Users test Should be able to switch search options 4`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"

--- a/__tests__/pages/admin/lessons/__snapshots__/lessons.test.js.snap
+++ b/__tests__/pages/admin/lessons/__snapshots__/lessons.test.js.snap
@@ -72,11 +72,12 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 1`] 
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -102,7 +103,7 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 1`] 
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -3986,11 +3987,12 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 2`] 
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -4016,7 +4018,7 @@ exports[`Users test should switch to selected lesson in AdminLessonsSidebar 2`] 
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"

--- a/__tests__/pages/curriculum/__snapshots__/[lessonSlug].test.js.snap
+++ b/__tests__/pages/curriculum/__snapshots__/[lessonSlug].test.js.snap
@@ -73,11 +73,12 @@ exports[`Lesson Page Should correctly render challenges page for students who ha
           </div>
           <div
             class="dropdown"
+            role="menu"
           >
             <div
               class="d-none d-lg-block"
             >
-              <div
+              <button
                 aria-expanded="false"
                 class="nav-user-toggle  dropdown-toggle"
                 data-testid="user-info-image"
@@ -103,7 +104,7 @@ exports[`Lesson Page Should correctly render challenges page for students who ha
                     fill-rule="evenodd"
                   />
                 </svg>
-              </div>
+              </button>
             </div>
             <div
               class="d-lg-none"
@@ -552,11 +553,12 @@ exports[`Lesson Page Should render correctly with invalid lesson route 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -582,7 +584,7 @@ exports[`Lesson Page Should render correctly with invalid lesson route 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -762,11 +764,12 @@ exports[`Lesson Page Should render correctly with valid lesson route 1`] = `
           </div>
           <div
             class="dropdown"
+            role="menu"
           >
             <div
               class="d-none d-lg-block"
             >
-              <div
+              <button
                 aria-expanded="false"
                 class="nav-user-toggle  dropdown-toggle"
                 data-testid="user-info-image"
@@ -792,7 +795,7 @@ exports[`Lesson Page Should render correctly with valid lesson route 1`] = `
                     fill-rule="evenodd"
                   />
                 </svg>
-              </div>
+              </button>
             </div>
             <div
               class="d-lg-none"
@@ -1268,11 +1271,12 @@ exports[`Lesson Page Should return Bad data if alerts or lessons are missing 1`]
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -1298,7 +1302,7 @@ exports[`Lesson Page Should return Bad data if alerts or lessons are missing 1`]
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -72,11 +72,12 @@ exports[`user profile test Should render anonymous users 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -102,7 +103,7 @@ exports[`user profile test Should render anonymous users 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -946,11 +947,12 @@ exports[`user profile test Should render if no stars received 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -976,7 +978,7 @@ exports[`user profile test Should render if no stars received 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -2665,11 +2667,12 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -2695,7 +2698,7 @@ exports[`user profile test Should render nulled submission lessonIds 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -3539,11 +3542,12 @@ exports[`user profile test Should render profile 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -3569,7 +3573,7 @@ exports[`user profile test Should render profile 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"

--- a/__tests__/pages/profile/__snapshots__/username.test.js.snap
+++ b/__tests__/pages/profile/__snapshots__/username.test.js.snap
@@ -4656,11 +4656,12 @@ exports[`user profile test should render discord avatar and username if user con
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -4691,7 +4692,7 @@ exports[`user profile test should render discord avatar and username if user con
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -72,11 +72,12 @@ exports[`Lesson Page Should render Error component if route is invalid 1`] = `
         </div>
         <div
           class="dropdown"
+          role="menu"
         >
           <div
             class="d-none d-lg-block"
           >
-            <div
+            <button
               aria-expanded="false"
               class="nav-user-toggle  dropdown-toggle"
               data-testid="user-info-image"
@@ -102,7 +103,7 @@ exports[`Lesson Page Should render Error component if route is invalid 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </button>
           </div>
           <div
             class="d-lg-none"
@@ -282,11 +283,12 @@ exports[`Lesson Page Should render empty submissions 1`] = `
           </div>
           <div
             class="dropdown"
+            role="menu"
           >
             <div
               class="d-none d-lg-block"
             >
-              <div
+              <button
                 aria-expanded="false"
                 class="nav-user-toggle  dropdown-toggle"
                 data-testid="user-info-image"
@@ -312,7 +314,7 @@ exports[`Lesson Page Should render empty submissions 1`] = `
                     fill-rule="evenodd"
                   />
                 </svg>
-              </div>
+              </button>
             </div>
             <div
               class="d-lg-none"
@@ -521,11 +523,12 @@ exports[`Lesson Page Should render new submissions 1`] = `
           </div>
           <div
             class="dropdown"
+            role="menu"
           >
             <div
               class="d-none d-lg-block"
             >
-              <div
+              <button
                 aria-expanded="false"
                 class="nav-user-toggle  dropdown-toggle"
                 data-testid="user-info-image"
@@ -551,7 +554,7 @@ exports[`Lesson Page Should render new submissions 1`] = `
                     fill-rule="evenodd"
                   />
                 </svg>
-              </div>
+              </button>
             </div>
             <div
               class="d-lg-none"

--- a/components/ProfileDropdownMenu.tsx
+++ b/components/ProfileDropdownMenu.tsx
@@ -63,8 +63,8 @@ const ProfileDropdownMenu: React.FC<ProfileDropDownMenuProps> = ({
   ))
 
   const buttonMenuToggle = React.forwardRef<
-    HTMLDivElement,
-    React.ComponentPropsWithoutRef<'div'>
+    HTMLButtonElement,
+    React.ComponentPropsWithoutRef<'button'>
   >((props, ref) => <button ref={ref} {...props}></button>)
 
   return (

--- a/components/ProfileDropdownMenu.tsx
+++ b/components/ProfileDropdownMenu.tsx
@@ -65,10 +65,10 @@ const ProfileDropdownMenu: React.FC<ProfileDropDownMenuProps> = ({
   const buttonMenuToggle = React.forwardRef<
     HTMLDivElement,
     React.ComponentPropsWithoutRef<'div'>
-  >((props, ref) => <div ref={ref} {...props}></div>)
+  >((props, ref) => <button ref={ref} {...props}></button>)
 
   return (
-    <Dropdown>
+    <Dropdown role="menu">
       <div className="d-none d-lg-block">
         <Dropdown.Toggle
           data-testid="user-info-image"

--- a/scss/profileDropDown.module.scss
+++ b/scss/profileDropDown.module.scss
@@ -8,7 +8,8 @@
   color: #343a40;
   align-items: center;
   grid-column-gap: 8px;
-  cursor: pointer;
+  background: none;
+  border: none;
   text-transform: capitalize;
   font-weight: 700;
   &::after {


### PR DESCRIPTION
This PR Closes #2270, it updates the user dropdown menu toggle button from a `div` element to a `button` element.

How to test:
- Cycle through the elements via `tab` key until you get to the dropdown menu
- Hit enter/space to toggle the menu
- Cycle through the dropdown menu using `tab` key