### PR TITLE
Allow user to hit enter to submit answer

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -5548,6 +5548,7 @@ a = a + 10
         aria-label="User answer"
         className="form-control mb-2 "
         onChange={[Function]}
+        onKeyDown={[Function]}
         value=""
       />
       <div

--- a/components/ExerciseCard/ExerciseCard.test.tsx
+++ b/components/ExerciseCard/ExerciseCard.test.tsx
@@ -81,6 +81,47 @@ describe('ExerciseCard component', () => {
     expect(submitUserAnswer).toBeCalledTimes(1)
   })
 
+  it('Should allow users to submit a message by hitting the enter key in the input', () => {
+    const setAnswerShown = jest.fn()
+    const setMessage = jest.fn()
+    const submitUserAnswer = jest.fn()
+
+    const { queryByText, getByLabelText } = render(
+      <ExerciseCard
+        problem={exampleProblem}
+        answer={exampleAnswer}
+        explanation={exampleExplanation}
+        answerShown={false}
+        setAnswerShown={setAnswerShown}
+        message={Message.ERROR}
+        setMessage={setMessage}
+        submitUserAnswer={submitUserAnswer}
+      />
+    )
+
+    expect(queryByText(Message.ERROR)).toBeInTheDocument()
+    expect(queryByText(Message.SUCCESS)).not.toBeInTheDocument()
+
+    const inputBox = getByLabelText('User answer')
+    fireEvent.change(inputBox, {
+      target: { value: '15' }
+    })
+
+    // Test that hitting the enter key submits answer and shows the success message and the answer explanation
+    fireEvent.keyDown(inputBox, { key: 'Enter', code: 'Enter', charCode: 13 })
+
+    expect(setAnswerShown).toBeCalledWith(true)
+    expect(setAnswerShown).toBeCalledTimes(1)
+    expect(setMessage).toBeCalledWith(Message.SUCCESS)
+    expect(setMessage).toBeCalledTimes(1)
+    expect(submitUserAnswer).toBeCalledWith('15')
+    expect(submitUserAnswer).toBeCalledTimes(1)
+
+    // Test that hitting non-enter keys does not submit answer
+    fireEvent.keyDown(inputBox, { key: 'a' })
+    expect(submitUserAnswer).toBeCalledTimes(1)
+  })
+
   it('Should render a success message', () => {
     const setAnswerShown = jest.fn()
     const setMessage = jest.fn()

--- a/components/ExerciseCard/ExerciseCard.tsx
+++ b/components/ExerciseCard/ExerciseCard.tsx
@@ -33,6 +33,16 @@ const ExerciseCard = ({
 }: ExerciseCardProps) => {
   const [studentAnswer, setStudentAnswer] = useState('')
 
+  const submitAnswer = () => {
+    if (studentAnswer.trim() === answer.trim()) {
+      setMessage(Message.SUCCESS)
+      setAnswerShown(true)
+    } else {
+      setMessage(Message.ERROR)
+    }
+    submitUserAnswer(studentAnswer.trim())
+  }
+
   return (
     <section className="card p-5 border-0 shadow">
       <div className="d-flex flex-column flex-md-row mb-2">
@@ -48,6 +58,11 @@ const ExerciseCard = ({
               message === Message.ERROR ? styles.exerciseCard__input__error : ''
             }`}
             value={studentAnswer}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                submitAnswer()
+              }
+            }}
             onChange={e => setStudentAnswer(e.target.value)}
           />
           <div
@@ -60,19 +75,7 @@ const ExerciseCard = ({
             {message}
           </div>
           <div className="d-flex flex-column flex-md-row">
-            <NewButton
-              onClick={() => {
-                if (studentAnswer.trim() === answer.trim()) {
-                  setMessage(Message.SUCCESS)
-                  setAnswerShown(true)
-                } else {
-                  setMessage(Message.ERROR)
-                }
-                submitUserAnswer(studentAnswer.trim())
-              }}
-            >
-              SUBMIT
-            </NewButton>
+            <NewButton onClick={submitAnswer}>SUBMIT</NewButton>
             <button
               className="bg-transparent mt-2 mt-md-0 ms-md-3 border-0 fw-normal"
               onClick={() => setAnswerShown(!answerShown)}


### PR DESCRIPTION
Changes:
* User can now hit the enter key to submit an answer on the exercise card

Why:
* Reduce friction and allow users to more quickly answer questions

How to test:
* Go to /exercises/js0
* Click "SOLVE EXERCISES" button
* Click the input box then hit the enter key and verify that the answer submits
* Verify that clicking the SUBMIT button still submit the answer too

This pull request is a part of https://github.com/garageScript/c0d3-app/issues/2253