### PR TITLE
feat: Enable playground for preview deployments

### DIFF
--- a/__tests__/pages/api/graphql.test.js
+++ b/__tests__/pages/api/graphql.test.js
@@ -25,8 +25,12 @@ session.mockImplementation(() => {
 })
 
 describe('Graphql Api', () => {
+  const OLD_ENV = process.env
   let apolloServerInput
+
   beforeEach(() => {
+    process.env = { ...OLD_ENV, VERCEL_ENV: 'preview' }
+
     nextConnect.mockImplementation(() => {
       return {
         use: returnHandler,
@@ -42,6 +46,10 @@ describe('Graphql Api', () => {
     }
   })
 
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
   test('Should have correct config object', async () => {
     const { config } = require('../../../pages/api/graphql.ts')
     expect(config).toEqual({
@@ -49,6 +57,13 @@ describe('Graphql Api', () => {
         bodyParser: false
       }
     })
+  })
+
+  test('Should have correct config object when deployed as a preview deployment', async () => {
+    require('../../../pages/api/graphql.ts')
+    expect(
+      apolloServerInput.playground && apolloServerInput.introspection
+    ).toBeTruthy()
   })
 
   test('Should call context', () => {

--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -8,6 +8,9 @@ import loggingMiddleware from '../../helpers/middleware/logger'
 import userMiddleware from '../../helpers/middleware/user'
 import sessionMiddleware from '../../helpers/middleware/session'
 
+// VERCEL_ENV is a reserved env key by Vercel that specify the deployment type: "preview", "production", or "deployment"
+const isPreview = process.env.VERCEL_ENV === 'preview'
+
 const handler = nextConnect()
 const apolloServer = new ApolloServer({
   typeDefs,
@@ -16,7 +19,9 @@ const apolloServer = new ApolloServer({
   /* Syncs server schema (used for server static generation) and api route server settings. 
   By default apolloServer accepts uploads, while schema-generated server does not.*/
   uploads: false,
-  plugins: [apolloLogPlugin]
+  plugins: [apolloLogPlugin],
+  playground: isPreview,
+  introspection: isPreview
 })
 
 const graphQLHandler = apolloServer.createHandler({ path: '/api/graphql' })

--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -9,7 +9,7 @@ import userMiddleware from '../../helpers/middleware/user'
 import sessionMiddleware from '../../helpers/middleware/session'
 
 // VERCEL_ENV is a reserved env key by Vercel that specify the deployment type: "preview", "production", or "deployment"
-const isPreview = process.env.VERCEL_ENV !== 'preview'
+const isPreview = process.env.VERCEL_ENV === 'preview'
 
 const handler = nextConnect()
 const apolloServer = new ApolloServer({
@@ -20,8 +20,10 @@ const apolloServer = new ApolloServer({
   By default apolloServer accepts uploads, while schema-generated server does not.*/
   uploads: false,
   plugins: [apolloLogPlugin],
-  playground: isPreview,
-  introspection: isPreview
+  ...(isPreview && {
+    playground: isPreview,
+    introspection: isPreview
+  })
 })
 
 const graphQLHandler = apolloServer.createHandler({ path: '/api/graphql' })

--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -9,7 +9,7 @@ import userMiddleware from '../../helpers/middleware/user'
 import sessionMiddleware from '../../helpers/middleware/session'
 
 // VERCEL_ENV is a reserved env key by Vercel that specify the deployment type: "preview", "production", or "deployment"
-const isPreview = process.env.VERCEL_ENV === 'preview'
+const isPreview = process.env.VERCEL_ENV !== 'preview'
 
 const handler = nextConnect()
 const apolloServer = new ApolloServer({


### PR DESCRIPTION
Closes #2350 

## Changes
Merging this PR will enable the Apollo playground for the preview deployments and keep it enabled for local development to make CRUD operations easier for engineers.

### How to test it

Head to https://c0d3-7u9vqmkyr-c0d3-prod.vercel.app/api/graphql and confirm it's working correctly.