### PR TITLE
Get exercises from backend on DOJO exercises page

### DIFF
--- a/__dummy__/getExercisesData.ts
+++ b/__dummy__/getExercisesData.ts
@@ -1,0 +1,95 @@
+import { GetExercisesQuery } from '../graphql'
+
+const getExercisesData: GetExercisesQuery = {
+  lessons: [
+    {
+      title: 'Foundations of JavaScript',
+      docUrl: '/curriculum/js0/primitive_data_and_operators',
+      slug: 'js0'
+    },
+    {
+      title: 'Variables & Functions',
+      docUrl: '/curriculum/js1/hypertext_markup_language',
+      slug: 'js1'
+    },
+    {
+      title: 'Arrays',
+      docUrl: '/curriculum/js2/introduction_to_testing_inner_properties',
+      slug: 'js2'
+    },
+    {
+      title: 'Objects',
+      docUrl: '/curriculum/js3/preflight',
+      slug: 'js3'
+    },
+    {
+      title: 'Front End Engineering',
+      docUrl: '/curriculum/js4/interactive_elements',
+      slug: 'js4'
+    },
+    {
+      title: 'End To End',
+      docUrl: '/curriculum/js5/request_and_response',
+      slug: 'js5'
+    },
+    {
+      title: 'React, GraphQL, SocketIO',
+      docUrl: '',
+      slug: 'js6'
+    },
+    {
+      title: 'JavaScript Algorithms',
+      docUrl:
+        'https://docs.google.com/document/d/1ekuu6VbN7qqypm71cVHT-BkdxYSwY0BBHLK8xGXSN1U/edit',
+      slug: 'js7'
+    },
+    {
+      title: 'Trees',
+      docUrl: '',
+      slug: 'js8'
+    },
+    {
+      title: 'General Algorithms',
+      docUrl: '',
+      slug: 'js9'
+    }
+  ],
+  alerts: [],
+  exercises: [
+    {
+      module: {
+        name: 'Numbers',
+        lesson: {
+          slug: 'js0'
+        }
+      },
+      description: '```\nlet a = 5\na = a + 10\n// what is a?\n```',
+      answer: '15',
+      explanation: 'You can reassign variables that were created with "let".'
+    },
+    {
+      module: {
+        name: 'Numbers',
+        lesson: {
+          slug: 'js0'
+        }
+      },
+      description: '```\nlet a = 1\na += 2\n// what is a?\n```',
+      answer: '3',
+      explanation: '`a += 2` is a shorter way to write `a = a + 2`'
+    },
+    {
+      module: {
+        name: 'Numbers',
+        lesson: {
+          slug: 'js0'
+        }
+      },
+      description: '```\nlet a = 1\na -= 2\n// what is a?\n```',
+      answer: '-1',
+      explanation: '`a -= 2` is a shorter way to write `a = a - 2`'
+    }
+  ]
+}
+
+export default getExercisesData

--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -4,16 +4,8 @@ import '@testing-library/jest-dom'
 import Exercises from '../../../pages/exercises/[lessonSlug]'
 import { useRouter } from 'next/router'
 import { MockedProvider } from '@apollo/client/testing'
-import dummyLessonData from '../../../__dummy__/lessonData'
-import dummySessionData from '../../../__dummy__/sessionData'
-import dummyAlertData from '../../../__dummy__/alertData'
-import GET_APP from '../../../graphql/queries/getApp'
-
-const session = {
-  ...dummySessionData,
-  submissions: [],
-  lessonStatus: []
-}
+import getExercisesData from '../../../__dummy__/getExercisesData'
+import GET_EXERCISES from '../../../graphql/queries/getExercises'
 
 describe('Exercises page', () => {
   const { query } = useRouter()
@@ -22,13 +14,9 @@ describe('Exercises page', () => {
   test('Should render correctly', async () => {
     const mocks = [
       {
-        request: { query: GET_APP },
+        request: { query: GET_EXERCISES },
         result: {
-          data: {
-            session,
-            lessons: dummyLessonData,
-            alerts: dummyAlertData
-          }
+          data: getExercisesData
         }
       }
     ]
@@ -51,13 +39,9 @@ describe('Exercises page', () => {
   test('Renders exercise card with the skip, previous, and exit buttons', async () => {
     const mocks = [
       {
-        request: { query: GET_APP },
+        request: { query: GET_EXERCISES },
         result: {
-          data: {
-            session,
-            lessons: dummyLessonData,
-            alerts: dummyAlertData
-          }
+          data: getExercisesData
         }
       }
     ]
@@ -101,15 +85,14 @@ describe('Exercises page', () => {
   test('Should not render lessons nav card tab if lesson docUrl is null', async () => {
     const mocks = [
       {
-        request: { query: GET_APP },
+        request: { query: GET_EXERCISES },
         result: {
           data: {
-            session,
-            lessons: dummyLessonData.map(lesson => ({
+            ...getExercisesData,
+            lessons: getExercisesData.lessons.map(lesson => ({
               ...lesson,
               docUrl: null
-            })),
-            alerts: dummyAlertData
+            }))
           }
         }
       }
@@ -133,12 +116,11 @@ describe('Exercises page', () => {
   test('Should render a 500 error page if the lesson data is null', async () => {
     const mocks = [
       {
-        request: { query: GET_APP },
+        request: { query: GET_EXERCISES },
         result: {
           data: {
-            session,
-            lessons: null,
-            alerts: dummyAlertData
+            ...getExercisesData,
+            lessons: null
           }
         }
       }
@@ -156,12 +138,11 @@ describe('Exercises page', () => {
   test('Should render a 404 error page if the lesson is not found', async () => {
     const mocks = [
       {
-        request: { query: GET_APP },
+        request: { query: GET_EXERCISES },
         result: {
           data: {
-            session,
-            lessons: [],
-            alerts: dummyAlertData
+            ...getExercisesData,
+            lessons: []
           }
         }
       }
@@ -182,13 +163,9 @@ describe('Exercises page', () => {
     }))
     const mocks = [
       {
-        request: { query: GET_APP },
+        request: { query: GET_EXERCISES },
         result: {
-          data: {
-            session,
-            lessons: dummyLessonData,
-            alerts: dummyAlertData
-          }
+          data: getExercisesData
         }
       }
     ]

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -427,57 +427,6 @@ export type UserLesson = {
   userId?: Maybe<Scalars['String']>
 }
 
-export type LessonAndChallengeInfoFragment = {
-  __typename?: 'Lesson'
-  id: number
-  docUrl?: string | null
-  githubUrl?: string | null
-  videoUrl?: string | null
-  chatUrl?: string | null
-  order: number
-  description: string
-  title: string
-  challenges: Array<{
-    __typename?: 'Challenge'
-    id: number
-    description: string
-    lessonId: number
-    title: string
-    order: number
-  }>
-}
-
-export type SubmissionsInfoFragment = {
-  __typename?: 'Submission'
-  id: number
-  status: SubmissionStatus
-  diff?: string | null
-  comment?: string | null
-  challengeId: number
-  lessonId: number
-  createdAt?: string | null
-  updatedAt: string
-  challenge: { __typename?: 'Challenge'; title: string; description: string }
-  user: { __typename?: 'User'; id: number; username: string }
-  reviewer?: {
-    __typename?: 'User'
-    id: number
-    username: string
-    name: string
-  } | null
-  comments?: Array<{
-    __typename?: 'Comment'
-    id: number
-    content: string
-    submissionId: number
-    createdAt: string
-    authorId: number
-    line?: number | null
-    fileName?: string | null
-    author?: { __typename?: 'User'; username: string; name: string } | null
-  }> | null
-}
-
 export type AcceptSubmissionMutationVariables = Exact<{
   submissionId: Scalars['Int']
   comment: Scalars['String']
@@ -706,6 +655,16 @@ export type DeleteModuleMutation = {
   }
 }
 
+export type EditCommentMutationVariables = Exact<{
+  id: Scalars['Int']
+  content: Scalars['String']
+}>
+
+export type EditCommentMutation = {
+  __typename?: 'Mutation'
+  editComment?: { __typename?: 'Comment'; id: number; content: string } | null
+}
+
 export type FlagExerciseMutationVariables = Exact<{
   id: Scalars['Int']
   flagReason: Scalars['String']
@@ -714,6 +673,57 @@ export type FlagExerciseMutationVariables = Exact<{
 export type FlagExerciseMutation = {
   __typename?: 'Mutation'
   flagExercise?: { __typename?: 'Exercise'; id: number } | null
+}
+
+export type LessonAndChallengeInfoFragment = {
+  __typename?: 'Lesson'
+  id: number
+  docUrl?: string | null
+  githubUrl?: string | null
+  videoUrl?: string | null
+  chatUrl?: string | null
+  order: number
+  description: string
+  title: string
+  challenges: Array<{
+    __typename?: 'Challenge'
+    id: number
+    description: string
+    lessonId: number
+    title: string
+    order: number
+  }>
+}
+
+export type SubmissionsInfoFragment = {
+  __typename?: 'Submission'
+  id: number
+  status: SubmissionStatus
+  diff?: string | null
+  comment?: string | null
+  challengeId: number
+  lessonId: number
+  createdAt?: string | null
+  updatedAt: string
+  challenge: { __typename?: 'Challenge'; title: string; description: string }
+  user: { __typename?: 'User'; id: number; username: string }
+  reviewer?: {
+    __typename?: 'User'
+    id: number
+    username: string
+    name: string
+  } | null
+  comments?: Array<{
+    __typename?: 'Comment'
+    id: number
+    content: string
+    submissionId: number
+    createdAt: string
+    authorId: number
+    line?: number | null
+    fileName?: string | null
+    author?: { __typename?: 'User'; username: string; name: string } | null
+  }> | null
 }
 
 export type GetAppQueryVariables = Exact<{ [key: string]: never }>
@@ -798,6 +808,37 @@ export type GetAppQuery = {
     url?: string | null
     urlCaption?: string | null
   }>
+}
+
+export type GetExercisesQueryVariables = Exact<{ [key: string]: never }>
+
+export type GetExercisesQuery = {
+  __typename?: 'Query'
+  lessons: Array<{
+    __typename?: 'Lesson'
+    title: string
+    docUrl?: string | null
+    slug: string
+  }>
+  alerts: Array<{
+    __typename?: 'Alert'
+    id: number
+    text?: string | null
+    type?: string | null
+    url?: string | null
+    urlCaption?: string | null
+  }>
+  exercises: Array<{
+    __typename?: 'Exercise'
+    description: string
+    answer: string
+    explanation?: string | null
+    module: {
+      __typename?: 'Module'
+      name: string
+      lesson: { __typename?: 'Lesson'; slug: string }
+    }
+  } | null>
 }
 
 export type GetFlaggedExercisesQueryVariables = Exact<{ [key: string]: never }>
@@ -1239,16 +1280,6 @@ export type UserInfoQuery = {
       } | null> | null
     }>
   } | null
-}
-
-export type EditCommentMutationVariables = Exact<{
-  id: Scalars['Int']
-  content: Scalars['String']
-}>
-
-export type EditCommentMutation = {
-  __typename?: 'Mutation'
-  editComment?: { __typename?: 'Comment'; id: number; content: string } | null
 }
 
 export type WithIndex<TObject> = TObject & Record<string, any>
@@ -3171,6 +3202,89 @@ export type DeleteModuleMutationOptions = Apollo.BaseMutationOptions<
   DeleteModuleMutation,
   DeleteModuleMutationVariables
 >
+export const EditCommentDocument = gql`
+  mutation editComment($id: Int!, $content: String!) {
+    editComment(id: $id, content: $content) {
+      id
+      content
+    }
+  }
+`
+export type EditCommentMutationFn = Apollo.MutationFunction<
+  EditCommentMutation,
+  EditCommentMutationVariables
+>
+export type EditCommentProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: Apollo.MutationFunction<
+    EditCommentMutation,
+    EditCommentMutationVariables
+  >
+} & TChildProps
+export function withEditComment<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    EditCommentMutation,
+    EditCommentMutationVariables,
+    EditCommentProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    EditCommentMutation,
+    EditCommentMutationVariables,
+    EditCommentProps<TChildProps, TDataName>
+  >(EditCommentDocument, {
+    alias: 'editComment',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useEditCommentMutation__
+ *
+ * To run a mutation, you first call `useEditCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useEditCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [editCommentMutation, { data, loading, error }] = useEditCommentMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      content: // value for 'content'
+ *   },
+ * });
+ */
+export function useEditCommentMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    EditCommentMutation,
+    EditCommentMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<EditCommentMutation, EditCommentMutationVariables>(
+    EditCommentDocument,
+    options
+  )
+}
+export type EditCommentMutationHookResult = ReturnType<
+  typeof useEditCommentMutation
+>
+export type EditCommentMutationResult =
+  Apollo.MutationResult<EditCommentMutation>
+export type EditCommentMutationOptions = Apollo.BaseMutationOptions<
+  EditCommentMutation,
+  EditCommentMutationVariables
+>
 export const FlagExerciseDocument = gql`
   mutation flagExercise($id: Int!, $flagReason: String!) {
     flagExercise(id: $id, flagReason: $flagReason) {
@@ -3401,6 +3515,114 @@ export type GetAppLazyQueryHookResult = ReturnType<typeof useGetAppLazyQuery>
 export type GetAppQueryResult = Apollo.QueryResult<
   GetAppQuery,
   GetAppQueryVariables
+>
+export const GetExercisesDocument = gql`
+  query GetExercises {
+    lessons {
+      title
+      docUrl
+      slug
+    }
+    alerts {
+      id
+      text
+      type
+      url
+      urlCaption
+    }
+    exercises {
+      module {
+        name
+        lesson {
+          slug
+        }
+      }
+      description
+      answer
+      explanation
+    }
+  }
+`
+export type GetExercisesProps<
+  TChildProps = {},
+  TDataName extends string = 'data'
+> = {
+  [key in TDataName]: ApolloReactHoc.DataValue<
+    GetExercisesQuery,
+    GetExercisesQueryVariables
+  >
+} & TChildProps
+export function withGetExercises<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'data'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    GetExercisesQuery,
+    GetExercisesQueryVariables,
+    GetExercisesProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withQuery<
+    TProps,
+    GetExercisesQuery,
+    GetExercisesQueryVariables,
+    GetExercisesProps<TChildProps, TDataName>
+  >(GetExercisesDocument, {
+    alias: 'getExercises',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useGetExercisesQuery__
+ *
+ * To run a query within a React component, call `useGetExercisesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetExercisesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetExercisesQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetExercisesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetExercisesQuery,
+    GetExercisesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetExercisesQuery, GetExercisesQueryVariables>(
+    GetExercisesDocument,
+    options
+  )
+}
+export function useGetExercisesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetExercisesQuery,
+    GetExercisesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetExercisesQuery, GetExercisesQueryVariables>(
+    GetExercisesDocument,
+    options
+  )
+}
+export type GetExercisesQueryHookResult = ReturnType<
+  typeof useGetExercisesQuery
+>
+export type GetExercisesLazyQueryHookResult = ReturnType<
+  typeof useGetExercisesLazyQuery
+>
+export type GetExercisesQueryResult = Apollo.QueryResult<
+  GetExercisesQuery,
+  GetExercisesQueryVariables
 >
 export const GetFlaggedExercisesDocument = gql`
   query getFlaggedExercises {
@@ -5247,89 +5469,6 @@ export type UserInfoLazyQueryHookResult = ReturnType<
 export type UserInfoQueryResult = Apollo.QueryResult<
   UserInfoQuery,
   UserInfoQueryVariables
->
-export const EditCommentDocument = gql`
-  mutation editComment($id: Int!, $content: String!) {
-    editComment(id: $id, content: $content) {
-      id
-      content
-    }
-  }
-`
-export type EditCommentMutationFn = Apollo.MutationFunction<
-  EditCommentMutation,
-  EditCommentMutationVariables
->
-export type EditCommentProps<
-  TChildProps = {},
-  TDataName extends string = 'mutate'
-> = {
-  [key in TDataName]: Apollo.MutationFunction<
-    EditCommentMutation,
-    EditCommentMutationVariables
-  >
-} & TChildProps
-export function withEditComment<
-  TProps,
-  TChildProps = {},
-  TDataName extends string = 'mutate'
->(
-  operationOptions?: ApolloReactHoc.OperationOption<
-    TProps,
-    EditCommentMutation,
-    EditCommentMutationVariables,
-    EditCommentProps<TChildProps, TDataName>
-  >
-) {
-  return ApolloReactHoc.withMutation<
-    TProps,
-    EditCommentMutation,
-    EditCommentMutationVariables,
-    EditCommentProps<TChildProps, TDataName>
-  >(EditCommentDocument, {
-    alias: 'editComment',
-    ...operationOptions
-  })
-}
-
-/**
- * __useEditCommentMutation__
- *
- * To run a mutation, you first call `useEditCommentMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useEditCommentMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [editCommentMutation, { data, loading, error }] = useEditCommentMutation({
- *   variables: {
- *      id: // value for 'id'
- *      content: // value for 'content'
- *   },
- * });
- */
-export function useEditCommentMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    EditCommentMutation,
-    EditCommentMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions }
-  return Apollo.useMutation<EditCommentMutation, EditCommentMutationVariables>(
-    EditCommentDocument,
-    options
-  )
-}
-export type EditCommentMutationHookResult = ReturnType<
-  typeof useEditCommentMutation
->
-export type EditCommentMutationResult =
-  Apollo.MutationResult<EditCommentMutation>
-export type EditCommentMutationOptions = Apollo.BaseMutationOptions<
-  EditCommentMutation,
-  EditCommentMutationVariables
 >
 export type AlertKeySpecifier = (
   | 'id'

--- a/graphql/queries/getExercises.ts
+++ b/graphql/queries/getExercises.ts
@@ -1,0 +1,31 @@
+import { gql } from '@apollo/client'
+
+const GET_EXERCISES = gql`
+  query GetExercises {
+    lessons {
+      title
+      docUrl
+      slug
+    }
+    alerts {
+      id
+      text
+      type
+      url
+      urlCaption
+    }
+    exercises {
+      module {
+        name
+        lesson {
+          slug
+        }
+      }
+      description
+      answer
+      explanation
+    }
+  }
+`
+
+export default GET_EXERCISES

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -4,10 +4,9 @@ import Layout from '../../components/Layout'
 import withQueryLoader, {
   QueryDataProps
 } from '../../containers/withQueryLoader'
-import { GetAppQuery } from '../../graphql'
+import { GetExercisesQuery } from '../../graphql'
 import Error, { StatusCode } from '../../components/Error'
 import LoadingSpinner from '../../components/LoadingSpinner'
-import GET_APP from '../../graphql/queries/getApp'
 import AlertsDisplay from '../../components/AlertsDisplay'
 import NavCard from '../../components/NavCard'
 import ExercisePreviewCard, {
@@ -16,17 +15,10 @@ import ExercisePreviewCard, {
 import { NewButton } from '../../components/theme/Button'
 import ExerciseCard, { ExerciseCardProps } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
+import GET_EXERCISES from '../../graphql/queries/getExercises'
 
 const exampleProblem = `const a = 5
 a = a + 10
-// what is a?`
-
-const exampleProblem2 = `let a = 5
-a = a + 10
-// what is a?`
-
-const exampleProblem3 = `let a = 5
-a = a + '10'
 // what is a?`
 
 const mockExercisePreviews: ExercisePreviewCardProps[] = [
@@ -35,36 +27,16 @@ const mockExercisePreviews: ExercisePreviewCardProps[] = [
   { moduleName: 'Variables', state: 'ANSWERED', problem: exampleProblem }
 ]
 
-const mockExercises: ExerciseCardProps[] = [
-  {
-    challengeName: 'Variable mutation',
-    problem: exampleProblem,
-    answer: 'An error is thrown',
-    explanation: 'You cannot reassign variables that were created with "const".'
-  },
-  {
-    challengeName: 'Variable mutation 2',
-    problem: exampleProblem2,
-    answer: '15',
-    explanation: 'You can reassign variables that were created with "let".'
-  },
-  {
-    challengeName: 'Variable mutation 3',
-    problem: exampleProblem3,
-    answer: `'510'`,
-    explanation:
-      'If you add a string and number together, the number gets converted to a string and then they get concatenated.'
-  }
-]
-
-const Exercises: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
-  const { lessons, alerts } = queryData
+const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
+  queryData
+}) => {
+  const { lessons, alerts, exercises } = queryData
   const router = useRouter()
   const [exerciseIndex, setExerciseIndex] = useState(-1)
   if (!router.isReady) return <LoadingSpinner />
 
   const slug = router.query.lessonSlug as string
-  if (!lessons || !alerts)
+  if (!lessons || !alerts || !exercises)
     return <Error code={StatusCode.INTERNAL_SERVER_ERROR} message="Bad data" />
 
   const currentLesson = lessons.find(lesson => lesson.slug === slug)
@@ -79,7 +51,16 @@ const Exercises: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
     { text: 'exercises', url: `/exercises/${currentLesson.slug}` }
   ]
 
-  const exercise = mockExercises[exerciseIndex]
+  const currentExercises = exercises
+    .filter(exercise => exercise?.module.lesson.slug === slug)
+    .map(exercise => ({
+      challengeName: exercise?.module.name!,
+      problem: exercise?.description!,
+      answer: exercise?.answer!,
+      explanation: exercise?.explanation!
+    }))
+
+  const exercise = currentExercises[exerciseIndex]
 
   return (
     <Layout title={currentLesson.title}>
@@ -89,7 +70,7 @@ const Exercises: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
           setExerciseIndex={setExerciseIndex}
           lessonTitle={currentLesson.title}
           showPreviousButton={exerciseIndex > 0}
-          showSkipButton={exerciseIndex < mockExercises.length - 1}
+          showSkipButton={exerciseIndex < currentExercises.length - 1}
         />
       ) : (
         <ExerciseList
@@ -206,9 +187,9 @@ const ExerciseList = ({
   )
 }
 
-export default withQueryLoader<GetAppQuery>(
+export default withQueryLoader<GetExercisesQuery>(
   {
-    query: GET_APP
+    query: GET_EXERCISES
   },
   Exercises
 )


### PR DESCRIPTION
This pull request doesn't affect any user-facing pages since there are no direct links to the DOJO exercises page.

This pull request makes it so the DOJO exercises page gets the exercises from the backend instead of relying on mock data on the frontend.

How to test:
* Create a module at /admin/lessons/js0/modules
* Create exercises at /curriculum/js0/mentor
* Go to /exercises/js0 and click on the "SOLVE EXERCISES" button on the right and verify the exercises still work

The exercise page currently doesn't send any mutations to the backend. We will add mutations to update the user's answers to the exercises on the backend in a subsequent pull request.

This pull request is a part of https://github.com/garageScript/c0d3-app/issues/2253