### PR TITLE
Make exercise card responsive and replace module name with "Your Answer"

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5222,20 +5222,24 @@ exports[`Storyshots Components/ExerciseCard Basic 1`] = `
   className="card p-5 border-0 shadow"
 >
   <div
-    className="fw-bold mb-2"
-  >
-    Problem
-  </div>
-  <div
     className="d-flex flex-column flex-md-row mb-2"
   >
-    <pre
-      className="bg-light py-3 px-4 mb-0 me-md-3 exerciseCard__section"
+    <div
+      className="mb-0 me-md-3 exerciseCard__section"
     >
-      let a = 5
+      <div
+        className="fw-bold mb-2"
+      >
+        Problem
+      </div>
+      <pre
+        className="bg-light py-3 px-4"
+      >
+        let a = 5
 a = a + 10
 // what is a?
-    </pre>
+      </pre>
+    </div>
     <div
       className="ms-md-3 exerciseCard__section"
     >
@@ -5251,7 +5255,7 @@ a = a + 10
         value=""
       />
       <div
-        className="exerciseCard__message  my-2"
+        className="exerciseCard__message  my-3"
       >
         
       </div>

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5227,22 +5227,22 @@ exports[`Storyshots Components/ExerciseCard Basic 1`] = `
     Problem
   </div>
   <div
-    className="d-flex mb-2"
+    className="d-flex flex-column flex-md-row mb-2"
   >
     <pre
-      className="w-50 bg-light py-3 px-4 mb-0 me-3"
+      className="bg-light py-3 px-4 mb-0 me-md-3 exerciseCard__section"
     >
       let a = 5
 a = a + 10
 // what is a?
     </pre>
     <div
-      className="w-50 ms-3"
+      className="ms-md-3 exerciseCard__section"
     >
       <div
-        className="mb-2"
+        className="fw-bold mt-2 mt-md-0 mb-2"
       >
-        Variable mutation
+        Your Answer
       </div>
       <input
         aria-label="User answer"
@@ -5256,7 +5256,7 @@ a = a + 10
         
       </div>
       <div
-        className="d-flex"
+        className="d-flex flex-column flex-md-row"
       >
         <button
           className="newButton "
@@ -5265,7 +5265,7 @@ a = a + 10
           SUBMIT
         </button>
         <button
-          className="bg-transparent ms-3 border-0 fw-normal"
+          className="bg-transparent mt-2 mt-md-0 ms-md-3 border-0 fw-normal"
           onClick={[Function]}
         >
           <div

--- a/components/ExerciseCard/ExerciseCard.test.tsx
+++ b/components/ExerciseCard/ExerciseCard.test.tsx
@@ -13,7 +13,6 @@ a = a + 10
 
     const { getByRole, queryByText, getByLabelText } = render(
       <ExerciseCard
-        challengeName="Variable mutation"
         problem={exampleProblem}
         answer={exampleAnswer}
         explanation={exampleExplanation}

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -75,9 +75,15 @@ const ExerciseCard = ({ problem, answer, explanation }: ExerciseCardProps) => {
         <>
           <hr />
           <div className="fw-bold mb-2">Answer</div>
-          <div className="d-flex mb-2">
-            <pre className="w-50 bg-light py-3 px-4 mb-0 me-3">{answer}</pre>
-            <div className="w-50 ms-3">{explanation}</div>
+          <div className="d-flex flex-column flex-md-row mb-2">
+            <pre
+              className={`bg-light py-3 px-4 mb-2 mb-md-0 me-md-3 ${styles.exerciseCard__section}`}
+            >
+              {answer}
+            </pre>
+            <div className={`ms-md-3 ${styles.exerciseCard__section}`}>
+              {explanation}
+            </div>
           </div>
         </>
       )}

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -4,7 +4,6 @@ import { Text } from '../theme/Text'
 import styles from './exerciseCard.module.scss'
 
 export type ExerciseCardProps = {
-  challengeName: string
   problem: string
   answer: string
   explanation: string
@@ -18,12 +17,7 @@ enum Message {
 
 type MessageKey = keyof typeof Message
 
-const ExerciseCard = ({
-  challengeName,
-  problem,
-  answer,
-  explanation
-}: ExerciseCardProps) => {
+const ExerciseCard = ({ problem, answer, explanation }: ExerciseCardProps) => {
   const [studentAnswer, setStudentAnswer] = useState('')
   const [answerShown, setAnswerShown] = useState(false)
   const [messageKey, setMessageKey] = useState<MessageKey>('EMPTY')
@@ -32,10 +26,14 @@ const ExerciseCard = ({
   return (
     <section className="card p-5 border-0 shadow">
       <div className="fw-bold mb-2">Problem</div>
-      <div className="d-flex mb-2">
-        <pre className="w-50 bg-light py-3 px-4 mb-0 me-3">{problem}</pre>
-        <div className="w-50 ms-3">
-          <div className="mb-2">{challengeName}</div>
+      <div className="d-flex flex-column flex-md-row mb-2">
+        <pre
+          className={`bg-light py-3 px-4 mb-0 me-md-3 ${styles.exerciseCard__section}`}
+        >
+          {problem}
+        </pre>
+        <div className={`ms-md-3 ${styles.exerciseCard__section}`}>
+          <div className="fw-bold mt-2 mt-md-0 mb-2">Your Answer</div>
           <input
             aria-label="User answer"
             className={`form-control mb-2 ${
@@ -51,7 +49,7 @@ const ExerciseCard = ({
           >
             {message}
           </div>
-          <div className="d-flex">
+          <div className="d-flex flex-column flex-md-row">
             <NewButton
               onClick={() => {
                 if (studentAnswer.trim() === answer.trim()) {
@@ -65,7 +63,7 @@ const ExerciseCard = ({
               SUBMIT
             </NewButton>
             <button
-              className="bg-transparent ms-3 border-0 fw-normal"
+              className="bg-transparent mt-2 mt-md-0 ms-md-3 border-0 fw-normal"
               onClick={() => setAnswerShown(!answerShown)}
             >
               <Text size="xs" bold>

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -25,13 +25,11 @@ const ExerciseCard = ({ problem, answer, explanation }: ExerciseCardProps) => {
 
   return (
     <section className="card p-5 border-0 shadow">
-      <div className="fw-bold mb-2">Problem</div>
       <div className="d-flex flex-column flex-md-row mb-2">
-        <pre
-          className={`bg-light py-3 px-4 mb-0 me-md-3 ${styles.exerciseCard__section}`}
-        >
-          {problem}
-        </pre>
+        <div className={`mb-0 me-md-3 ${styles.exerciseCard__section}`}>
+          <div className="fw-bold mb-2">Problem</div>
+          <pre className="bg-light py-3 px-4">{problem}</pre>
+        </div>
         <div className={`ms-md-3 ${styles.exerciseCard__section}`}>
           <div className="fw-bold mt-2 mt-md-0 mb-2">Your Answer</div>
           <input
@@ -45,7 +43,7 @@ const ExerciseCard = ({ problem, answer, explanation }: ExerciseCardProps) => {
           <div
             className={`${styles.exerciseCard__message} ${
               messageKey === 'ERROR' ? styles.exerciseCard__message__error : ''
-            } my-2`}
+            } my-3`}
           >
             {message}
           </div>

--- a/components/ExerciseCard/exerciseCard.module.scss
+++ b/components/ExerciseCard/exerciseCard.module.scss
@@ -1,5 +1,13 @@
 $error-red: #a0213e;
 
+.exerciseCard__section {
+  width: 100%;
+
+  @media (min-width: 768px) {
+    width: 50%;
+  }
+}
+
 .exerciseCard__message {
   min-height: 20px;
   font-size: 12px;

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -107,7 +107,7 @@ const Exercise = ({
   showSkipButton
 }: ExerciseProps) => {
   return (
-    <div className="w-75 mx-auto">
+    <div className={`mx-auto ${styles.exercise__container}`}>
       <button
         className="btn ps-0 d-flex align-items-center"
         onClick={() => setExerciseIndex(-1)}
@@ -117,7 +117,6 @@ const Exercise = ({
 
       <h1 className="mb-4 fs-2">{lessonTitle}</h1>
       <ExerciseCard
-        challengeName={exercise.challengeName}
         problem={exercise.problem}
         answer={exercise.answer}
         explanation={exercise.explanation}

--- a/scss/exercises.module.scss
+++ b/scss/exercises.module.scss
@@ -9,3 +9,10 @@
     width: 100%;
   }
 }
+
+.exercise__container {
+  width: 100%;
+  @media (min-width: 768px) {
+    width: 75%;
+  }
+}

--- a/stories/components/ExerciseCard.stories.tsx
+++ b/stories/components/ExerciseCard.stories.tsx
@@ -17,7 +17,6 @@ const exampleExplanation = `You can reassign variables that are initialized with
 export const Basic = () => {
   return (
     <ExerciseCard
-      challengeName="Variable mutation"
       problem={exampleProblem}
       answer={exampleAnswer}
       explanation={exampleExplanation}


### PR DESCRIPTION
Changes in this pull request:
* Exercise card looks better and is easier to use on mobile.
* Replace the module name part of the exercise card with the text "Your Answer" so it's more clear.

How to test:
* Go to the DOJO exercises page (e.g. /exercises/js0).
* Click on the "Solve Exercises" button.
* Check that the exercise card looks good.

400px width:
![exercise-card-400px](https://user-images.githubusercontent.com/7637655/192115462-38a42e1c-7344-42bc-b6c5-552611f71df5.png)

400px width (answered):
![exercise-card-400px-answered](https://user-images.githubusercontent.com/7637655/192115461-6ca14b6b-d3ec-4c1c-a937-857db69ecd22.png)

600px width:
![exercise-card-600px](https://user-images.githubusercontent.com/7637655/192115459-70e13541-bcdc-4f3c-a075-f50c64df23d6.png)

600px width (answered):
![exercise-card-600px-answered](https://user-images.githubusercontent.com/7637655/192115458-830f6e26-61be-4706-9490-97fdd1ed27e6.png)

1000px width:
![exercise-card-1000px](https://user-images.githubusercontent.com/7637655/192115456-a36e55f0-81b3-4349-a0c8-094bf627dddd.png)

1000px width (answered):
![exercise-card-1000px-answered](https://user-images.githubusercontent.com/7637655/192115457-0d3edb52-91a5-45cc-97fc-7d4d9eb5ed68.png)

This is a part of https://github.com/garageScript/c0d3-app/issues/2253
