### PR TITLE
Make DOJO exercises not nullable and fix React key bug

### DIFF
--- a/__dummy__/getExercisesData.ts
+++ b/__dummy__/getExercisesData.ts
@@ -87,7 +87,7 @@ const getExercisesData: GetExercisesQuery = {
       },
       description: '```\nlet a = 1\na -= 2\n// what is a?\n```',
       answer: '-1',
-      explanation: '`a -= 2` is a shorter way to write `a = a - 2`'
+      explanation: null
     }
   ]
 }

--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -64,10 +64,11 @@ describe('Exercises page', () => {
     // Previous button is not in the document on the first exercise.
     expect(queryByRole('button', { name: 'PREVIOUS' })).not.toBeInTheDocument()
 
-    const skipButton = getByRole('button', { name: 'SKIP' })
+    let skipButton = getByRole('button', { name: 'SKIP' })
     fireEvent.click(skipButton)
     expect(queryByRole('button', { name: 'PREVIOUS' })).toBeInTheDocument()
 
+    skipButton = getByRole('button', { name: 'SKIP' })
     fireEvent.click(skipButton)
     // Skip button should not be in the document because we're on the last exercise now.
     expect(queryByRole('button', { name: 'SKIP' })).not.toBeInTheDocument()

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -315,7 +315,7 @@ export type Query = {
   __typename?: 'Query'
   alerts: Array<Alert>
   allUsers?: Maybe<Array<Maybe<User>>>
-  exercises: Array<Maybe<Exercise>>
+  exercises: Array<Exercise>
   getLessonMentors?: Maybe<Array<Maybe<User>>>
   getPreviousSubmissions?: Maybe<Array<Submission>>
   isTokenValid: Scalars['Boolean']
@@ -838,7 +838,7 @@ export type GetExercisesQuery = {
       name: string
       lesson: { __typename?: 'Lesson'; slug: string }
     }
-  } | null>
+  }>
 }
 
 export type GetFlaggedExercisesQueryVariables = Exact<{ [key: string]: never }>
@@ -852,7 +852,7 @@ export type GetFlaggedExercisesQuery = {
       __typename?: 'Module'
       lesson: { __typename?: 'Lesson'; title: string }
     }
-  } | null>
+  }>
 }
 
 export type LessonMentorsQueryVariables = Exact<{
@@ -1780,7 +1780,7 @@ export type QueryResolvers<
     ContextType
   >
   exercises?: Resolver<
-    Array<Maybe<ResolversTypes['Exercise']>>,
+    Array<ResolversTypes['Exercise']>,
     ParentType,
     ContextType
   >

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -6,7 +6,7 @@ export default gql`
     session: Session!
     allUsers: [User]
     modules: [Module]!
-    exercises: [Exercise]!
+    exercises: [Exercise!]!
     getLessonMentors(lessonId: Int!): [User]
     userInfo(username: String!): Session
     isTokenValid(cliToken: String!): Boolean!

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -54,10 +54,10 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   const currentExercises = exercises
     .filter(exercise => exercise?.module.lesson.slug === slug)
     .map(exercise => ({
-      challengeName: exercise?.module.name!,
-      problem: exercise?.description!,
-      answer: exercise?.answer!,
-      explanation: exercise?.explanation!
+      challengeName: exercise.module.name,
+      problem: exercise.description,
+      answer: exercise.answer,
+      explanation: exercise.explanation || ''
     }))
 
   const exercise = currentExercises[exerciseIndex]
@@ -66,6 +66,7 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
     <Layout title={currentLesson.title}>
       {exercise ? (
         <Exercise
+          key={exerciseIndex}
           exercise={exercise}
           setExerciseIndex={setExerciseIndex}
           lessonTitle={currentLesson.title}


### PR DESCRIPTION
This pull request doesn't affect any user-facing pages.

This pull request makes the exercises type definition on the backend non-nullable (i.e. `[Exercise!]!`) which makes the data easier to deal with. This won't cause any problems because we never return any null values in the exercises array.

This pull request also fixes a small React key bug which made it possible to previously press "Show Answer" then "Skip" which would make it go to the next exercise but the next exercise would already be showing the answer. Now if you press "Show Answer" then "Skip" the next answer will not be showing because we added a `key={exerciseIndex}` property to the Exercise component which causes a rerender when `exerciseIndex` changes.

We also safely handle the case where there is no exercise explanation (notice the bottom right is empty because this exercise happens to not have an explanation):
![empty-explanation](https://user-images.githubusercontent.com/7637655/191484620-dea4d476-1cdc-4a24-85e5-24530b678aa4.png)

How to test:
* Create a module at /admin/lessons/js0/modules
* Create exercises at /curriculum/js0/mentor
* Go to /exercises/js0 and click on the "SOLVE EXERCISES" button on the right and verify the exercises still work

This pull request is a part of https://github.com/garageScript/c0d3-app/issues/2253