### PR TITLE
Fix ungraceful error when no user profile is found

### DIFF
--- a/pages/profile/[username].tsx
+++ b/pages/profile/[username].tsx
@@ -34,12 +34,7 @@ const UserProfile: React.FC = () => {
     return <LoadingSpinner />
   }
   if (error) {
-    return (
-      <Error
-        code={StatusCode.INTERNAL_SERVER_ERROR}
-        message="Internal server error"
-      />
-    )
+    return <Error code={StatusCode.NOT_FOUND} message="User not found" />
   }
   const { lessons } = data || {}
   const lessonsList = lessons || []


### PR DESCRIPTION
This PR closes #2324
It will show `404 Error! User not found` instead of the ungraceful `Internal server error` message.

![Screen Shot 2022-09-18 at 18 47 26](https://user-images.githubusercontent.com/1410462/190921248-712daaf7-c6e0-401e-9a5c-d30fdcd541b4.png)
