### PR TITLE
feat: Make `ExerciseCardPreview` state optional

### DIFF
--- a/components/ExercisePreviewCard/ExercisePreviewCard.tsx
+++ b/components/ExercisePreviewCard/ExercisePreviewCard.tsx
@@ -3,7 +3,7 @@ import styles from './exercisePreviewCard.module.scss'
 
 export type ExercisePreviewCardProps = {
   moduleName: string
-  state: 'NOT ANSWERED' | 'INCORRECT' | 'ANSWERED'
+  state?: 'NOT ANSWERED' | 'INCORRECT' | 'ANSWERED'
   problem: string
   className?: string
 }
@@ -29,10 +29,10 @@ const ExercisePreviewCard = ({
     <section
       className={`card p-3 d-inline-block border-0 shadow position-relative overflow-hidden ${className}`}
     >
-      <div className={topBorderStyle} />
+      {state && <div className={topBorderStyle} />}
       <div className="d-flex align-items-center mb-3">
         <h2 className="fw-bold fs-6 my-2 me-4">{moduleName.toUpperCase()}</h2>
-        <div className={`badge ${topMessageStyle}`}>{state}</div>
+        {state && <div className={`badge ${topMessageStyle}`}>{state}</div>}
       </div>
       <div className="mb-2">Problem</div>
       <pre className="bg-light py-2 px-3">{problem}</pre>

--- a/pages/curriculum/[lessonSlug]/mentor/index.tsx
+++ b/pages/curriculum/[lessonSlug]/mentor/index.tsx
@@ -113,7 +113,6 @@ const ExerciseList = ({
           <ExercisePreviewCard
             key={i}
             moduleName={exercise.moduleName}
-            state={'ANSWERED'}
             problem={exercise.problem}
           />
         ))}


### PR DESCRIPTION
Related to #2029 
Depends on #2385

### Description

Merging this PR makes it possible to reuse the [ExercisePreviewCard](https://github.com/garageScript/c0d3-app/blob/master/components/ExercisePreviewCard/ExercisePreviewCard.tsx) by making the exercise `state` type optional.

### Testing

- Create a module from `/admin/lessons/js0/modules`
- Create an exercise from `/curriculum/js0/mentor/addExercise`

1. Go to `/curriculum/js0/mentor`
2. Confirm the exercises look like the following

<img width="452" alt="image" src="https://user-images.githubusercontent.com/35906419/193434835-8ac11b5e-4696-4cbb-8526-f2a48110fb5f.png">
