### PR TITLE
Mark exercise answered based on user answers

### DIFF
--- a/__dummy__/getExercisesData.ts
+++ b/__dummy__/getExercisesData.ts
@@ -57,6 +57,7 @@ const getExercisesData: GetExercisesQuery = {
   alerts: [],
   exercises: [
     {
+      id: 1,
       module: {
         name: 'Numbers',
         lesson: {
@@ -68,6 +69,7 @@ const getExercisesData: GetExercisesQuery = {
       explanation: 'You can reassign variables that were created with "let".'
     },
     {
+      id: 2,
       module: {
         name: 'Numbers',
         lesson: {
@@ -79,6 +81,7 @@ const getExercisesData: GetExercisesQuery = {
       explanation: '`a += 2` is a shorter way to write `a = a + 2`'
     },
     {
+      id: 3,
       module: {
         name: 'Numbers',
         lesson: {

--- a/components/ExerciseCard/ExerciseCard.test.tsx
+++ b/components/ExerciseCard/ExerciseCard.test.tsx
@@ -13,6 +13,7 @@ describe('ExerciseCard component', () => {
   it('Should render an exercise card', async () => {
     const setAnswerShown = jest.fn()
     const setMessage = jest.fn()
+    const submitUserAnswer = jest.fn()
 
     const { getByRole, queryByText } = render(
       <ExerciseCard
@@ -23,6 +24,7 @@ describe('ExerciseCard component', () => {
         setAnswerShown={setAnswerShown}
         message={Message.EMPTY}
         setMessage={setMessage}
+        submitUserAnswer={submitUserAnswer}
       />
     )
 
@@ -41,6 +43,7 @@ describe('ExerciseCard component', () => {
   it('Should render an error message', () => {
     const setAnswerShown = jest.fn()
     const setMessage = jest.fn()
+    const submitUserAnswer = jest.fn()
 
     const { getByRole, queryByText, getByLabelText } = render(
       <ExerciseCard
@@ -51,6 +54,7 @@ describe('ExerciseCard component', () => {
         setAnswerShown={setAnswerShown}
         message={Message.ERROR}
         setMessage={setMessage}
+        submitUserAnswer={submitUserAnswer}
       />
     )
 
@@ -76,6 +80,7 @@ describe('ExerciseCard component', () => {
   it('Should render a success message', () => {
     const setAnswerShown = jest.fn()
     const setMessage = jest.fn()
+    const submitUserAnswer = jest.fn()
 
     const { getByRole, queryByText } = render(
       <ExerciseCard
@@ -86,6 +91,7 @@ describe('ExerciseCard component', () => {
         setAnswerShown={setAnswerShown}
         message={Message.SUCCESS}
         setMessage={setMessage}
+        submitUserAnswer={submitUserAnswer}
       />
     )
 
@@ -105,6 +111,7 @@ describe('ExerciseCard component', () => {
   it('Should hide the answer', () => {
     const setAnswerShown = jest.fn()
     const setMessage = jest.fn()
+    const submitUserAnswer = jest.fn()
 
     const { queryByText, getByRole } = render(
       <ExerciseCard
@@ -115,6 +122,7 @@ describe('ExerciseCard component', () => {
         setAnswerShown={setAnswerShown}
         message={Message.SUCCESS}
         setMessage={setMessage}
+        submitUserAnswer={submitUserAnswer}
       />
     )
 

--- a/components/ExerciseCard/ExerciseCard.test.tsx
+++ b/components/ExerciseCard/ExerciseCard.test.tsx
@@ -38,6 +38,8 @@ describe('ExerciseCard component', () => {
     expect(setAnswerShown).toBeCalledTimes(0)
     expect(setMessage).toBeCalledWith(Message.ERROR)
     expect(setMessage).toBeCalledTimes(1)
+    expect(submitUserAnswer).toBeCalledWith('')
+    expect(submitUserAnswer).toBeCalledTimes(1)
   })
 
   it('Should render an error message', () => {
@@ -75,6 +77,8 @@ describe('ExerciseCard component', () => {
     expect(setAnswerShown).toBeCalledTimes(1)
     expect(setMessage).toBeCalledWith(Message.SUCCESS)
     expect(setMessage).toBeCalledTimes(1)
+    expect(submitUserAnswer).toBeCalledWith('15')
+    expect(submitUserAnswer).toBeCalledTimes(1)
   })
 
   it('Should render a success message', () => {
@@ -106,6 +110,7 @@ describe('ExerciseCard component', () => {
     expect(setAnswerShown).toBeCalledWith(false)
     expect(setAnswerShown).toBeCalledTimes(1)
     expect(setMessage).toBeCalledTimes(0)
+    expect(submitUserAnswer).toBeCalledTimes(0)
   })
 
   it('Should hide the answer', () => {
@@ -137,5 +142,6 @@ describe('ExerciseCard component', () => {
     expect(setAnswerShown).toBeCalledWith(true)
     expect(setAnswerShown).toBeCalledTimes(1)
     expect(setMessage).toBeCalledTimes(0)
+    expect(submitUserAnswer).toBeCalledTimes(0)
   })
 })

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -11,6 +11,7 @@ export type ExerciseCardProps = {
   setAnswerShown: (answerShown: boolean) => void
   message: Message
   setMessage: (message: Message) => void
+  submitUserAnswer: (userAnswer: string) => void
 }
 
 export enum Message {
@@ -26,7 +27,8 @@ const ExerciseCard = ({
   answerShown,
   setAnswerShown,
   message,
-  setMessage
+  setMessage,
+  submitUserAnswer
 }: ExerciseCardProps) => {
   const [studentAnswer, setStudentAnswer] = useState('')
 
@@ -65,6 +67,7 @@ const ExerciseCard = ({
                 } else {
                   setMessage(Message.ERROR)
                 }
+                submitUserAnswer(studentAnswer.trim())
               }}
             >
               SUBMIT

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -830,6 +830,7 @@ export type GetExercisesQuery = {
   }>
   exercises: Array<{
     __typename?: 'Exercise'
+    id: number
     description: string
     answer: string
     explanation?: string | null
@@ -3531,6 +3532,7 @@ export const GetExercisesDocument = gql`
       urlCaption
     }
     exercises {
+      id
       module {
         name
         lesson {

--- a/graphql/queries/getExercises.ts
+++ b/graphql/queries/getExercises.ts
@@ -15,6 +15,7 @@ const GET_EXERCISES = gql`
       urlCaption
     }
     exercises {
+      id
       module {
         name
         lesson {

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -209,6 +209,8 @@ const ExerciseList = ({
             problem={exercise.problem}
           />
         ))}
+        <div />
+        <div />
       </div>
     </>
   )

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -9,29 +9,17 @@ import Error, { StatusCode } from '../../components/Error'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import AlertsDisplay from '../../components/AlertsDisplay'
 import NavCard from '../../components/NavCard'
-import ExercisePreviewCard, {
-  ExercisePreviewCardProps
-} from '../../components/ExercisePreviewCard'
+import ExercisePreviewCard from '../../components/ExercisePreviewCard'
 import { NewButton } from '../../components/theme/Button'
 import ExerciseCard, { Message } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
 import GET_EXERCISES from '../../graphql/queries/getExercises'
 import styles from '../../scss/exercises.module.scss'
+import getExercisesData from '../../__dummy__/getExercisesData'
 
-const exampleProblem = `const a = 5
-a = a + 10
-// what is a?`
+const mockExercises = getExercisesData.exercises
 
-const mockExercisePreviews: ExercisePreviewCardProps[] = [
-  { moduleName: 'Variables', state: 'ANSWERED', problem: exampleProblem },
-  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
-  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
-  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
-  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
-  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
-  { moduleName: 'Variables', state: 'NOT ANSWERED', problem: exampleProblem },
-  { moduleName: 'Variables', state: 'ANSWERED', problem: exampleProblem }
-]
+const mockUserAnswers: Record<number, string> = { 1: '15', 3: '0' }
 
 const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   queryData
@@ -39,6 +27,7 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   const { lessons, alerts, exercises } = queryData
   const router = useRouter()
   const [exerciseIndex, setExerciseIndex] = useState(-1)
+
   if (!router.isReady) return <LoadingSpinner />
 
   const slug = router.query.lessonSlug as string
@@ -84,6 +73,12 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
           tabs={tabs}
           setExerciseIndex={setExerciseIndex}
           lessonTitle={currentLesson.title}
+          exercises={mockExercises.map(exercise => ({
+            problem: exercise.description,
+            answer: exercise.answer,
+            moduleName: exercise.module.name,
+            userAnswer: mockUserAnswers[exercise.id] ?? null
+          }))}
         />
       )}
       {alerts && <AlertsDisplay alerts={alerts} />}
@@ -170,12 +165,19 @@ type ExerciseListProps = {
   tabs: { text: string; url: string }[]
   setExerciseIndex: React.Dispatch<React.SetStateAction<number>>
   lessonTitle: string
+  exercises: {
+    moduleName: string
+    problem: string
+    answer: string
+    userAnswer: string | null
+  }[]
 }
 
 const ExerciseList = ({
   tabs,
   setExerciseIndex,
-  lessonTitle
+  lessonTitle,
+  exercises
 }: ExerciseListProps) => {
   return (
     <>
@@ -199,12 +201,12 @@ const ExerciseList = ({
         </div>
       </div>
       <div className={styles.exerciseList__container}>
-        {mockExercisePreviews.map((exercisePreview, i) => (
+        {exercises.map((exercise, i) => (
           <ExercisePreviewCard
             key={i}
-            moduleName={exercisePreview.moduleName}
-            state={exercisePreview.state}
-            problem={exercisePreview.problem}
+            moduleName={exercise.moduleName}
+            state={exercise.userAnswer === null ? 'NOT ANSWERED' : 'ANSWERED'}
+            problem={exercise.problem}
           />
         ))}
       </div>

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -15,11 +15,6 @@ import ExerciseCard, { Message } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
 import GET_EXERCISES from '../../graphql/queries/getExercises'
 import styles from '../../scss/exercises.module.scss'
-import getExercisesData from '../../__dummy__/getExercisesData'
-
-const mockExercises = getExercisesData.exercises
-
-const mockUserAnswers: Record<number, string> = { 1: '15', 3: '0' }
 
 const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   queryData
@@ -27,6 +22,7 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   const { lessons, alerts, exercises } = queryData
   const router = useRouter()
   const [exerciseIndex, setExerciseIndex] = useState(-1)
+  const [userAnswers, setUserAnswers] = useState<Record<number, string>>({})
 
   if (!router.isReady) return <LoadingSpinner />
 
@@ -49,6 +45,7 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   const currentExercises = exercises
     .filter(exercise => exercise?.module.lesson.slug === slug)
     .map(exercise => ({
+      id: exercise.id,
       challengeName: exercise.module.name,
       problem: exercise.description,
       answer: exercise.answer,
@@ -67,17 +64,20 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
           lessonTitle={currentLesson.title}
           hasPrevious={exerciseIndex > 0}
           hasNext={exerciseIndex < currentExercises.length - 1}
+          submitUserAnswer={(userAnswer: string) =>
+            setUserAnswers({ ...userAnswers, [exercise.id]: userAnswer })
+          }
         />
       ) : (
         <ExerciseList
           tabs={tabs}
           setExerciseIndex={setExerciseIndex}
           lessonTitle={currentLesson.title}
-          exercises={mockExercises.map(exercise => ({
+          exercises={exercises.map(exercise => ({
             problem: exercise.description,
             answer: exercise.answer,
             moduleName: exercise.module.name,
-            userAnswer: mockUserAnswers[exercise.id] ?? null
+            userAnswer: userAnswers[exercise.id] ?? null
           }))}
         />
       )}
@@ -98,6 +98,7 @@ type ExerciseProps = {
   lessonTitle: string
   hasPrevious: boolean
   hasNext: boolean
+  submitUserAnswer: (userAnswer: string) => void
 }
 
 const Exercise = ({
@@ -105,7 +106,8 @@ const Exercise = ({
   setExerciseIndex,
   lessonTitle,
   hasPrevious,
-  hasNext
+  hasNext,
+  submitUserAnswer
 }: ExerciseProps) => {
   const [answerShown, setAnswerShown] = useState(false)
   const [message, setMessage] = useState(Message.EMPTY)
@@ -128,6 +130,7 @@ const Exercise = ({
         setAnswerShown={setAnswerShown}
         message={message}
         setMessage={setMessage}
+        submitUserAnswer={submitUserAnswer}
       />
       <div className="d-flex justify-content-between mt-4">
         {hasPrevious ? (

--- a/stories/components/ExerciseCard.stories.tsx
+++ b/stories/components/ExerciseCard.stories.tsx
@@ -27,6 +27,9 @@ export const Basic = () => {
       setAnswerShown={setAnswerShown}
       message={message}
       setMessage={setMessage}
+      submitUserAnswer={userAnswer => {
+        console.log(`User answer submitted: ${userAnswer}`)
+      }}
     />
   )
 }


### PR DESCRIPTION
Changes:
* User's answers get saved on the frontend.
* Exercise preview get displayed differently based on whether the user answered that question.
* Fixed exercise list styling bug that occurred when there were only 1 or 2 exercises.

How to test:
* Create a DOJO module at /admin/lessons/js0/modules
* Create a DOJO exercise at /curriculum/js0/mentor
* Go to the DOJO exercises page at /exercises/js0
* Click on "SOLVE EXERCISES" button.
* Answer an exercise.
* Click back arrow and verify that the exercise is now marked as answered.

This pull request doesn't actually save the user's answers. If they refresh the page then their answers are cleared. We will store the user's answers on the backend in a subsequent pull request.

This pull request is a part of https://github.com/garageScript/c0d3-app/issues/2253 and https://github.com/garageScript/c0d3-app/issues/2251