### PR TITLE
feat(DOJO/mentor): Only display mentor created exercises

### DIFF
--- a/__dummy__/getExercisesData.ts
+++ b/__dummy__/getExercisesData.ts
@@ -64,6 +64,9 @@ const getExercisesData: GetExercisesQuery = {
           slug: 'js0'
         }
       },
+      author: {
+        id: 1
+      },
       description: '```\nlet a = 5\na = a + 10\n// what is a?\n```',
       answer: '15',
       explanation: 'You can reassign variables that were created with "let".'
@@ -76,6 +79,9 @@ const getExercisesData: GetExercisesQuery = {
           slug: 'js0'
         }
       },
+      author: {
+        id: 1
+      },
       description: '```\nlet a = 1\na += 2\n// what is a?\n```',
       answer: '3',
       explanation: '`a += 2` is a shorter way to write `a = a + 2`'
@@ -87,6 +93,9 @@ const getExercisesData: GetExercisesQuery = {
         lesson: {
           slug: 'js0'
         }
+      },
+      author: {
+        id: 1
       },
       description: '```\nlet a = 1\na -= 2\n// what is a?\n```',
       answer: '-1',

--- a/__tests__/pages/curriculum/[lessonSlug]/mentor/index.test.js
+++ b/__tests__/pages/curriculum/[lessonSlug]/mentor/index.test.js
@@ -41,8 +41,6 @@ describe('Mentor page', () => {
       </MockedProvider>
     )
 
-    await new Promise(res => setTimeout(res, 0))
-
     await waitFor(() =>
       screen.getByRole('heading', { name: /Foundations of JavaScript/i })
     )
@@ -84,8 +82,6 @@ describe('Mentor page', () => {
     await waitFor(() =>
       screen.getByRole('heading', { name: /Foundations of JavaScript/i })
     )
-
-    await new Promise(res => setTimeout(res, 0))
 
     expect(screen.queryByText('Numbers')).not.toBeInTheDocument()
     expect(

--- a/__tests__/pages/curriculum/[lessonSlug]/mentor/index.test.js
+++ b/__tests__/pages/curriculum/[lessonSlug]/mentor/index.test.js
@@ -6,8 +6,12 @@ import { useRouter } from 'next/router'
 import { MockedProvider } from '@apollo/client/testing'
 import getExercisesData from '../../../../../__dummy__/getExercisesData'
 import GET_EXERCISES from '../../../../../graphql/queries/getExercises'
+import GET_SESSION from '../../../../../graphql/queries/getSession'
+import dummySessionData from '../../../../../__dummy__/sessionData'
 
-describe('AddExercises page', () => {
+import '@testing-library/jest-dom'
+
+describe('Mentor page', () => {
   const { query, push } = useRouter()
   query['lessonSlug'] = 'js0'
 
@@ -17,6 +21,56 @@ describe('AddExercises page', () => {
         request: { query: GET_EXERCISES },
         result: {
           data: getExercisesData
+        }
+      },
+      {
+        request: { query: GET_SESSION },
+        result: {
+          data: {
+            session: {
+              ...dummySessionData
+            }
+          }
+        }
+      }
+    ]
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <AddExercises />
+      </MockedProvider>
+    )
+
+    await new Promise(res => setTimeout(res, 0))
+
+    await waitFor(() =>
+      screen.getByRole('heading', { name: /Foundations of JavaScript/i })
+    )
+
+    screen.getByRole('link', { name: 'CHALLENGES' })
+    screen.getByRole('link', { name: 'EXERCISES' })
+    screen.getByRole('link', { name: 'LESSON' })
+  })
+
+  test('Should not render exercises if the user id mismatch exercise author.id', async () => {
+    const mocks = [
+      {
+        request: { query: GET_EXERCISES },
+        result: {
+          data: getExercisesData
+        }
+      },
+      {
+        request: { query: GET_SESSION },
+        result: {
+          data: {
+            session: {
+              ...dummySessionData,
+              user: {
+                id: 4
+              }
+            }
+          }
         }
       }
     ]
@@ -31,9 +85,12 @@ describe('AddExercises page', () => {
       screen.getByRole('heading', { name: /Foundations of JavaScript/i })
     )
 
-    screen.getByRole('link', { name: 'CHALLENGES' })
-    screen.getByRole('link', { name: 'EXERCISES' })
-    screen.getByRole('link', { name: 'LESSON' })
+    await new Promise(res => setTimeout(res, 0))
+
+    expect(screen.queryByText('Numbers')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /Foundations of JavaScript/i })
+    ).toBeInTheDocument()
   })
 
   test('Should push to addExercise page', async () => {
@@ -42,6 +99,16 @@ describe('AddExercises page', () => {
         request: { query: GET_EXERCISES },
         result: {
           data: getExercisesData
+        }
+      },
+      {
+        request: { query: GET_SESSION },
+        result: {
+          data: {
+            session: {
+              ...dummySessionData
+            }
+          }
         }
       }
     ]
@@ -78,6 +145,16 @@ describe('AddExercises page', () => {
             }))
           }
         }
+      },
+      {
+        request: { query: GET_SESSION },
+        result: {
+          data: {
+            session: {
+              ...dummySessionData
+            }
+          }
+        }
       }
     ]
 
@@ -106,6 +183,16 @@ describe('AddExercises page', () => {
             lessons: null
           }
         }
+      },
+      {
+        request: { query: GET_SESSION },
+        result: {
+          data: {
+            session: {
+              ...dummySessionData
+            }
+          }
+        }
       }
     ]
 
@@ -126,6 +213,16 @@ describe('AddExercises page', () => {
           data: {
             ...getExercisesData,
             lessons: []
+          }
+        }
+      },
+      {
+        request: { query: GET_SESSION },
+        result: {
+          data: {
+            session: {
+              ...dummySessionData
+            }
           }
         }
       }
@@ -149,6 +246,16 @@ describe('AddExercises page', () => {
         request: { query: GET_EXERCISES },
         result: {
           data: getExercisesData
+        }
+      },
+      {
+        request: { query: GET_SESSION },
+        result: {
+          data: {
+            session: {
+              ...dummySessionData
+            }
+          }
         }
       }
     ]

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -865,6 +865,7 @@ export type GetExercisesQuery = {
     description: string
     answer: string
     explanation?: string | null
+    author: { __typename?: 'User'; id: number }
     module: {
       __typename?: 'Module'
       name: string
@@ -3682,6 +3683,9 @@ export const GetExercisesDocument = gql`
     }
     exercises {
       id
+      author {
+        id
+      }
       module {
         name
         lesson {

--- a/graphql/queries/getExercises.ts
+++ b/graphql/queries/getExercises.ts
@@ -16,6 +16,9 @@ const GET_EXERCISES = gql`
     }
     exercises {
       id
+      author {
+        id
+      }
       module {
         name
         lesson {

--- a/pages/curriculum/[lessonSlug]/mentor/addExercise/index.tsx
+++ b/pages/curriculum/[lessonSlug]/mentor/addExercise/index.tsx
@@ -132,7 +132,7 @@ const initValues = [
   }
 ]
 
-const MentorPage = ({ data }: GetAppProps) => {
+const AddExercisePage = ({ data }: GetAppProps) => {
   const router = useRouter()
   const { lessonSlug } = router.query
 
@@ -218,4 +218,4 @@ const MentorPage = ({ data }: GetAppProps) => {
   )
 }
 
-export default withGetApp()(MentorPage)
+export default withGetApp()(AddExercisePage)

--- a/pages/curriculum/[lessonSlug]/mentor/index.tsx
+++ b/pages/curriculum/[lessonSlug]/mentor/index.tsx
@@ -4,7 +4,7 @@ import Layout from '../../../../components/Layout'
 import withQueryLoader, {
   QueryDataProps
 } from '../../../../containers/withQueryLoader'
-import { GetExercisesQuery } from '../../../../graphql'
+import { GetExercisesQuery, useGetSessionQuery } from '../../../../graphql'
 import Error, { StatusCode } from '../../../../components/Error'
 import LoadingSpinner from '../../../../components/LoadingSpinner'
 import AlertsDisplay from '../../../../components/AlertsDisplay'
@@ -14,9 +14,12 @@ import { NewButton } from '../../../../..../../components/theme/Button'
 import GET_EXERCISES from '../../../../..../../graphql/queries/getExercises'
 import styles from '../../../../scss/exercises.module.scss'
 
-const AddExercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
+const MentorPage: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   queryData
 }) => {
+  const { data } = useGetSessionQuery()
+  const sessionUser = data?.session.user
+
   const { lessons, alerts, exercises } = queryData
   const router = useRouter()
 
@@ -43,7 +46,11 @@ const AddExercises: React.FC<QueryDataProps<GetExercisesQuery>> = ({
   ]
 
   const currentExercises = exercises
-    .filter(exercise => exercise?.module.lesson.slug === slug)
+    .filter(
+      exercise =>
+        exercise.module.lesson.slug === slug &&
+        exercise.author.id === sessionUser?.id
+    )
     .map(exercise => ({
       id: exercise.id,
       moduleName: exercise.module.name,
@@ -128,5 +135,5 @@ export default withQueryLoader<GetExercisesQuery>(
   {
     query: GET_EXERCISES
   },
-  AddExercises
+  MentorPage
 )


### PR DESCRIPTION
Related to #2029 

### Description

Merging this PR will update the mentor page under `/curriculum/[lessonSlug]/mentor` to only show the exercises that the mentor created by comparing the exercise author's `id` to the user session `id`.

### Testing

- Create a module from `/admin/lessons/js0/modules`
- Create an exercise from `/curriculum/js0/mentor/addExercise`

1. Go to `/curriculum/js0/mentor`
2. Confirm the exercise you created are the only ones appearing

### Bugs

While pushing, I noticed a flaky test caused by [this line](https://github.com/flacial/c0d3-app/blob/fc9ae7fe5165a5ceb13503db9a2c59a2c5aba1f8/pages/exercises/[lessonSlug].tsx#L44) in the `Exercises` page. I couldn't trace back what caused it.