### PR TITLE
Add exercise card to DOJO exercises page

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5219,7 +5219,7 @@ Array [
 
 exports[`Storyshots Components/ExerciseCard Basic 1`] = `
 <section
-  className="card p-4 border-0 shadow"
+  className="card p-5 border-0 shadow"
 >
   <div
     className="fw-bold mb-2"

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -21,7 +21,7 @@ const ExerciseCard = ({
   const [answerShown, setAnswerShown] = useState(false)
 
   return (
-    <section className="card p-4 border-0 shadow">
+    <section className="card p-5 border-0 shadow">
       <div className="fw-bold mb-2">Problem</div>
       <div className="d-flex mb-2">
         <pre className="w-50 bg-light py-3 px-4 mb-0 me-3">{problem}</pre>

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -61,7 +61,7 @@ const mockExercises: ExerciseCardProps[] = [
 const Exercises: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
   const { lessons, alerts } = queryData
   const router = useRouter()
-  const [exerciseIndex, setExerciseIndex] = useState<number>(-1)
+  const [exerciseIndex, setExerciseIndex] = useState(-1)
   if (!router.isReady) return <LoadingSpinner />
 
   const slug = router.query.lessonSlug as string
@@ -125,10 +125,7 @@ const Exercise = ({
         className="btn ps-0 d-flex align-items-center"
         onClick={() => setExerciseIndex(-1)}
       >
-        <ArrowLeftIcon size="medium" />
-        <div className="p-3">
-          <Text size="xs">Exit</Text>
-        </div>
+        <ArrowLeftIcon size="medium" aria-label="Exit" />
       </button>
 
       <h1 className="mb-4 fs-2">{lessonTitle}</h1>

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -138,7 +138,8 @@ const Exercise = ({
         {showPreviousButton ? (
           <button
             onClick={() => setExerciseIndex(i => i - 1)}
-            className="btn btn-outline-primary"
+            className="btn btn-outline-primary fw-bold px-4 py-2"
+            style={{ fontFamily: 'PT Mono', fontSize: 14 }}
           >
             PREVIOUS
           </button>
@@ -148,7 +149,8 @@ const Exercise = ({
         {showSkipButton ? (
           <button
             onClick={() => setExerciseIndex(i => i + 1)}
-            className="btn btn-outline-primary"
+            className="btn btn-outline-primary fw-bold px-4 py-2"
+            style={{ fontFamily: 'PT Mono', fontSize: 14 }}
           >
             SKIP
           </button>

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -173,12 +173,14 @@ const ExerciseList = ({
 }: ExerciseListProps) => {
   return (
     <>
-      <NavCard
-        tabSelected={tabs.findIndex(tab => tab.text === 'exercises')}
-        tabs={tabs}
-      />
+      <div className="mb-4">
+        <NavCard
+          tabSelected={tabs.findIndex(tab => tab.text === 'exercises')}
+          tabs={tabs}
+        />
+      </div>
       <div className="d-flex justify-content-between align-items-center">
-        <h1 className="my-4 fs-2">{lessonTitle}</h1>
+        <h1 className="my-5 fs-2">{lessonTitle}</h1>
         <NewButton onClick={() => setExerciseIndex(0)}>
           SOLVE EXERCISES
         </NewButton>

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -16,7 +16,6 @@ import ExercisePreviewCard, {
 import { NewButton } from '../../components/theme/Button'
 import ExerciseCard, { ExerciseCardProps } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
-import { Text } from '../../components/theme/Text'
 
 const exampleProblem = `const a = 5
 a = a + 10


### PR DESCRIPTION
This pull request doesn't change any user-facing pages, it only changes the DOJO exercises pages (e.g. /exercises/js0) which currently doesn't have any links to it.

This pull request adds the exercise card to the DOJO exercises page. It currently uses mock data on the frontend and doesn't store the user's answers. It will be connected to the backend and real data in a subsequent pull request.

How to test:
* Go to /exercises/js0
* Click "SOLVE EXERCISES" button
* Answer questions, show and hide solutions, click "SKIP" button, click "PREVIOUS" button, click "Exit" button

The newly added "SOLVED EXERCISES" button on the right side of the /exercises/js0 page:
![solve-exercises-button](https://user-images.githubusercontent.com/7637655/190899805-86d4f905-cfb6-47d5-a015-86c7106f8683.png)

The first exercise:
![solve-exercise](https://user-images.githubusercontent.com/7637655/190899803-39f4310d-54bd-43f3-8cb1-d2bb3c6e7b0d.png)

The solved second exercise:
![solve-exercise-2](https://user-images.githubusercontent.com/7637655/190899802-d7d13083-d650-4e75-8f6e-1567cff0c5f3.png)

This pull request is a part of https://github.com/garageScript/c0d3-app/issues/2253