### PR TITLE
Update `AdminLessonExerciseCard` types and  `getExercises` query

### DIFF
--- a/__dummy__/getExercisesData.ts
+++ b/__dummy__/getExercisesData.ts
@@ -65,7 +65,10 @@ const getExercisesData: GetExercisesQuery = {
         }
       },
       author: {
-        id: 1
+        id: 1,
+        username: 'noob',
+        email: 'noob@c0d3.com',
+        discordUsername: 'noobOnDiscord'
       },
       description: '```\nlet a = 5\na = a + 10\n// what is a?\n```',
       answer: '15',
@@ -80,7 +83,10 @@ const getExercisesData: GetExercisesQuery = {
         }
       },
       author: {
-        id: 1
+        id: 1,
+        username: 'noob',
+        email: 'noob@c0d3.com',
+        discordUsername: 'noobOnDiscord'
       },
       description: '```\nlet a = 1\na += 2\n// what is a?\n```',
       answer: '3',
@@ -95,7 +101,10 @@ const getExercisesData: GetExercisesQuery = {
         }
       },
       author: {
-        id: 1
+        id: 1,
+        username: 'noob',
+        email: 'noob@c0d3.com',
+        discordUsername: 'noobOnDiscord'
       },
       description: '```\nlet a = 1\na -= 2\n// what is a?\n```',
       answer: '-1',

--- a/components/admin/lessons/AdminLessonExerciseCard.tsx
+++ b/components/admin/lessons/AdminLessonExerciseCard.tsx
@@ -2,15 +2,23 @@ import { get, toUpper } from 'lodash'
 import React, { useState } from 'react'
 import { Collapse, Spinner } from 'react-bootstrap'
 import {
-  Exercise,
   useDeleteExerciseMutation,
-  User,
-  useRemoveExerciseFlagMutation
+  useRemoveExerciseFlagMutation,
+  Exercise,
+  User
 } from '../../../graphql'
 import styles from '../../../scss/adminLessonExerciseCard.module.scss'
 import CopyButton from '../../CopyButton'
 
-type HeaderProps = { user: User; exercise: Exercise }
+type NarrowedUser = Pick<User, 'discordUsername' | 'email' | 'username'>
+type NarrowedExercise = Omit<Exercise, 'author' | 'module'> & {
+  author: NarrowedUser
+  module: {
+    name: string
+  }
+}
+
+type HeaderProps = { user: NarrowedUser; exercise: NarrowedExercise }
 const Header = ({ user, exercise }: HeaderProps) => {
   return (
     <div className={styles.card__header}>
@@ -78,7 +86,7 @@ const Section = ({ header, paragraph, explanation }: SectionProps) => {
 }
 
 type FooterProps = {
-  exercise: Exercise
+  exercise: NarrowedExercise
   onRemove?: (id: number) => void
   onUnflag?: (id: number) => void
 }
@@ -143,8 +151,8 @@ const Footer = ({ exercise, onRemove, onUnflag }: FooterProps) => {
 }
 
 type Props = {
-  user: User
-  exercise: Exercise
+  user: NarrowedUser
+  exercise: NarrowedExercise
   onRemove?: (id: number) => void
   onUnflag?: (id: number) => void
 }

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -865,7 +865,13 @@ export type GetExercisesQuery = {
     description: string
     answer: string
     explanation?: string | null
-    author: { __typename?: 'User'; id: number }
+    author: {
+      __typename?: 'User'
+      id: number
+      username: string
+      email: string
+      discordUsername: string
+    }
     module: {
       __typename?: 'Module'
       name: string
@@ -3685,6 +3691,9 @@ export const GetExercisesDocument = gql`
       id
       author {
         id
+        username
+        email
+        discordUsername
       }
       module {
         name

--- a/graphql/queries/getExercises.ts
+++ b/graphql/queries/getExercises.ts
@@ -18,6 +18,9 @@ const GET_EXERCISES = gql`
       id
       author {
         id
+        username
+        email
+        discordUsername
       }
       module {
         name


### PR DESCRIPTION
Related to #1990 

### Description

When using `AdminLessonExerciseCard`, we'll pass `exercise[i]` from [getExercises query](https://github.com/garageScript/c0d3-app/blob/master/graphql/queries/getExercises.ts).

`exercise` type in `AdminLessonExerciseCard` is:

```ts
export type Exercise = {
  __typename?: 'Exercise'
  answer: Scalars['String']
  author: User
  description: Scalars['String']
  explanation?: Maybe<Scalars['String']>
  flagReason?: Maybe<Scalars['String']>
  flaggedAt?: Maybe<Scalars['String']>
  flaggedBy?: Maybe<User>
  flaggedById?: Maybe<Scalars['Int']>
  id: Scalars['Int']
  module: Module
  testStr?: Maybe<Scalars['String']>
}
```

And we're trying to pass the `exercise` as:

```graphql
id
author {
  id
}
module {
  name
  lesson {
    slug
  }
}
description
answer
explanation
```

This will result in two errors. One would be the mismatch between the `author` type we're passing and `Exercise.author` from `GraphQL` types. Second would be mismatch between the `module` types.

### Solution

Narrow the `exercise` and `user` types to only include what we need and update the `getExercise` query to include the author's `username`, `email`, and `discordUsername` in order to use them in the component.