### PR TITLE
Make NewButton the same size across breakpoints

### DIFF
--- a/scss/button.module.scss
+++ b/scss/button.module.scss
@@ -50,10 +50,3 @@
     outline: 3px solid variables.$mint-green-dark;
   }
 }
-
-@media screen and (max-width: 400px) {
-  .newButton {
-    font-size: 10px;
-    padding: 8px 24px;
-  }
-}


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-app/issues/2343

Changes:
* Removes NewButton size changes across breakpoints so it looks more consistent and makes the button styling more simple.
* Makes NewButton easier to see and press on mobile (for example, the DOJO exercises "Solve Exercises" button was pretty small on mobile before, etc).

How to test:
* Go to the pages that use NewButton and make sure everything looks good on mobile.
  * Here are all the pages that use NewButton:
    * /exercises/js0
    * /admin/lessons/js0/introduction
    * /curriculum/js0/mentor

/exercises/js0 page on mobile (DOJO exercise list):
![exercise-list-mobile](https://user-images.githubusercontent.com/7637655/192137822-40eb620a-1729-4467-81bd-539d7566d547.png)

/exercises/js0 page on mobile (DOJO exercise card):
![exercise-card-mobile](https://user-images.githubusercontent.com/7637655/192137837-aa9ed7df-8bc0-45c4-8849-5be20d84f28e.png)

/exercises/js0 page on mobile (DOJO exercise card answered):
![exercise-card-mobile-answered](https://user-images.githubusercontent.com/7637655/192137890-98bdc02e-a5fb-4ae5-a0a9-0d42a9e60596.png)

/admin/lessons/js0/introduction on mobile (this wasn't designed for mobile before this pull request so it doesn't look as good here but this can be fixed in a subsequent pull request):
![admin-curriculum-lessons-introduction-mobile](https://user-images.githubusercontent.com/7637655/192137909-ca0e3eb8-ca98-4b34-b0b0-f0ef3547d73b.png)

/curriculum/js0/mentor on mobile (this page isn't designed for mobile so it doesn't look as good here):
![curriculum-lesson-mentor-mobile](https://user-images.githubusercontent.com/7637655/192137949-7c217c8d-9316-4f9f-9530-635411eba57e.png)
