### PR TITLE
Make DOJO exercise list responsive

### DIFF
--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -16,6 +16,7 @@ import { NewButton } from '../../components/theme/Button'
 import ExerciseCard, { ExerciseCardProps } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
 import GET_EXERCISES from '../../graphql/queries/getExercises'
+import styles from '../../scss/exercises.module.scss'
 
 const exampleProblem = `const a = 5
 a = a + 10
@@ -23,6 +24,11 @@ a = a + 10
 
 const mockExercisePreviews: ExercisePreviewCardProps[] = [
   { moduleName: 'Variables', state: 'ANSWERED', problem: exampleProblem },
+  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
+  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
+  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
+  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
+  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
   { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
   { moduleName: 'Variables', state: 'ANSWERED', problem: exampleProblem }
 ]
@@ -169,20 +175,15 @@ const ExerciseList = ({
           SOLVE EXERCISES
         </NewButton>
       </div>
-      <div className="container">
-        <div className="row">
-          {mockExercisePreviews.map((exercisePreview, i) => (
-            <ExercisePreviewCard
-              key={i}
-              moduleName={exercisePreview.moduleName}
-              state={exercisePreview.state}
-              problem={exercisePreview.problem}
-              className={`col ${
-                i < mockExercisePreviews.length - 1 ? 'me-4' : ''
-              }`}
-            />
-          ))}
-        </div>
+      <div className={styles.exerciseList__container}>
+        {mockExercisePreviews.map((exercisePreview, i) => (
+          <ExercisePreviewCard
+            key={i}
+            moduleName={exercisePreview.moduleName}
+            state={exercisePreview.state}
+            problem={exercisePreview.problem}
+          />
+        ))}
       </div>
     </>
   )

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -169,11 +169,18 @@ const ExerciseList = ({
           tabs={tabs}
         />
       </div>
-      <div className="d-flex justify-content-between align-items-center">
-        <h1 className="my-5 fs-2">{lessonTitle}</h1>
-        <NewButton onClick={() => setExerciseIndex(0)}>
-          SOLVE EXERCISES
-        </NewButton>
+      <div className="d-flex flex-column flex-md-row justify-content-between align-items-center">
+        <h1 className="my-2 my-md-5 fs-2">{lessonTitle}</h1>
+        <div
+          className={`mb-3 mb-md-0 d-flex d-md-block ${styles.exerciseList__solveExercisesButtonContainer}`}
+        >
+          <NewButton
+            className="flex-grow-1"
+            onClick={() => setExerciseIndex(0)}
+          >
+            SOLVE EXERCISES
+          </NewButton>
+        </div>
       </div>
       <div className={styles.exerciseList__container}>
         {mockExercisePreviews.map((exercisePreview, i) => (

--- a/scss/exercises.module.scss
+++ b/scss/exercises.module.scss
@@ -1,0 +1,5 @@
+.exerciseList__container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2em;
+}

--- a/scss/exercises.module.scss
+++ b/scss/exercises.module.scss
@@ -3,3 +3,9 @@
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 2em;
 }
+
+.exerciseList__solveExercisesButtonContainer {
+  @media (max-width: 767px) {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
This pull request switches the DOJO exercise list styling to use CSS grid instead of Bootstrap rows so that it's responsive to different screen widths. 

How to test:
* Go to /exercises/js0
* Look at how the page looks at different screen widths and leave a comment if you see anything that looks off.
* Make sure styling looks good at Bootstrap breakpoints ([i.e. <576px, >=576px, >=768px, >=992px, >=1200px, >=1400px](https://getbootstrap.com/docs/5.0/layout/breakpoints/))

400px wide phone:
![exercise-list-400px](https://user-images.githubusercontent.com/7637655/192105689-94791d72-eb2a-44c4-b70e-89bac1e5e478.png)
600px wide:
![exercise-list-600px](https://user-images.githubusercontent.com/7637655/192105690-c6760309-00eb-4eb8-9cb5-ad8fcf60d8ad.png)
1000px wide:
![exercise-list-1000px](https://user-images.githubusercontent.com/7637655/192105691-25726a90-342a-4c1f-bbf1-42cd5df925f7.png)
1200px wide:
![exercise-list-1200px](https://user-images.githubusercontent.com/7637655/192105692-70b18f8e-d966-4291-83ca-b31fb34a8d21.png)
1600px wide:
![exercise-list-1600px](https://user-images.githubusercontent.com/7637655/192105693-373ea141-13e1-4b71-b2f3-bdd69f1793e7.png)

This pull request is a part of https://github.com/garageScript/c0d3-app/issues/2251