### PR TITLE
Fix NavCard word wrap

### DIFF
--- a/scss/navCard.module.scss
+++ b/scss/navCard.module.scss
@@ -37,6 +37,7 @@ $light_primary: color.adjust(variables.$primary, $lightness: 28%);
   font-weight: bold;
   text-decoration: none;
   font-size: 14px;
+  white-space: nowrap;
 }
 
 .navCard__tabsNav__nav__item:hover {
@@ -53,6 +54,7 @@ $light_primary: color.adjust(variables.$primary, $lightness: 28%);
   text-decoration: none;
   transition: background-color 0.1s ease-in;
   font-size: 14px;
+  white-space: nowrap;
 }
 
 .navCard__tabsNav__nav__item--inactive:hover {


### PR DESCRIPTION
Changes:
* Words no longer wrap on the NavCard on mobile

How to test:
* Go to /exercises/js0 on mobile
* Notice that the NavCard has each link on a single line

Before:
![before](https://user-images.githubusercontent.com/7637655/193637826-f2616b48-7f8c-462a-9eaf-184f9663b578.png)

After:
![after](https://user-images.githubusercontent.com/7637655/193637854-fd656195-e36f-4f45-b58d-0684f40aa6db.png)