### PR TITLE
feat: Make `AdminLessonInputs` generic

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -505,9 +505,9 @@ Array [
           >
             <span
               className="optionInfo__span"
-              data-testid="spanModule Name0"
+              data-testid="spanItem Name0"
             >
-              Module name
+              Item name
             </span>
             <input
               className="form-control optionInfo__input"

--- a/__tests__/pages/admin/lessons/[lessonSlug]/[pageName]/lessons.test.js
+++ b/__tests__/pages/admin/lessons/[lessonSlug]/[pageName]/lessons.test.js
@@ -221,7 +221,7 @@ describe('modules', () => {
       delay: 1
     })
 
-    const submit = screen.getByText('ADD ITEM')
+    const submit = screen.getByText('ADD MODULE')
 
     await userEvent.click(submit)
 

--- a/components/admin/lessons/AdminLessonInputs/AdminLessonInputs.test.js
+++ b/components/admin/lessons/AdminLessonInputs/AdminLessonInputs.test.js
@@ -106,8 +106,12 @@ const errorMocks = [errorMock, { ...errorMock }]
 const loadingMocks = [loadingMock]
 
 describe('AdminLessonInputs component', () => {
-  it('Should add module', async () => {
+  it('Should add item', async () => {
     expect.assertions(1)
+
+    const mutation = jest.fn().mockResolvedValue({
+      ...modules.basic
+    })
 
     const { getByText, getByTestId } = render(
       <MockedProvider mocks={mocks}>
@@ -115,6 +119,8 @@ describe('AdminLessonInputs component', () => {
           lessonId={lesson.id}
           title={lesson.title}
           refetch={() => {}}
+          action={mutation}
+          loading={false}
         />
       </MockedProvider>
     )
@@ -129,7 +135,7 @@ describe('AdminLessonInputs component', () => {
       delay: 1
     })
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     await waitFor(() =>
@@ -139,8 +145,12 @@ describe('AdminLessonInputs component', () => {
     )
   })
 
-  it('Should update module', async () => {
+  it('Should update item', async () => {
     expect.assertions(1)
+
+    const mutation = jest.fn().mockResolvedValue({
+      ...modules.basic
+    })
 
     const { getByText, getByTestId } = render(
       <MockedProvider mocks={updateModuleMocks}>
@@ -148,7 +158,8 @@ describe('AdminLessonInputs component', () => {
           lessonId={lesson.id}
           title={lesson.title}
           refetch={() => {}}
-          module={modules.withId}
+          action={mutation}
+          item={modules.basic}
         />
       </MockedProvider>
     )
@@ -176,21 +187,29 @@ describe('AdminLessonInputs component', () => {
   it('Should display error message if inputs are empty', async () => {
     expect.assertions(1)
 
+    const mutation = jest.fn().mockResolvedValue({
+      ...modules.basic
+    })
+
     const { getByText, getByTestId } = render(
       <MockedProvider mocks={mocks}>
-        <AdminLessonInputs lessonId={lesson.id} title={lesson.title} />
+        <AdminLessonInputs
+          lessonId={lesson.id}
+          title={lesson.title}
+          action={mutation}
+        />
       </MockedProvider>
     )
 
     await userEvent.clear(getByTestId('input0'))
     await userEvent.clear(getByTestId('textbox'))
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     await waitFor(() =>
       expect(
-        getByText('An error occurred. Please try again.')
+        getByText('missing item name, description, or order')
       ).toBeInTheDocument()
     )
   })
@@ -198,9 +217,17 @@ describe('AdminLessonInputs component', () => {
   it('Should display error message if network or GraphQL error', async () => {
     expect.assertions(1)
 
+    const mutation = jest.fn().mockRejectedValue({
+      message: 'An error occurred. Please try again.'
+    })
+
     const { getByText, getByTestId } = render(
       <MockedProvider mocks={errorMocks}>
-        <AdminLessonInputs lessonId={lesson.id} title={lesson.title} />
+        <AdminLessonInputs
+          lessonId={lesson.id}
+          title={lesson.title}
+          action={mutation}
+        />
       </MockedProvider>
     )
 
@@ -211,7 +238,7 @@ describe('AdminLessonInputs component', () => {
       delay: 1
     })
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     await waitFor(() =>
@@ -230,6 +257,8 @@ describe('AdminLessonInputs component', () => {
           lessonId={lesson.id}
           title={lesson.title}
           refetch={() => {}}
+          loading={true}
+          mutation={() => {}}
         />
       </MockedProvider>
     )
@@ -244,7 +273,7 @@ describe('AdminLessonInputs component', () => {
       delay: 1
     })
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     expect(container.querySelector('.spinner-grow')).toBeInTheDocument()
@@ -261,24 +290,30 @@ describe('AdminLessonInputs component', () => {
 
     await userEvent.clear(getByTestId('input0'))
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     expect(getByText('Untitled')).toBeInTheDocument()
   })
 
-  it('Should call onAddModule when a module is added', async () => {
+  it('Should call onActionFinish when an item is added', async () => {
     expect.hasAssertions()
 
-    const onAddModule = jest.fn()
+    const onActionFinish = jest.fn()
+
+    const mutation = jest.fn().mockResolvedValue({
+      ...basicMock.result.data.addModule,
+      lesson: { id: lesson.id }
+    })
 
     const { getByText, getByTestId } = render(
       <MockedProvider mocks={mocks}>
         <AdminLessonInputs
           lessonId={lesson.id}
           title={lesson.title}
-          onAddModule={onAddModule}
+          onActionFinish={onActionFinish}
           refetch={() => {}}
+          action={mutation}
         />
       </MockedProvider>
     )
@@ -293,30 +328,36 @@ describe('AdminLessonInputs component', () => {
       delay: 1
     })
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     await waitFor(() =>
-      expect(onAddModule).toBeCalledWith(
+      expect(onActionFinish).toBeCalledWith(
         { ...basicMock.result.data.addModule, lesson: { id: lesson.id } },
         null
       )
     )
   })
 
-  it('Should call onAddModule when a module is updated', async () => {
+  it('Should call onActionFinish when an item is updated', async () => {
     expect.hasAssertions()
 
-    const onAddModule = jest.fn()
+    const onActionFinish = jest.fn()
+
+    const mutation = jest.fn().mockResolvedValue({
+      ...basicUpdateModuleMock.result.data.updateModule,
+      lesson: { id: lesson.id }
+    })
 
     const { getByText, getByTestId } = render(
       <MockedProvider mocks={updateModuleMocks}>
         <AdminLessonInputs
           lessonId={lesson.id}
           title={lesson.title}
-          onAddModule={onAddModule}
+          onActionFinish={onActionFinish}
           refetch={() => {}}
-          module={modules.withId}
+          action={mutation}
+          item={modules.withId}
         />
       </MockedProvider>
     )
@@ -335,7 +376,7 @@ describe('AdminLessonInputs component', () => {
     await userEvent.click(submit)
 
     await waitFor(() =>
-      expect(onAddModule).toBeCalledWith(
+      expect(onActionFinish).toBeCalledWith(
         {
           ...basicUpdateModuleMock.result.data.updateModule,
           lesson: { id: lesson.id }
@@ -345,10 +386,12 @@ describe('AdminLessonInputs component', () => {
     )
   })
 
-  it('Should call onAddModule with null when a module is added', async () => {
+  it('Should call onActionFinish with null when an item is added', async () => {
     expect.hasAssertions()
 
-    const onAddModule = jest.fn()
+    const onActionFinish = jest.fn()
+
+    const mutation = jest.fn().mockResolvedValue(null)
 
     const { getByText, getByTestId } = render(
       <MockedProvider
@@ -365,8 +408,9 @@ describe('AdminLessonInputs component', () => {
         <AdminLessonInputs
           lessonId={lesson.id}
           title={lesson.title}
-          onAddModule={onAddModule}
+          onActionFinish={onActionFinish}
           refetch={() => {}}
+          action={mutation}
         />
       </MockedProvider>
     )
@@ -381,24 +425,28 @@ describe('AdminLessonInputs component', () => {
       delay: 1
     })
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
-    await waitFor(() => expect(onAddModule).toBeCalledWith(null, null))
+    await waitFor(() => expect(onActionFinish).toBeCalledWith(null, null))
   })
 
-  it('Should call onAddModule when there is error', async () => {
+  it('Should call onActionFinish when there is error', async () => {
     expect.hasAssertions()
 
-    const onAddModule = jest.fn()
+    const onActionFinish = jest.fn()
+    const mutation = jest.fn().mockRejectedValue({
+      message: 'error'
+    })
 
     const { getByText, getByTestId } = render(
       <MockedProvider mocks={errorMocks}>
         <AdminLessonInputs
           lessonId={lesson.id}
           title={lesson.title}
-          onAddModule={onAddModule}
+          onActionFinish={onActionFinish}
           refetch={() => {}}
+          action={mutation}
         />
       </MockedProvider>
     )
@@ -412,62 +460,20 @@ describe('AdminLessonInputs component', () => {
     await userEvent.type(getByTestId('textbox'), 'Functions are cool', {
       delay: 1
     })
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     await waitFor(() =>
-      expect(onAddModule).toBeCalledWith(null, { ...modules.basic })
-    )
-  })
-
-  it('Should handle false module update/add query response name', async () => {
-    expect.assertions(1)
-
-    const { getByText, getByTestId } = render(
-      <MockedProvider
-        mocks={[
-          {
-            ...updateModuleMocks[0],
-            result: {
-              data: {
-                updateModule: {
-                  ...updateModuleMocks[0].result.data.updateModule,
-                  name: undefined
-                }
-              }
-            }
-          }
-        ]}
-      >
-        <AdminLessonInputs
-          lessonId={lesson.id}
-          title={lesson.title}
-          refetch={() => {}}
-          module={modules.withId}
-        />
-      </MockedProvider>
-    )
-
-    await userEvent.type(getByTestId('input0'), 'Functions', {
-      delay: 1
-    })
-    await userEvent.type(getByTestId('input2'), '1', {
-      delay: 1
-    })
-    await userEvent.type(getByTestId('textbox'), 'Functions are cool', {
-      delay: 1
-    })
-
-    const submit = getByText('SAVE CHANGES')
-    await userEvent.click(submit)
-
-    await waitFor(() =>
-      expect(getByText('Updated the item successfully!')).toBeInTheDocument()
+      expect(onActionFinish).toBeCalledWith(null, { ...modules.basic })
     )
   })
 
   it('Should dismiss success message', async () => {
     expect.assertions(1)
+
+    const mutation = jest.fn().mockResolvedValue({
+      ...modules.basic
+    })
 
     const { getByText, getByTestId, queryByText, getByLabelText } = render(
       <MockedProvider mocks={mocks}>
@@ -475,6 +481,7 @@ describe('AdminLessonInputs component', () => {
           lessonId={lesson.id}
           title={lesson.title}
           refetch={() => {}}
+          action={mutation}
         />
       </MockedProvider>
     )
@@ -489,7 +496,7 @@ describe('AdminLessonInputs component', () => {
       delay: 1
     })
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     await userEvent.click(getByLabelText('Close alert'))
@@ -504,16 +511,24 @@ describe('AdminLessonInputs component', () => {
   it('Should dismiss error message', async () => {
     expect.assertions(1)
 
+    const mutation = jest.fn().mockResolvedValue({
+      ...modules.basic
+    })
+
     const { getByText, getByTestId, queryByText, getByLabelText } = render(
       <MockedProvider mocks={mocks}>
-        <AdminLessonInputs lessonId={lesson.id} title={lesson.title} />
+        <AdminLessonInputs
+          lessonId={lesson.id}
+          title={lesson.title}
+          action={mutation}
+        />
       </MockedProvider>
     )
 
     await userEvent.clear(getByTestId('input0'))
     await userEvent.clear(getByTestId('textbox'))
 
-    const submit = getByText('ADD MODULE')
+    const submit = getByText('ADD ITEM')
     await userEvent.click(submit)
 
     await userEvent.click(getByLabelText('Close alert'))

--- a/components/admin/lessons/AdminLessonInputs/AdminLessonInputs.tsx
+++ b/components/admin/lessons/AdminLessonInputs/AdminLessonInputs.tsx
@@ -22,6 +22,7 @@ export type Props<MainItem extends Item> = {
   lessonId: number
   title?: string
   item?: Item
+  itemName?: string
   loading: boolean
   refetch: (variables?: Partial<OperationVariables>) => Promise<
     ApolloQueryResult<{
@@ -35,17 +36,18 @@ export type Props<MainItem extends Item> = {
   action: (options: { variables: Item }) => Promise<Item | undefined>
 }
 
-enum Error {
-  InvalidData = 'missing item name, description, or order'
-}
-
 const initValues = (
   nameValue?: string,
   descValue?: string,
-  orderValue?: number
+  orderValue?: number,
+  itemName?: string
 ): [TextField, TextField, Option] => [
   {
-    title: 'Item Name',
+    title: `${
+      itemName
+        ? itemName[0].toUpperCase() + itemName.slice(1).toLowerCase()
+        : 'Item'
+    } Name`,
     value: nameValue || ''
   },
   {
@@ -63,6 +65,7 @@ const AdminLessonInputs = <MainItem extends Item>({
   title,
   lessonId,
   item,
+  itemName,
   loading,
   refetch,
   onActionFinish,
@@ -74,7 +77,10 @@ const AdminLessonInputs = <MainItem extends Item>({
   const [data, setData] = useState<null | undefined | typeof item>(null)
 
   useEffect(
-    () => setFormOptions(initValues(item?.name, item?.content, item?.order)),
+    () =>
+      setFormOptions(
+        initValues(item?.name, item?.content, item?.order, itemName)
+      ),
     [item]
   )
 
@@ -106,7 +112,9 @@ const AdminLessonInputs = <MainItem extends Item>({
         order.value === '' ||
         order.value < 0
       ) {
-        return setErrorMsg(Error.InvalidData)
+        return setErrorMsg(
+          `missing ${itemName || 'item'} name, description, or order`
+        )
       }
 
       setErrorMsg('')
@@ -156,7 +164,7 @@ const AdminLessonInputs = <MainItem extends Item>({
         loading={loading}
         error={errorMsg}
         texts={{
-          loading: 'Adding the item...',
+          loading: `Adding the ${itemName || 'item'}...`,
           data: dataText(),
           error: errorMsg
         }}
@@ -172,7 +180,9 @@ const AdminLessonInputs = <MainItem extends Item>({
         title={name.value || title || 'Untitled'}
         values={formOptions}
         onSubmit={{
-          title: item ? 'SAVE CHANGES' : 'ADD ITEM',
+          title: item
+            ? 'SAVE CHANGES'
+            : `ADD ${itemName?.toUpperCase() || 'ITEM'}`,
           onClick: onSubmit
         }}
         onChange={handleChange}

--- a/components/admin/lessons/AdminLessonInputs/AdminLessonInputs.tsx
+++ b/components/admin/lessons/AdminLessonInputs/AdminLessonInputs.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { formChange } from '../../../../helpers/formChange'
 import { FormCard, MD_INPUT, Option, TextField } from '../../../FormCard'
 import styles from './adminLessonInputs.module.scss'
-import { get, isEqual } from 'lodash'
+import { isEqual } from 'lodash'
 import {
   ApolloError,
   OperationVariables,
@@ -11,12 +11,11 @@ import {
 import QueryInfo from '../../../QueryInfo'
 
 export type Item = {
-  __typename?: string | undefined
   id?: number
   name: string
   content: string
   order: number
-  lesson?: { __typename?: string | undefined; id?: number }
+  lesson?: { __typename?: string; id?: number }
 }
 
 export type Props<MainItem extends Item> = {
@@ -30,18 +29,10 @@ export type Props<MainItem extends Item> = {
     }>
   >
   onActionFinish?: (
-    m:
-      | (Item & { lesson: { id: number } })
-      | (Item & { lesson: { id: number } })
-      | null,
+    m: (Item & { lesson: { id: number } }) | null,
     e: { name: string; content: string; order: number } | null
   ) => void
-  action: (options: { variables: Item }) => Promise<
-    | {
-        [Key in keyof Item]: Item[Key]
-      }
-    | undefined
-  >
+  action: (options: { variables: Item }) => Promise<Item | undefined>
 }
 
 enum Error {
@@ -83,10 +74,7 @@ const AdminLessonInputs = <MainItem extends Item>({
   const [data, setData] = useState<null | undefined | typeof item>(null)
 
   useEffect(
-    () =>
-      setFormOptions(
-        initValues(get(item, 'name'), get(item, 'content'), get(item, 'order'))
-      ),
+    () => setFormOptions(initValues(item?.name, item?.content, item?.order)),
     [item]
   )
 
@@ -94,7 +82,7 @@ const AdminLessonInputs = <MainItem extends Item>({
     content: content.value as string,
     lessonId,
     name: name.value as string,
-    order: +order.value as number
+    order: Number(order.value)
   }
 
   const [dataDiff, setDataDiff] = useState<undefined | typeof data>(data)

--- a/pages/admin/lessons/[lessonSlug]/[pageName]/index.tsx
+++ b/pages/admin/lessons/[lessonSlug]/[pageName]/index.tsx
@@ -162,6 +162,7 @@ const ModulesPage = ({ modules, lessonId, refetch }: ModulesPageProps) => {
           item={selectedModule}
           action={action}
           loading={loading}
+          itemName="module"
         />
       </div>
     </div>

--- a/stories/components/AdminLessonInputs.stories.tsx
+++ b/stories/components/AdminLessonInputs.stories.tsx
@@ -113,6 +113,7 @@ export const Basic = () => {
           refetch={(() => {}) as any}
           action={mutationFn}
           loading={loading}
+          itemName="module"
         />
       </MockedProvider>
     </>

--- a/stories/components/AdminLessonInputs.stories.tsx
+++ b/stories/components/AdminLessonInputs.stories.tsx
@@ -57,7 +57,7 @@ export const Basic = () => {
     error: false
   })
 
-  const { data, loading } = someFn(null)
+  const { loading } = someFn(null)
 
   const mutationFn = async (options: { variables: Item }) => {
     const { data } = await someFn({

--- a/stories/components/AdminLessonInputs.stories.tsx
+++ b/stories/components/AdminLessonInputs.stories.tsx
@@ -1,8 +1,8 @@
-import { ApolloQueryResult, OperationVariables } from '@apollo/client'
 import { MockedProvider } from '@apollo/client/testing'
 import React from 'react'
 import AdminLessonInputs from '../../components/admin/lessons/AdminLessonInputs'
-import { AddModuleDocument, Module } from '../../graphql'
+import { Item } from '../../components/admin/lessons/AdminLessonInputs/AdminLessonInputs'
+import { AddModuleDocument, UpdateModuleDocument } from '../../graphql'
 
 export default {
   component: AdminLessonInputs,
@@ -19,52 +19,102 @@ const modules = [
   }
 ]
 
-export const Basic = () => (
-  <>
-    <div>
-      <ol>
-        <li>Submit with empty values for error</li>
-        <li>
-          <code>name: {modules[0].name}</code> /{' '}
-          <code>description: {modules[0].content}</code> for success message
-        </li>
-      </ol>
-    </div>
-    <MockedProvider
-      mocks={[
-        {
-          request: {
-            query: AddModuleDocument,
-            variables: {
-              ...modules[0],
-              lessonId: 1
-            }
-          },
-          result: {
-            data: {
-              addModule: {
+const moduleWithId = {
+  name: 'Functions',
+  content: 'Functions are cool',
+  order: 1,
+  id: 1
+}
+
+const basicUpdateModuleMock = {
+  request: {
+    query: UpdateModuleDocument,
+    variables: {
+      ...moduleWithId,
+      lessonId: 1
+    }
+  },
+  result: {
+    data: {
+      updateModule: {
+        ...moduleWithId,
+        lesson: {
+          title: 'Foundations of JavaScript'
+        }
+      }
+    }
+  }
+}
+
+export const Basic = () => {
+  const someFn = (_: any) => ({
+    data: {
+      updateModule: {
+        name: 'Cool item'
+      }
+    } as any,
+    loading: false,
+    error: false
+  })
+
+  const { data, loading } = someFn(null)
+
+  const mutationFn = async (options: { variables: Item }) => {
+    const { data } = await someFn({
+      variables: {
+        ...options.variables,
+        lessonId: 1,
+        id: 1
+      }
+    })
+
+    return data?.updateModule
+  }
+
+  return (
+    <>
+      <div>
+        <ol>
+          <li>Submit with empty values for error</li>
+          <li>
+            <code>name: {modules[0].name}</code> /{' '}
+            <code>description: {modules[0].content}</code> for success message
+          </li>
+        </ol>
+      </div>
+      <MockedProvider
+        mocks={[
+          {
+            request: {
+              query: AddModuleDocument,
+              variables: {
                 ...modules[0],
-                lesson: {
-                  title: 'Foundations of JavaScript'
+                lessonId: 1
+              }
+            },
+            result: {
+              data: {
+                addModule: {
+                  ...modules[0],
+                  lesson: {
+                    title: 'Foundations of JavaScript'
+                  }
                 }
               }
             }
-          }
-        }
-      ]}
-    >
-      <AdminLessonInputs
-        module={modules[0]}
-        lessonId={lesson.id}
-        title={lesson.title}
-        refetch={
-          (() => {}) as (variables?: Partial<OperationVariables>) => Promise<
-            ApolloQueryResult<{
-              modules: Module[]
-            }>
-          >
-        }
-      />
-    </MockedProvider>
-  </>
-)
+          },
+          basicUpdateModuleMock
+        ]}
+      >
+        <AdminLessonInputs
+          item={modules[0]}
+          lessonId={lesson.id}
+          title={lesson.title}
+          refetch={(() => {}) as any}
+          action={mutationFn}
+          loading={loading}
+        />
+      </MockedProvider>
+    </>
+  )
+}


### PR DESCRIPTION
Related to #2081 

### Description

This PR aims at making the [AdminLessonInputs](https://github.com/garageScript/c0d3-app/blob/master/components/admin/lessons/AdminLessonInputs/AdminLessonInputs.tsx) component generic by updating it to take the hooks for adding/updating the item as props and make its types generic.

### Small features

- Show a custom error message for empty inputs
- Change all references for `MODULE` with `ITEM`

### Concerns

I had trouble trying to make its types generic. I'm aware it's not perfect. Please let me know in the comments how it could be improved.

### Testing

1. Go to `/admin/lessons/js1/modules`
2. Fill in the inputs and hit `ADD ITEM`
3. Make sure it works