### PR TITLE
Fix overflowing text between 768px and 991px on DOJO exercise card

### DIFF
--- a/scss/exercises.module.scss
+++ b/scss/exercises.module.scss
@@ -12,7 +12,7 @@
 
 .exercise__container {
   width: 100%;
-  @media (min-width: 768px) {
+  @media (min-width: 992px) {
     width: 75%;
   }
 }


### PR DESCRIPTION
Changes:
* The "Show Answer" button text on the DOJO exercise card no longer overflows to the next line on screen widths from 768px to 991px.

How to test:
* Create a module at /admin/lessons/js0/modules
* Create an exercise at /curriculum/js0/mentor
* Go to /exercises/js0
* Click on "Solve Exercises" button
* Check that the exercise card "Show Answer" button no longer has text overflow to the next line on screen widths from 768px to 991px.

After this change (screen width 770px):
![after](https://user-images.githubusercontent.com/7637655/192160517-a801992d-e509-48b5-a024-0b941baa33e2.png)


Before this change (screen width 770px):
![before](https://user-images.githubusercontent.com/7637655/192160525-3f3e2293-d3c8-44c7-8622-2687c271f382.png)
