### PR TITLE
refactor: Use `CLIENT_URL` for signup confirm link

### DIFF
--- a/helpers/mailTemplate.ts
+++ b/helpers/mailTemplate.ts
@@ -1,6 +1,6 @@
 const CLIENT_URL =
-  process.env.VERCEL_URL ??
   process.env.CLIENT_URL ??
+  process.env.VERCEL_URL ??
   `http://localhost:${process.env.PORT ?? 3000}`
 
 export const getSignupTemplate = (token: string) => {


### PR DESCRIPTION
Closes #2374 

### Description

This PR sets the `CLIENT_URL` variable as the env key `CLIENT_URL` if it's not null or undefined. Previously, it was setting it to `VERCEL_URL` which is the production deployment [c0d3-8u3uezvkv-c0d3-prod.vercel.app](https://vercel.com/c0d3-prod/c0d3-app/DYDtr2aq7vxFB6dYj5jKXHPNxgAP) 

### Testing

Currently, it can only be tested on production because preview deployments can't send emails.