### PR TITLE
Add DOJO exercise filtering checkbox

### DIFF
--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -168,16 +168,16 @@ describe('Exercises page', () => {
     let checkbox = await findByLabelText('Show incomplete exercises only')
 
     let exercisePreviews = await findAllByText('Problem')
-    expect(exercisePreviews.length).toBe(3)
+    expect(exercisePreviews).toHaveLength(3)
     let notAnsweredExercisePreviews = await findAllByText('NOT ANSWERED')
-    expect(notAnsweredExercisePreviews.length).toBe(2)
+    expect(notAnsweredExercisePreviews).toHaveLength(2)
 
     fireEvent.click(checkbox)
 
     exercisePreviews = await findAllByText('Problem')
-    expect(exercisePreviews.length).toBe(2)
+    expect(exercisePreviews).toHaveLength(2)
     notAnsweredExercisePreviews = await findAllByText('NOT ANSWERED')
-    expect(notAnsweredExercisePreviews.length).toBe(2)
+    expect(notAnsweredExercisePreviews).toHaveLength(2)
 
     const solveExercisesButton = await findByRole('button', {
       name: 'SOLVE EXERCISES'
@@ -207,17 +207,17 @@ describe('Exercises page', () => {
     fireEvent.click(nextQuestionButton)
 
     exercisePreviews = await findAllByText('Problem')
-    expect(exercisePreviews.length).toBe(1)
+    expect(exercisePreviews).toHaveLength(1)
     let incorrectExercisePreviews = await findAllByText('INCORRECT')
-    expect(incorrectExercisePreviews.length).toBe(1)
+    expect(incorrectExercisePreviews).toHaveLength(1)
 
     checkbox = await findByLabelText('Show incomplete exercises only')
     fireEvent.click(checkbox)
 
     exercisePreviews = await findAllByText('Problem')
-    expect(exercisePreviews.length).toBe(3)
+    expect(exercisePreviews).toHaveLength(3)
     incorrectExercisePreviews = await findAllByText('INCORRECT')
-    expect(incorrectExercisePreviews.length).toBe(1)
+    expect(incorrectExercisePreviews).toHaveLength(1)
   })
 
   test('Should not render lessons nav card tab if lesson docUrl is null', async () => {

--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, waitFor, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Exercises from '../../../pages/exercises/[lessonSlug]'
 import { useRouter } from 'next/router'
@@ -28,9 +28,7 @@ describe('Exercises page', () => {
       </MockedProvider>
     )
 
-    await waitFor(() =>
-      screen.getByRole('heading', { name: /Foundations of JavaScript/i })
-    )
+    await screen.findByRole('heading', { name: /Foundations of JavaScript/i })
 
     screen.getByRole('link', { name: 'CHALLENGES' })
     screen.getByRole('link', { name: 'EXERCISES' })
@@ -66,15 +64,13 @@ describe('Exercises page', () => {
       }
     ]
 
-    const { getByRole, queryByRole, getByLabelText } = render(
+    const { getByRole, findByRole, queryByRole, getByLabelText } = render(
       <MockedProvider mocks={mocks} addTypename={false}>
         <Exercises />
       </MockedProvider>
     )
 
-    await waitFor(() =>
-      getByRole('heading', { name: /Foundations of JavaScript/i })
-    )
+    await findByRole('heading', { name: /Foundations of JavaScript/i })
 
     const solveExercisesButton = getByRole('button', {
       name: 'SOLVE EXERCISES'
@@ -242,9 +238,7 @@ describe('Exercises page', () => {
       </MockedProvider>
     )
 
-    await waitFor(() =>
-      screen.getByRole('heading', { name: /Foundations of JavaScript/i })
-    )
+    await screen.findByRole('heading', { name: /Foundations of JavaScript/i })
 
     screen.getByRole('link', { name: 'CHALLENGES' })
     screen.getByRole('link', { name: 'EXERCISES' })
@@ -270,7 +264,7 @@ describe('Exercises page', () => {
       </MockedProvider>
     )
 
-    await waitFor(() => screen.getByRole('heading', { name: /500 Error/i }))
+    await screen.findByRole('heading', { name: /500 Error/i })
   })
 
   test('Should render a 404 error page if the lesson is not found', async () => {
@@ -292,7 +286,7 @@ describe('Exercises page', () => {
       </MockedProvider>
     )
 
-    await waitFor(() => screen.getByRole('heading', { name: /404 Error/i }))
+    await screen.findByRole('heading', { name: /404 Error/i })
   })
 
   test('Should render a loading spinner if useRouter is not ready', async () => {
@@ -314,6 +308,6 @@ describe('Exercises page', () => {
       </MockedProvider>
     )
 
-    await waitFor(() => screen.getByText('Loading...'))
+    await screen.findByText('Loading...')
   })
 })

--- a/components/ExercisePreviewCard/ExercisePreviewCard.tsx
+++ b/components/ExercisePreviewCard/ExercisePreviewCard.tsx
@@ -3,7 +3,7 @@ import styles from './exercisePreviewCard.module.scss'
 
 export type ExercisePreviewCardProps = {
   moduleName: string
-  state: 'NOT ANSWERED' | 'ANSWERED'
+  state: 'NOT ANSWERED' | 'INCORRECT' | 'ANSWERED'
   problem: string
   className?: string
 }

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -12,7 +12,9 @@ import Error, { StatusCode } from '../../components/Error'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import AlertsDisplay from '../../components/AlertsDisplay'
 import NavCard from '../../components/NavCard'
-import ExercisePreviewCard from '../../components/ExercisePreviewCard'
+import ExercisePreviewCard, {
+  ExercisePreviewCardProps
+} from '../../components/ExercisePreviewCard'
 import { NewButton } from '../../components/theme/Button'
 import ExerciseCard, { Message } from '../../components/ExerciseCard'
 import { ArrowLeftIcon } from '@primer/octicons-react'
@@ -63,14 +65,22 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
 
   const currentExercises = exercises
     .filter(exercise => exercise?.module.lesson.slug === slug)
-    .map(exercise => ({
-      id: exercise.id,
-      moduleName: exercise.module.name,
-      problem: exercise.description,
-      answer: exercise.answer,
-      explanation: exercise.explanation || '',
-      userAnswer: userAnswers[exercise.id] ?? null
-    }))
+    .map(exercise => {
+      const userAnswer = userAnswers[exercise.id] ?? null
+      return {
+        id: exercise.id,
+        moduleName: exercise.module.name,
+        problem: exercise.description,
+        answer: exercise.answer,
+        explanation: exercise.explanation || '',
+        userAnswer,
+        state: ((): ExercisePreviewCardProps['state'] => {
+          if (userAnswer === exercise.answer) return 'ANSWERED'
+          if (userAnswer) return 'INCORRECT'
+          return 'NOT ANSWERED'
+        })()
+      }
+    })
     .filter(
       exercise => !hideAnswered || exercise.userAnswer !== exercise.answer
     )
@@ -220,6 +230,7 @@ type ExerciseItem = {
   problem: string
   answer: string
   userAnswer: string | null
+  state: ExercisePreviewCardProps['state']
 }
 
 type ExerciseListProps = {
@@ -276,11 +287,7 @@ const ExerciseList = ({
           <ExercisePreviewCard
             key={i}
             moduleName={exercise.moduleName}
-            state={(() => {
-              if (exercise.userAnswer === exercise.answer) return 'ANSWERED'
-              if (exercise.userAnswer) return 'INCORRECT'
-              return 'NOT ANSWERED'
-            })()}
+            state={exercise.state}
             problem={exercise.problem}
           />
         ))}

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -261,13 +261,15 @@ const ExerciseList = ({
             <span>Show incomplete exercises only</span>
           </label>
         </div>
-        <div
-          className={`mb-3 mb-md-0 d-flex d-md-block ${styles.exerciseList__solveExercisesButtonContainer}`}
-        >
-          <NewButton className="flex-grow-1" onClick={onClickSolveExercises}>
-            SOLVE EXERCISES
-          </NewButton>
-        </div>
+        {exercises.length > 0 && (
+          <div
+            className={`mb-3 mb-md-0 d-flex d-md-block ${styles.exerciseList__solveExercisesButtonContainer}`}
+          >
+            <NewButton className="flex-grow-1" onClick={onClickSolveExercises}>
+              SOLVE EXERCISES
+            </NewButton>
+          </div>
+        )}
       </div>
       <div className={styles.exerciseList__container}>
         {exercises.map((exercise, i) => (

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -262,7 +262,7 @@ const ExerciseList = ({
               checked={hideAnswered}
               onChange={() => setHideAnswered(!hideAnswered)}
             />
-            <span>Show unanswered exercises only</span>
+            <span>Show incomplete exercises only</span>
           </label>
         </div>
         <div
@@ -278,7 +278,11 @@ const ExerciseList = ({
           <ExercisePreviewCard
             key={i}
             moduleName={exercise.moduleName}
-            state={exercise.userAnswer ? 'ANSWERED' : 'NOT ANSWERED'}
+            state={(() => {
+              if (exercise.userAnswer === exercise.answer) return 'ANSWERED'
+              if (exercise.userAnswer) return 'INCORRECT'
+              return 'NOT ANSWERED'
+            })()}
             problem={exercise.problem}
           />
         ))}

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -24,6 +24,7 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
 }) => {
   const { lessons, alerts, exercises, exerciseSubmissions } = queryData
   const router = useRouter()
+  const [hideAnswered, setHideAnswered] = useState(false)
   const [exerciseIndex, setExerciseIndex] = useState(-1)
   const [addExerciseSubmission] = useAddExerciseSubmissionMutation()
   const [userAnswers, setUserAnswers] = useState<Record<number, string>>({})
@@ -70,6 +71,9 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
       explanation: exercise.explanation || '',
       userAnswer: userAnswers[exercise.id] ?? null
     }))
+    .filter(
+      exercise => !hideAnswered || exercise.userAnswer !== exercise.answer
+    )
 
   const exercise = currentExercises[exerciseIndex]
 
@@ -95,6 +99,8 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
           tabs={tabs}
           setExerciseIndex={setExerciseIndex}
           lessonTitle={currentLesson.title}
+          hideAnswered={hideAnswered}
+          setHideAnswered={setHideAnswered}
           exercises={currentExercises}
         />
       )}
@@ -185,6 +191,8 @@ type ExerciseListProps = {
   tabs: { text: string; url: string }[]
   setExerciseIndex: React.Dispatch<React.SetStateAction<number>>
   lessonTitle: string
+  hideAnswered: boolean
+  setHideAnswered: (hideAnswered: boolean) => void
   exercises: {
     moduleName: string
     problem: string
@@ -197,6 +205,8 @@ const ExerciseList = ({
   tabs,
   setExerciseIndex,
   lessonTitle,
+  hideAnswered,
+  setHideAnswered,
   exercises
 }: ExerciseListProps) => {
   return (
@@ -208,7 +218,19 @@ const ExerciseList = ({
         />
       </div>
       <div className="d-flex flex-column flex-md-row justify-content-between align-items-center">
-        <h1 className="my-2 my-md-5 fs-2">{lessonTitle}</h1>
+        <div className="my-2 my-md-5">
+          <h1 className="fs-2">{lessonTitle}</h1>
+          <label className="d-inline-flex align-items-center">
+            <input
+              className="form-check-input m-0 me-3"
+              type="checkbox"
+              style={{ width: 30, height: 30 }}
+              checked={hideAnswered}
+              onChange={() => setHideAnswered(!hideAnswered)}
+            />
+            <span>Show unanswered exercises only</span>
+          </label>
+        </div>
         <div
           className={`mb-3 mb-md-0 d-flex d-md-block ${styles.exerciseList__solveExercisesButtonContainer}`}
         >
@@ -225,7 +247,7 @@ const ExerciseList = ({
           <ExercisePreviewCard
             key={i}
             moduleName={exercise.moduleName}
-            state={exercise.userAnswer === null ? 'NOT ANSWERED' : 'ANSWERED'}
+            state={exercise.userAnswer ? 'ANSWERED' : 'NOT ANSWERED'}
             problem={exercise.problem}
           />
         ))}

--- a/pages/exercises/[lessonSlug].tsx
+++ b/pages/exercises/[lessonSlug].tsx
@@ -95,11 +95,7 @@ const Exercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
       ) : (
         <ExerciseList
           tabs={tabs}
-          onClickSolveExercises={() => {
-            if (currentExercises.length > 0) {
-              setSolvingExercise(true)
-            }
-          }}
+          onClickSolveExercises={() => setSolvingExercise(true)}
           lessonTitle={currentLesson.title}
           hideAnswered={hideAnswered}
           setHideAnswered={setHideAnswered}


### PR DESCRIPTION
Changes:
* Add DOJO exercise filter checkbox which shows which exercise previews get displayed and which exercises you will solve when you press the SOLVE EXERCISES button
* Add INCORRECT state to ExercisePreview component (so now there are 3 states: NOT ANSWERED, INCORRECT, ANSWERED)
* Make it so if you submit an answer with an empty string in the input box, it will make it so the exercise is NOT ANSWERED (this makes it easier to test exercises because you can set ANSWERED or INCORRECT exercises to NOT ANSWERED now)
* Move React state down to the Exercise component
* Only show the SOLVE EXERCISES button if there is at least 1 exercise

How to test:
* Create a DOJO module at /admin/lessons/js0/modules
* Create DOJO exercises at /curriculum/js0/mentor
* Go to /exercises/js0
* Answer exercises correctly, incorrectly, and leave them empty when submitting, then go back and see how the previews look
* Toggle the exercise filtering checkbox to make sure it works correctly

Desktop unchecked:
![desktop-unchecked](https://user-images.githubusercontent.com/7637655/193429420-7ecd7438-f157-42e9-a8cc-0c9cebfc79f7.png)

Desktop checked:
![desktop-checked](https://user-images.githubusercontent.com/7637655/193429430-39fd2175-c29f-4709-8944-688380155a09.png)

Mobile unchecked:
![mobile-unchecked](https://user-images.githubusercontent.com/7637655/193429436-3b336378-22ff-4e17-b760-152ec9419701.png)

Mobile checked:
![mobile-checked](https://user-images.githubusercontent.com/7637655/193429439-10648e5b-4313-4f90-a90d-b1fc60a83a74.png)

This pull request is related to https://github.com/garageScript/c0d3-app/issues/2253 and https://github.com/garageScript/c0d3-app/issues/2251