### PR TITLE
Add markdown support to exercise card and exercise preview

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5528,13 +5528,13 @@ exports[`Storyshots Components/ExerciseCard Basic 1`] = `
       >
         Problem
       </div>
-      <pre
+      <p
         className="bg-light py-3 px-4"
       >
         let a = 5
 a = a + 10
 // what is a?
-      </pre>
+      </p>
     </div>
     <div
       className="ms-md-3 exerciseCard__section"
@@ -5692,13 +5692,13 @@ exports[`Storyshots Components/ExercisePreviewCard Answered 1`] = `
   >
     Problem
   </div>
-  <pre
+  <p
     className="bg-light py-2 px-3"
   >
     const a = 5
 a = a + 10
 // what is a?
-  </pre>
+  </p>
 </section>
 `;
 
@@ -5728,13 +5728,13 @@ exports[`Storyshots Components/ExercisePreviewCard Not Answered 1`] = `
   >
     Problem
   </div>
-  <pre
+  <p
     className="bg-light py-2 px-3"
   >
     const a = 5
 a = a + 10
 // what is a?
-  </pre>
+  </p>
 </section>
 `;
 

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5529,7 +5529,7 @@ exports[`Storyshots Components/ExerciseCard Basic 1`] = `
         Problem
       </div>
       <p
-        className="bg-light py-3 px-4"
+        className="d-block bg-light py-3 px-4"
       >
         let a = 5
 a = a + 10
@@ -5693,7 +5693,7 @@ exports[`Storyshots Components/ExercisePreviewCard Answered 1`] = `
     Problem
   </div>
   <p
-    className="bg-light py-2 px-3"
+    className="d-block bg-light py-2 px-3"
   >
     const a = 5
 a = a + 10
@@ -5729,7 +5729,7 @@ exports[`Storyshots Components/ExercisePreviewCard Not Answered 1`] = `
     Problem
   </div>
   <p
-    className="bg-light py-2 px-3"
+    className="d-block bg-light py-2 px-3"
   >
     const a = 5
 a = a + 10

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -1,3 +1,4 @@
+import Markdown from 'markdown-to-jsx'
 import React, { useState } from 'react'
 import { NewButton } from '../theme/Button'
 import { Text } from '../theme/Text'
@@ -37,7 +38,7 @@ const ExerciseCard = ({
       <div className="d-flex flex-column flex-md-row mb-2">
         <div className={`mb-0 me-md-3 ${styles.exerciseCard__section}`}>
           <div className="fw-bold mb-2">Problem</div>
-          <pre className="bg-light py-3 px-4">{problem}</pre>
+          <Markdown className="bg-light py-3 px-4">{problem}</Markdown>
         </div>
         <div className={`ms-md-3 ${styles.exerciseCard__section}`}>
           <div className="fw-bold mt-2 mt-md-0 mb-2">Your Answer</div>
@@ -88,11 +89,11 @@ const ExerciseCard = ({
           <hr />
           <div className="fw-bold mb-2">Answer</div>
           <div className="d-flex flex-column flex-md-row mb-2">
-            <pre
+            <Markdown
               className={`bg-light py-3 px-4 mb-2 mb-md-0 me-md-3 ${styles.exerciseCard__section}`}
             >
               {answer}
-            </pre>
+            </Markdown>
             <div className={`ms-md-3 ${styles.exerciseCard__section}`}>
               {explanation}
             </div>

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -94,9 +94,11 @@ const ExerciseCard = ({
             >
               {answer}
             </Markdown>
-            <div className={`ms-md-3 ${styles.exerciseCard__section}`}>
+            <Markdown
+              className={`d-block ms-md-3 ${styles.exerciseCard__section}`}
+            >
               {explanation}
-            </div>
+            </Markdown>
           </div>
         </>
       )}

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -38,7 +38,7 @@ const ExerciseCard = ({
       <div className="d-flex flex-column flex-md-row mb-2">
         <div className={`mb-0 me-md-3 ${styles.exerciseCard__section}`}>
           <div className="fw-bold mb-2">Problem</div>
-          <Markdown className="bg-light py-3 px-4">{problem}</Markdown>
+          <Markdown className="d-block bg-light py-3 px-4">{problem}</Markdown>
         </div>
         <div className={`ms-md-3 ${styles.exerciseCard__section}`}>
           <div className="fw-bold mt-2 mt-md-0 mb-2">Your Answer</div>
@@ -90,7 +90,7 @@ const ExerciseCard = ({
           <div className="fw-bold mb-2">Answer</div>
           <div className="d-flex flex-column flex-md-row mb-2">
             <Markdown
-              className={`bg-light py-3 px-4 mb-2 mb-md-0 me-md-3 ${styles.exerciseCard__section}`}
+              className={`d-block bg-light py-3 px-4 mb-2 mb-md-0 me-md-3 ${styles.exerciseCard__section}`}
             >
               {answer}
             </Markdown>

--- a/components/ExercisePreviewCard/ExercisePreviewCard.tsx
+++ b/components/ExercisePreviewCard/ExercisePreviewCard.tsx
@@ -36,7 +36,7 @@ const ExercisePreviewCard = ({
         {state && <div className={`badge ${topMessageStyle}`}>{state}</div>}
       </div>
       <div className="mb-2">Problem</div>
-      <Markdown className="bg-light py-2 px-3">{problem}</Markdown>
+      <Markdown className="d-block bg-light py-2 px-3">{problem}</Markdown>
     </section>
   )
 }

--- a/components/ExercisePreviewCard/ExercisePreviewCard.tsx
+++ b/components/ExercisePreviewCard/ExercisePreviewCard.tsx
@@ -1,3 +1,4 @@
+import Markdown from 'markdown-to-jsx'
 import React from 'react'
 import styles from './exercisePreviewCard.module.scss'
 
@@ -35,7 +36,7 @@ const ExercisePreviewCard = ({
         {state && <div className={`badge ${topMessageStyle}`}>{state}</div>}
       </div>
       <div className="mb-2">Problem</div>
-      <pre className="bg-light py-2 px-3">{problem}</pre>
+      <Markdown className="bg-light py-2 px-3">{problem}</Markdown>
     </section>
   )
 }


### PR DESCRIPTION
How to test:
* Go to /exercises/js0
* Check that markdown looks good

Before:
![before](https://user-images.githubusercontent.com/7637655/193488057-f8e2fe92-cb46-4988-8ecf-be43c48bb1b5.png)


After:
![exercise-preview-after](https://user-images.githubusercontent.com/7637655/193488080-2f7daa2d-366c-4f7e-aa25-d919ee560acc.png)
![exercise-preview-after-mobile](https://user-images.githubusercontent.com/7637655/193488081-27e52d72-fe8f-4af3-be51-11166f1ead33.png)
![exercise-card-after](https://user-images.githubusercontent.com/7637655/193488077-d022196f-e651-4519-9dcb-f0e8d9f3964e.png)
![exercise-card-after-mobile](https://user-images.githubusercontent.com/7637655/193488079-c38d33fa-4ff6-4fef-8a50-84eefbe2d747.png)
