### PR TITLE
Remove unnecessary TODO tag

### DIFF
--- a/pages/admin/lessons/[lessonSlug]/[pageName]/index.tsx
+++ b/pages/admin/lessons/[lessonSlug]/[pageName]/index.tsx
@@ -87,7 +87,6 @@ const IntroductionPage = ({ lesson }: { lesson: Lesson }) => {
 
       await updateLesson(makeGraphqlVariable(formOptions))
     } catch (err) {
-      // TODO: Display error with QueryStateMessage #2181
       Sentry.captureException(err)
     }
   }


### PR DESCRIPTION
Removes the TODO tag `// TODO: Display error with QueryStateMessage #2181` because `QueryStateMessage` (actual name `QueryInfo`) was already added to page in line 97:

https://github.com/garageScript/c0d3-app/blob/629f2dda1e966d3e74be86d9dc0298296fa0e939/pages/admin/lessons/%5BlessonSlug%5D/%5BpageName%5D/index.tsx#L98-L110