### PR TITLE
Handle styling of varying amounts of DOJO exercise previews

### DIFF
--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -16,6 +16,7 @@ import { NewButton } from '../../components/theme/Button'
 import ExerciseCard, { ExerciseCardProps } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
 import GET_EXERCISES from '../../graphql/queries/getExercises'
+import chunk from 'lodash/chunk'
 
 const exampleProblem = `const a = 5
 a = a + 10
@@ -24,6 +25,7 @@ a = a + 10
 const mockExercisePreviews: ExercisePreviewCardProps[] = [
   { moduleName: 'Variables', state: 'ANSWERED', problem: exampleProblem },
   { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
+  { moduleName: 'Variables', state: 'ANSWERED', problem: exampleProblem },
   { moduleName: 'Variables', state: 'ANSWERED', problem: exampleProblem }
 ]
 
@@ -170,19 +172,20 @@ const ExerciseList = ({
         </NewButton>
       </div>
       <div className="container">
-        <div className="row">
-          {mockExercisePreviews.map((exercisePreview, i) => (
-            <ExercisePreviewCard
-              key={i}
-              moduleName={exercisePreview.moduleName}
-              state={exercisePreview.state}
-              problem={exercisePreview.problem}
-              className={`col ${
-                i < mockExercisePreviews.length - 1 ? 'me-4' : ''
-              }`}
-            />
-          ))}
-        </div>
+        {chunk(mockExercisePreviews, 3).map((exercisePreviewChunk, i) => (
+          <div key={i} className="row mb-4">
+            {exercisePreviewChunk.map((exercisePreview, j) => (
+              <div key={j} className="col-4 d-flex">
+                <ExercisePreviewCard
+                  moduleName={exercisePreview.moduleName}
+                  state={exercisePreview.state}
+                  problem={exercisePreview.problem}
+                  className="flex-grow-1"
+                />
+              </div>
+            ))}
+          </div>
+        ))}
       </div>
     </>
   )


### PR DESCRIPTION
This pull request fixes some of the styling for the DOJO exercise previews so that they look good with any amount.

With 8 exercise previews:
![exercise-previews](https://user-images.githubusercontent.com/7637655/192060682-d9b764e2-0dbb-43b4-abab-7032d0d84b04.png)

With 4 exercise previews:
![exercise-previews-2](https://user-images.githubusercontent.com/7637655/192060737-e984b207-848a-4564-93b8-eda5444fa0bf.png)

How to test:
* Go to /exercises/js0
* Check that the exercise previews look good

This is a part of https://github.com/garageScript/c0d3-app/issues/2251