### PR TITLE
Show next question button after user answers exercise correctly

### DIFF
--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -46,7 +46,7 @@ describe('Exercises page', () => {
       }
     ]
 
-    const { getByRole, queryByRole } = render(
+    const { getByRole, queryByRole, getByLabelText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
         <Exercises />
       </MockedProvider>
@@ -64,12 +64,20 @@ describe('Exercises page', () => {
     // Previous button is not in the document on the first exercise.
     expect(queryByRole('button', { name: 'PREVIOUS' })).not.toBeInTheDocument()
 
-    let skipButton = getByRole('button', { name: 'SKIP' })
+    const skipButton = getByRole('button', { name: 'SKIP' })
     fireEvent.click(skipButton)
     expect(queryByRole('button', { name: 'PREVIOUS' })).toBeInTheDocument()
 
-    skipButton = getByRole('button', { name: 'SKIP' })
-    fireEvent.click(skipButton)
+    // Expect "NEXT QUESTION" button to appear once you answered a question correctly.
+    const inputBox = getByLabelText('User answer')
+    fireEvent.change(inputBox, {
+      target: { value: '3' }
+    })
+    const submitButton = getByRole('button', { name: 'SUBMIT' })
+    fireEvent.click(submitButton)
+    const nextQuestionButton = getByRole('button', { name: 'NEXT QUESTION' })
+    fireEvent.click(nextQuestionButton)
+
     // Skip button should not be in the document because we're on the last exercise now.
     expect(queryByRole('button', { name: 'SKIP' })).not.toBeInTheDocument()
 

--- a/components/ExerciseCard/ExerciseCard.test.tsx
+++ b/components/ExerciseCard/ExerciseCard.test.tsx
@@ -1,10 +1,7 @@
 import '@testing-library/jest-dom'
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
-import ExerciseCard from './ExerciseCard'
-
-const successMessage = '🎉 Your answer is correct!'
-const errorMessage = 'Your answer is incorrect - please try again.'
+import ExerciseCard, { Message } from './ExerciseCard'
 
 const exampleProblem = `let a = 5
 a = a + 10
@@ -15,7 +12,7 @@ const exampleExplanation = `You can reassign variables that are initialized with
 describe('ExerciseCard component', () => {
   it('Should render an exercise card', async () => {
     const setAnswerShown = jest.fn()
-    const setMessageKey = jest.fn()
+    const setMessage = jest.fn()
 
     const { getByRole, queryByText } = render(
       <ExerciseCard
@@ -24,25 +21,26 @@ describe('ExerciseCard component', () => {
         explanation={exampleExplanation}
         answerShown={false}
         setAnswerShown={setAnswerShown}
-        messageKey={'EMPTY'}
-        setMessageKey={setMessageKey}
+        message={Message.EMPTY}
+        setMessage={setMessage}
       />
     )
 
     // Test that an error message shows if the user is wrong
 
-    expect(queryByText(errorMessage)).not.toBeInTheDocument()
+    expect(queryByText(Message.ERROR)).not.toBeInTheDocument()
 
     const submitButton = getByRole('button', { name: 'SUBMIT' })
     fireEvent.click(submitButton)
 
-    expect(setAnswerShown.mock.calls).toEqual([])
-    expect(setMessageKey.mock.calls).toEqual([['ERROR']])
+    expect(setAnswerShown).toBeCalledTimes(0)
+    expect(setMessage).toBeCalledWith(Message.ERROR)
+    expect(setMessage).toBeCalledTimes(1)
   })
 
   it('Should render an error message', () => {
     const setAnswerShown = jest.fn()
-    const setMessageKey = jest.fn()
+    const setMessage = jest.fn()
 
     const { getByRole, queryByText, getByLabelText } = render(
       <ExerciseCard
@@ -51,14 +49,13 @@ describe('ExerciseCard component', () => {
         explanation={exampleExplanation}
         answerShown={false}
         setAnswerShown={setAnswerShown}
-        messageKey={'ERROR'}
-        setMessageKey={setMessageKey}
+        message={Message.ERROR}
+        setMessage={setMessage}
       />
     )
 
-    expect(queryByText(errorMessage)).toBeInTheDocument()
-
-    expect(queryByText(successMessage)).not.toBeInTheDocument()
+    expect(queryByText(Message.ERROR)).toBeInTheDocument()
+    expect(queryByText(Message.SUCCESS)).not.toBeInTheDocument()
 
     const inputBox = getByLabelText('User answer')
     fireEvent.change(inputBox, {
@@ -70,13 +67,15 @@ describe('ExerciseCard component', () => {
     const submitButton = getByRole('button', { name: 'SUBMIT' })
     fireEvent.click(submitButton)
 
-    expect(setAnswerShown.mock.calls).toEqual([[true]])
-    expect(setMessageKey.mock.calls).toEqual([['SUCCESS']])
+    expect(setAnswerShown).toBeCalledWith(true)
+    expect(setAnswerShown).toBeCalledTimes(1)
+    expect(setMessage).toBeCalledWith(Message.SUCCESS)
+    expect(setMessage).toBeCalledTimes(1)
   })
 
   it('Should render a success message', () => {
     const setAnswerShown = jest.fn()
-    const setMessageKey = jest.fn()
+    const setMessage = jest.fn()
 
     const { getByRole, queryByText } = render(
       <ExerciseCard
@@ -85,12 +84,12 @@ describe('ExerciseCard component', () => {
         explanation={exampleExplanation}
         answerShown={true}
         setAnswerShown={setAnswerShown}
-        messageKey={'SUCCESS'}
-        setMessageKey={setMessageKey}
+        message={Message.SUCCESS}
+        setMessage={setMessage}
       />
     )
 
-    expect(queryByText(successMessage)).toBeInTheDocument()
+    expect(queryByText(Message.SUCCESS)).toBeInTheDocument()
     expect(queryByText(exampleExplanation)).toBeInTheDocument()
 
     // Test that the hide button hides the answer explanation
@@ -98,13 +97,14 @@ describe('ExerciseCard component', () => {
     const hideButton = getByRole('button', { name: 'Hide Answer' })
     fireEvent.click(hideButton)
 
-    expect(setAnswerShown.mock.calls).toEqual([[false]])
-    expect(setMessageKey.mock.calls).toEqual([])
+    expect(setAnswerShown).toBeCalledWith(false)
+    expect(setAnswerShown).toBeCalledTimes(1)
+    expect(setMessage).toBeCalledTimes(0)
   })
 
   it('Should hide the answer', () => {
     const setAnswerShown = jest.fn()
-    const setMessageKey = jest.fn()
+    const setMessage = jest.fn()
 
     const { queryByText, getByRole } = render(
       <ExerciseCard
@@ -113,12 +113,12 @@ describe('ExerciseCard component', () => {
         explanation={exampleExplanation}
         answerShown={false}
         setAnswerShown={setAnswerShown}
-        messageKey={'SUCCESS'}
-        setMessageKey={setMessageKey}
+        message={Message.SUCCESS}
+        setMessage={setMessage}
       />
     )
 
-    expect(queryByText(successMessage)).toBeInTheDocument()
+    expect(queryByText(Message.SUCCESS)).toBeInTheDocument()
     expect(queryByText(exampleExplanation)).not.toBeInTheDocument()
 
     // Test that the show button shows the answer explanation
@@ -126,7 +126,8 @@ describe('ExerciseCard component', () => {
     const hideButton = getByRole('button', { name: 'Show Answer' })
     fireEvent.click(hideButton)
 
-    expect(setAnswerShown.mock.calls).toEqual([[true]])
-    expect(setMessageKey.mock.calls).toEqual([])
+    expect(setAnswerShown).toBeCalledWith(true)
+    expect(setAnswerShown).toBeCalledTimes(1)
+    expect(setMessage).toBeCalledTimes(0)
   })
 })

--- a/components/ExerciseCard/ExerciseCard.test.tsx
+++ b/components/ExerciseCard/ExerciseCard.test.tsx
@@ -3,36 +3,60 @@ import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import ExerciseCard from './ExerciseCard'
 
-describe('ExerciseCard component', () => {
-  it('Should render an exercise card', () => {
-    const exampleProblem = `let a = 5
+const successMessage = '🎉 Your answer is correct!'
+const errorMessage = 'Your answer is incorrect - please try again.'
+
+const exampleProblem = `let a = 5
 a = a + 10
 // what is a?`
-    const exampleAnswer = '15'
-    const exampleExplanation = `You can reassign variables that are initialized with "let".`
+const exampleAnswer = '15'
+const exampleExplanation = `You can reassign variables that are initialized with "let".`
 
-    const { getByRole, queryByText, getByLabelText } = render(
+describe('ExerciseCard component', () => {
+  it('Should render an exercise card', async () => {
+    const setAnswerShown = jest.fn()
+    const setMessageKey = jest.fn()
+
+    const { getByRole, queryByText } = render(
       <ExerciseCard
         problem={exampleProblem}
         answer={exampleAnswer}
         explanation={exampleExplanation}
+        answerShown={false}
+        setAnswerShown={setAnswerShown}
+        messageKey={'EMPTY'}
+        setMessageKey={setMessageKey}
       />
     )
 
     // Test that an error message shows if the user is wrong
-
-    const errorMessage = 'Your answer is incorrect - please try again.'
 
     expect(queryByText(errorMessage)).not.toBeInTheDocument()
 
     const submitButton = getByRole('button', { name: 'SUBMIT' })
     fireEvent.click(submitButton)
 
+    expect(setAnswerShown.mock.calls).toEqual([])
+    expect(setMessageKey.mock.calls).toEqual([['ERROR']])
+  })
+
+  it('Should render an error message', () => {
+    const setAnswerShown = jest.fn()
+    const setMessageKey = jest.fn()
+
+    const { getByRole, queryByText, getByLabelText } = render(
+      <ExerciseCard
+        problem={exampleProblem}
+        answer={exampleAnswer}
+        explanation={exampleExplanation}
+        answerShown={false}
+        setAnswerShown={setAnswerShown}
+        messageKey={'ERROR'}
+        setMessageKey={setMessageKey}
+      />
+    )
+
     expect(queryByText(errorMessage)).toBeInTheDocument()
-
-    // Test that a success message shows and the answer is shown if the user is right
-
-    const successMessage = '🎉 Your answer is correct!'
 
     expect(queryByText(successMessage)).not.toBeInTheDocument()
 
@@ -40,7 +64,31 @@ a = a + 10
     fireEvent.change(inputBox, {
       target: { value: '15' }
     })
+
+    // Test that the submit button shows the success message and the answer explanation
+
+    const submitButton = getByRole('button', { name: 'SUBMIT' })
     fireEvent.click(submitButton)
+
+    expect(setAnswerShown.mock.calls).toEqual([[true]])
+    expect(setMessageKey.mock.calls).toEqual([['SUCCESS']])
+  })
+
+  it('Should render a success message', () => {
+    const setAnswerShown = jest.fn()
+    const setMessageKey = jest.fn()
+
+    const { getByRole, queryByText } = render(
+      <ExerciseCard
+        problem={exampleProblem}
+        answer={exampleAnswer}
+        explanation={exampleExplanation}
+        answerShown={true}
+        setAnswerShown={setAnswerShown}
+        messageKey={'SUCCESS'}
+        setMessageKey={setMessageKey}
+      />
+    )
 
     expect(queryByText(successMessage)).toBeInTheDocument()
     expect(queryByText(exampleExplanation)).toBeInTheDocument()
@@ -50,6 +98,35 @@ a = a + 10
     const hideButton = getByRole('button', { name: 'Hide Answer' })
     fireEvent.click(hideButton)
 
+    expect(setAnswerShown.mock.calls).toEqual([[false]])
+    expect(setMessageKey.mock.calls).toEqual([])
+  })
+
+  it('Should hide the answer', () => {
+    const setAnswerShown = jest.fn()
+    const setMessageKey = jest.fn()
+
+    const { queryByText, getByRole } = render(
+      <ExerciseCard
+        problem={exampleProblem}
+        answer={exampleAnswer}
+        explanation={exampleExplanation}
+        answerShown={false}
+        setAnswerShown={setAnswerShown}
+        messageKey={'SUCCESS'}
+        setMessageKey={setMessageKey}
+      />
+    )
+
+    expect(queryByText(successMessage)).toBeInTheDocument()
     expect(queryByText(exampleExplanation)).not.toBeInTheDocument()
+
+    // Test that the show button shows the answer explanation
+
+    const hideButton = getByRole('button', { name: 'Show Answer' })
+    fireEvent.click(hideButton)
+
+    expect(setAnswerShown.mock.calls).toEqual([[true]])
+    expect(setMessageKey.mock.calls).toEqual([])
   })
 })

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -9,17 +9,15 @@ export type ExerciseCardProps = {
   explanation: string
   answerShown: boolean
   setAnswerShown: (answerShown: boolean) => void
-  messageKey: MessageKey
-  setMessageKey: (messageKey: MessageKey) => void
+  message: Message
+  setMessage: (message: Message) => void
 }
 
-enum Message {
+export enum Message {
   EMPTY = '',
   ERROR = 'Your answer is incorrect - please try again.',
   SUCCESS = '🎉 Your answer is correct!'
 }
-
-export type MessageKey = keyof typeof Message
 
 const ExerciseCard = ({
   problem,
@@ -27,11 +25,10 @@ const ExerciseCard = ({
   explanation,
   answerShown,
   setAnswerShown,
-  messageKey,
-  setMessageKey
+  message,
+  setMessage
 }: ExerciseCardProps) => {
   const [studentAnswer, setStudentAnswer] = useState('')
-  const message = Message[messageKey]
 
   return (
     <section className="card p-5 border-0 shadow">
@@ -45,14 +42,16 @@ const ExerciseCard = ({
           <input
             aria-label="User answer"
             className={`form-control mb-2 ${
-              messageKey === 'ERROR' ? styles.exerciseCard__input__error : ''
+              message === Message.ERROR ? styles.exerciseCard__input__error : ''
             }`}
             value={studentAnswer}
             onChange={e => setStudentAnswer(e.target.value)}
           />
           <div
             className={`${styles.exerciseCard__message} ${
-              messageKey === 'ERROR' ? styles.exerciseCard__message__error : ''
+              message === Message.ERROR
+                ? styles.exerciseCard__message__error
+                : ''
             } my-3`}
           >
             {message}
@@ -61,10 +60,10 @@ const ExerciseCard = ({
             <NewButton
               onClick={() => {
                 if (studentAnswer.trim() === answer.trim()) {
-                  setMessageKey('SUCCESS')
+                  setMessage(Message.SUCCESS)
                   setAnswerShown(true)
                 } else {
-                  setMessageKey('ERROR')
+                  setMessage(Message.ERROR)
                 }
               }}
             >

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -7,6 +7,10 @@ export type ExerciseCardProps = {
   problem: string
   answer: string
   explanation: string
+  answerShown: boolean
+  setAnswerShown: (answerShown: boolean) => void
+  messageKey: MessageKey
+  setMessageKey: (messageKey: MessageKey) => void
 }
 
 enum Message {
@@ -15,12 +19,18 @@ enum Message {
   SUCCESS = '🎉 Your answer is correct!'
 }
 
-type MessageKey = keyof typeof Message
+export type MessageKey = keyof typeof Message
 
-const ExerciseCard = ({ problem, answer, explanation }: ExerciseCardProps) => {
+const ExerciseCard = ({
+  problem,
+  answer,
+  explanation,
+  answerShown,
+  setAnswerShown,
+  messageKey,
+  setMessageKey
+}: ExerciseCardProps) => {
   const [studentAnswer, setStudentAnswer] = useState('')
-  const [answerShown, setAnswerShown] = useState(false)
-  const [messageKey, setMessageKey] = useState<MessageKey>('EMPTY')
   const message = Message[messageKey]
 
   return (

--- a/components/ExerciseCard/index.tsx
+++ b/components/ExerciseCard/index.tsx
@@ -1,5 +1,1 @@
-export {
-  default,
-  type ExerciseCardProps,
-  type MessageKey
-} from './ExerciseCard'
+export { default, type ExerciseCardProps, Message } from './ExerciseCard'

--- a/components/ExerciseCard/index.tsx
+++ b/components/ExerciseCard/index.tsx
@@ -1,1 +1,5 @@
-export { default, type ExerciseCardProps } from './ExerciseCard'
+export {
+  default,
+  type ExerciseCardProps,
+  type MessageKey
+} from './ExerciseCard'

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -76,8 +76,8 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
           exercise={exercise}
           setExerciseIndex={setExerciseIndex}
           lessonTitle={currentLesson.title}
-          showPreviousButton={exerciseIndex > 0}
-          showSkipButton={exerciseIndex < currentExercises.length - 1}
+          hasPrevious={exerciseIndex > 0}
+          hasNext={exerciseIndex < currentExercises.length - 1}
         />
       ) : (
         <ExerciseList
@@ -95,16 +95,16 @@ type ExerciseProps = {
   exercise: ExerciseCardProps
   setExerciseIndex: React.Dispatch<React.SetStateAction<number>>
   lessonTitle: string
-  showPreviousButton: boolean
-  showSkipButton: boolean
+  hasPrevious: boolean
+  hasNext: boolean
 }
 
 const Exercise = ({
   exercise,
   setExerciseIndex,
   lessonTitle,
-  showPreviousButton,
-  showSkipButton
+  hasPrevious,
+  hasNext
 }: ExerciseProps) => {
   return (
     <div className={`mx-auto ${styles.exercise__container}`}>
@@ -122,7 +122,7 @@ const Exercise = ({
         explanation={exercise.explanation}
       />
       <div className="d-flex justify-content-between mt-4">
-        {showPreviousButton ? (
+        {hasPrevious ? (
           <button
             onClick={() => setExerciseIndex(i => i - 1)}
             className="btn btn-outline-primary fw-bold px-4 py-2"
@@ -133,7 +133,7 @@ const Exercise = ({
         ) : (
           <div />
         )}
-        {showSkipButton ? (
+        {hasNext ? (
           <button
             onClick={() => setExerciseIndex(i => i + 1)}
             className="btn btn-outline-primary fw-bold px-4 py-2"

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -146,7 +146,11 @@ const Exercise = ({
         ) : (
           <div />
         )}
-        {hasNext ? (
+        {messageKey === 'SUCCESS' ? (
+          <NewButton onClick={() => setExerciseIndex(i => i + 1)}>
+            NEXT QUESTION
+          </NewButton>
+        ) : hasNext ? (
           <button
             onClick={() => setExerciseIndex(i => i + 1)}
             className="btn btn-outline-primary fw-bold px-4 py-2"

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -13,7 +13,7 @@ import ExercisePreviewCard, {
   ExercisePreviewCardProps
 } from '../../components/ExercisePreviewCard'
 import { NewButton } from '../../components/theme/Button'
-import ExerciseCard, { MessageKey } from '../../components/ExerciseCard'
+import ExerciseCard, { Message } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
 import GET_EXERCISES from '../../graphql/queries/getExercises'
 import styles from '../../scss/exercises.module.scss'
@@ -113,7 +113,7 @@ const Exercise = ({
   hasNext
 }: ExerciseProps) => {
   const [answerShown, setAnswerShown] = useState(false)
-  const [messageKey, setMessageKey] = useState<MessageKey>('EMPTY')
+  const [message, setMessage] = useState(Message.EMPTY)
 
   return (
     <div className={`mx-auto ${styles.exercise__container}`}>
@@ -131,8 +131,8 @@ const Exercise = ({
         explanation={exercise.explanation}
         answerShown={answerShown}
         setAnswerShown={setAnswerShown}
-        messageKey={messageKey}
-        setMessageKey={setMessageKey}
+        message={message}
+        setMessage={setMessage}
       />
       <div className="d-flex justify-content-between mt-4">
         {hasPrevious ? (
@@ -146,7 +146,7 @@ const Exercise = ({
         ) : (
           <div />
         )}
-        {messageKey === 'SUCCESS' ? (
+        {message === Message.SUCCESS ? (
           <NewButton onClick={() => setExerciseIndex(i => i + 1)}>
             NEXT QUESTION
           </NewButton>

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -13,7 +13,7 @@ import ExercisePreviewCard, {
   ExercisePreviewCardProps
 } from '../../components/ExercisePreviewCard'
 import { NewButton } from '../../components/theme/Button'
-import ExerciseCard, { ExerciseCardProps } from '../../components/ExerciseCard'
+import ExerciseCard, { MessageKey } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
 import GET_EXERCISES from '../../graphql/queries/getExercises'
 import styles from '../../scss/exercises.module.scss'
@@ -91,8 +91,14 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   )
 }
 
+type ExerciseData = {
+  problem: string
+  answer: string
+  explanation: string
+}
+
 type ExerciseProps = {
-  exercise: ExerciseCardProps
+  exercise: ExerciseData
   setExerciseIndex: React.Dispatch<React.SetStateAction<number>>
   lessonTitle: string
   hasPrevious: boolean
@@ -106,6 +112,9 @@ const Exercise = ({
   hasPrevious,
   hasNext
 }: ExerciseProps) => {
+  const [answerShown, setAnswerShown] = useState(false)
+  const [messageKey, setMessageKey] = useState<MessageKey>('EMPTY')
+
   return (
     <div className={`mx-auto ${styles.exercise__container}`}>
       <button
@@ -120,6 +129,10 @@ const Exercise = ({
         problem={exercise.problem}
         answer={exercise.answer}
         explanation={exercise.explanation}
+        answerShown={answerShown}
+        setAnswerShown={setAnswerShown}
+        messageKey={messageKey}
+        setMessageKey={setMessageKey}
       />
       <div className="d-flex justify-content-between mt-4">
         {hasPrevious ? (

--- a/stories/components/ExerciseCard.stories.tsx
+++ b/stories/components/ExerciseCard.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import ExerciseCard, { MessageKey } from '../../components/ExerciseCard'
+import ExerciseCard, { Message } from '../../components/ExerciseCard'
 
 export default {
   component: ExerciseCard,
@@ -16,7 +16,7 @@ const exampleExplanation = `You can reassign variables that are initialized with
 
 export const Basic = () => {
   const [answerShown, setAnswerShown] = useState(false)
-  const [messageKey, setMessageKey] = useState<MessageKey>('EMPTY')
+  const [message, setMessage] = useState(Message.EMPTY)
 
   return (
     <ExerciseCard
@@ -25,8 +25,8 @@ export const Basic = () => {
       explanation={exampleExplanation}
       answerShown={answerShown}
       setAnswerShown={setAnswerShown}
-      messageKey={messageKey}
-      setMessageKey={setMessageKey}
+      message={message}
+      setMessage={setMessage}
     />
   )
 }

--- a/stories/components/ExerciseCard.stories.tsx
+++ b/stories/components/ExerciseCard.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import ExerciseCard from '../../components/ExerciseCard'
+import React, { useState } from 'react'
+import ExerciseCard, { MessageKey } from '../../components/ExerciseCard'
 
 export default {
   component: ExerciseCard,
@@ -15,11 +15,18 @@ const exampleAnswer = '15'
 const exampleExplanation = `You can reassign variables that are initialized with "let".`
 
 export const Basic = () => {
+  const [answerShown, setAnswerShown] = useState(false)
+  const [messageKey, setMessageKey] = useState<MessageKey>('EMPTY')
+
   return (
     <ExerciseCard
       problem={exampleProblem}
       answer={exampleAnswer}
       explanation={exampleExplanation}
+      answerShown={answerShown}
+      setAnswerShown={setAnswerShown}
+      messageKey={messageKey}
+      setMessageKey={setMessageKey}
     />
   )
 }


### PR DESCRIPTION
Changes:
* Add "NEXT QUESTION" button after user successfully answers a question
* Extract ExerciseCard state as props
* Rename ExerciseCard props

How to test:
* Create a DOJO module at /admin/lessons/js0/modules
* Create a DOJO exercise at /curriculum/js0/mentor
* Go to the DOJO exercises page at /exercises/js0
* Click on "SOLVE EXERCISES" button
* Answer the exercise correctly
* Verify that the "NEXT QUESTION" button shows up

![next-question-400px](https://user-images.githubusercontent.com/7637655/192308675-7dbb041c-c5c9-4c8e-8bc8-2fc1d3393fa0.png)
![next-question-770px](https://user-images.githubusercontent.com/7637655/192308678-67b0512d-ca07-4fe7-b31c-346bfc93b4f4.png)
![next-question-desktop](https://user-images.githubusercontent.com/7637655/192308685-cc97a4f1-9880-406a-be52-3bcec0c6f078.png)

This pull request is related to https://github.com/garageScript/c0d3-app/issues/2253