### PR TITLE
feat(DOJO): Add back button to addExercise page

### DIFF
--- a/__tests__/pages/curriculum/[lessonSlug]/mentor/addExercise/index.test.js
+++ b/__tests__/pages/curriculum/[lessonSlug]/mentor/addExercise/index.test.js
@@ -157,20 +157,6 @@ describe('AddExercise page', () => {
     expect(screen.queryAllByText('Select a module')[0]).toBeInTheDocument()
   })
 
-  it('should go back to mentor page', async () => {
-    render(
-      <MockedProvider mocks={mocks}>
-        <AddExercisePage />
-      </MockedProvider>
-    )
-
-    // Helps the data to resolve
-    await act(() => new Promise(res => setTimeout(res, 0)))
-
-    await userEvent.click(screen.getByLabelText('Exit'))
-
-    expect(useRouterObj.push).toBeCalledWith('/curriculum/js1/mentor')
-  })
   it('should fill out the inputs', async () => {
     render(
       <MockedProvider mocks={mocks}>

--- a/__tests__/pages/curriculum/[lessonSlug]/mentor/addExercise/index.test.js
+++ b/__tests__/pages/curriculum/[lessonSlug]/mentor/addExercise/index.test.js
@@ -157,6 +157,20 @@ describe('AddExercise page', () => {
     expect(screen.queryAllByText('Select a module')[0]).toBeInTheDocument()
   })
 
+  it('should go back to mentor page', async () => {
+    render(
+      <MockedProvider mocks={mocks}>
+        <AddExercisePage />
+      </MockedProvider>
+    )
+
+    // Helps the data to resolve
+    await act(() => new Promise(res => setTimeout(res, 0)))
+
+    await userEvent.click(screen.getByLabelText('Exit'))
+
+    expect(useRouterObj.push).toBeCalledWith('/curriculum/js1/mentor')
+  })
   it('should fill out the inputs', async () => {
     render(
       <MockedProvider mocks={mocks}>

--- a/pages/curriculum/[lessonSlug]/mentor/addExercise/index.tsx
+++ b/pages/curriculum/[lessonSlug]/mentor/addExercise/index.tsx
@@ -17,6 +17,7 @@ import styles from '../../../../../scss/mentorPage.module.scss'
 import { get } from 'lodash'
 import QueryInfo from '../../../../../components/QueryInfo'
 import { errorCheckAllFields } from '../../../../../helpers/admin/adminHelpers'
+import { ArrowLeftIcon } from '@primer/octicons-react'
 import * as Sentry from '@sentry/nextjs'
 
 type DetachedModule = Omit<Module, 'lesson' | 'author'>
@@ -43,10 +44,19 @@ const Header = <
   setModule,
   setErrorMsg
 }: HeaderProps<T>) => {
+  const { query, push } = useRouter()
+  const { lessonSlug } = query
+
   const modules = get(lesson, 'modules') ?? []
 
   return (
     <header className={styles.header}>
+      <button
+        className="btn ps-0 d-flex align-items-center mb-3"
+        onClick={() => push(`/curriculum/${lessonSlug}/mentor`)}
+      >
+        <ArrowLeftIcon size="medium" aria-label="Exit" />
+      </button>
       <div>
         <h1>{get(lesson, 'title')}</h1>
       </div>
@@ -133,8 +143,8 @@ const initValues = [
 ]
 
 const AddExercisePage = ({ data }: GetAppProps) => {
-  const router = useRouter()
-  const { lessonSlug } = router.query
+  const { query } = useRouter()
+  const { lessonSlug } = query
 
   // Omitting author and lesson because data.lessons[i].modules[i] mismatching type
   const [module, setModule] = useState<null | DetachedModule>(null)

--- a/pages/curriculum/[lessonSlug]/mentor/addExercise/index.tsx
+++ b/pages/curriculum/[lessonSlug]/mentor/addExercise/index.tsx
@@ -18,6 +18,7 @@ import { get } from 'lodash'
 import QueryInfo from '../../../../../components/QueryInfo'
 import { errorCheckAllFields } from '../../../../../helpers/admin/adminHelpers'
 import { ArrowLeftIcon } from '@primer/octicons-react'
+import Link from 'next/link'
 import * as Sentry from '@sentry/nextjs'
 
 type DetachedModule = Omit<Module, 'lesson' | 'author'>
@@ -44,19 +45,18 @@ const Header = <
   setModule,
   setErrorMsg
 }: HeaderProps<T>) => {
-  const { query, push } = useRouter()
+  const { query } = useRouter()
   const { lessonSlug } = query
 
   const modules = get(lesson, 'modules') ?? []
 
   return (
     <header className={styles.header}>
-      <button
-        className="btn ps-0 d-flex align-items-center mb-3"
-        onClick={() => push(`/curriculum/${lessonSlug}/mentor`)}
-      >
-        <ArrowLeftIcon size="medium" aria-label="Exit" />
-      </button>
+      <Link href={`/curriculum/${lessonSlug}/mentor`}>
+        <a className="btn ps-0 d-flex align-items-center mb-3">
+          <ArrowLeftIcon size="medium" aria-label="Exit" />
+        </a>
+      </Link>
       <div>
         <h1>{get(lesson, 'title')}</h1>
       </div>


### PR DESCRIPTION
Related to #2029 

### Description

This PR adds a back button that links to the mentor page under `/curriculum/[lessonSlug]/mentor`. So, once the mentor finish adding exercises, they can return to the mentor page.

### Testing

1. Go to `/curriculum/js0/mentor`
2. Click `ADD EXERCISE`
3. Click the back button arrow on the top
4. Make sure you went back to the mentor page