### PR TITLE
Add required fields to `getExercises` query

### DIFF
--- a/__dummy__/getExercisesData.ts
+++ b/__dummy__/getExercisesData.ts
@@ -67,8 +67,7 @@ const getExercisesData: GetExercisesQuery = {
       author: {
         id: 1,
         username: 'noob',
-        email: 'noob@c0d3.com',
-        discordUsername: 'noobOnDiscord'
+        email: 'noob@c0d3.com'
       },
       description: '```\nlet a = 5\na = a + 10\n// what is a?\n```',
       answer: '15',
@@ -85,8 +84,7 @@ const getExercisesData: GetExercisesQuery = {
       author: {
         id: 1,
         username: 'noob',
-        email: 'noob@c0d3.com',
-        discordUsername: 'noobOnDiscord'
+        email: 'noob@c0d3.com'
       },
       description: '```\nlet a = 1\na += 2\n// what is a?\n```',
       answer: '3',
@@ -103,8 +101,7 @@ const getExercisesData: GetExercisesQuery = {
       author: {
         id: 1,
         username: 'noob',
-        email: 'noob@c0d3.com',
-        discordUsername: 'noobOnDiscord'
+        email: 'noob@c0d3.com'
       },
       description: '```\nlet a = 1\na -= 2\n// what is a?\n```',
       answer: '-1',

--- a/__dummy__/getExercisesData.ts
+++ b/__dummy__/getExercisesData.ts
@@ -67,11 +67,14 @@ const getExercisesData: GetExercisesQuery = {
       author: {
         id: 1,
         username: 'noob',
-        email: 'noob@c0d3.com'
+        email: 'noob@c0d3.com',
+        discordId: '8321'
       },
       description: '```\nlet a = 5\na = a + 10\n// what is a?\n```',
       answer: '15',
-      explanation: 'You can reassign variables that were created with "let".'
+      explanation: 'You can reassign variables that were created with "let".',
+      flaggedAt: null,
+      flagReason: null
     },
     {
       id: 2,
@@ -84,11 +87,14 @@ const getExercisesData: GetExercisesQuery = {
       author: {
         id: 1,
         username: 'noob',
-        email: 'noob@c0d3.com'
+        email: 'noob@c0d3.com',
+        discordId: '8321'
       },
       description: '```\nlet a = 1\na += 2\n// what is a?\n```',
       answer: '3',
-      explanation: '`a += 2` is a shorter way to write `a = a + 2`'
+      explanation: '`a += 2` is a shorter way to write `a = a + 2`',
+      flaggedAt: null,
+      flagReason: null
     },
     {
       id: 3,
@@ -101,11 +107,14 @@ const getExercisesData: GetExercisesQuery = {
       author: {
         id: 1,
         username: 'noob',
-        email: 'noob@c0d3.com'
+        email: 'noob@c0d3.com',
+        discordId: '8321'
       },
       description: '```\nlet a = 1\na -= 2\n// what is a?\n```',
       answer: '-1',
-      explanation: null
+      explanation: null,
+      flaggedAt: null,
+      flagReason: null
     }
   ],
   exerciseSubmissions: [{ exerciseId: 1, userAnswer: '15' }]

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -421,6 +421,7 @@ export type User = {
   __typename?: 'User'
   cliToken?: Maybe<Scalars['String']>
   discordAvatarUrl: Scalars['String']
+  discordId?: Maybe<Scalars['String']>
   discordUserId: Scalars['String']
   discordUsername: Scalars['String']
   email: Scalars['String']
@@ -865,7 +866,15 @@ export type GetExercisesQuery = {
     description: string
     answer: string
     explanation?: string | null
-    author: { __typename?: 'User'; id: number; username: string; email: string }
+    flaggedAt?: string | null
+    flagReason?: string | null
+    author: {
+      __typename?: 'User'
+      id: number
+      username: string
+      email: string
+      discordId?: string | null
+    }
     module: {
       __typename?: 'Module'
       name: string
@@ -1973,6 +1982,7 @@ export type UserResolvers<
 > = ResolversObject<{
   cliToken?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   discordAvatarUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  discordId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   discordUserId?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   discordUsername?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>
@@ -3687,6 +3697,7 @@ export const GetExercisesDocument = gql`
         id
         username
         email
+        discordId
       }
       module {
         name
@@ -3697,6 +3708,8 @@ export const GetExercisesDocument = gql`
       description
       answer
       explanation
+      flaggedAt
+      flagReason
     }
     exerciseSubmissions {
       exerciseId
@@ -5961,6 +5974,7 @@ export type TokenResponseFieldPolicy = {
 export type UserKeySpecifier = (
   | 'cliToken'
   | 'discordAvatarUrl'
+  | 'discordId'
   | 'discordUserId'
   | 'discordUsername'
   | 'email'
@@ -5975,6 +5989,7 @@ export type UserKeySpecifier = (
 export type UserFieldPolicy = {
   cliToken?: FieldPolicy<any> | FieldReadFunction<any>
   discordAvatarUrl?: FieldPolicy<any> | FieldReadFunction<any>
+  discordId?: FieldPolicy<any> | FieldReadFunction<any>
   discordUserId?: FieldPolicy<any> | FieldReadFunction<any>
   discordUsername?: FieldPolicy<any> | FieldReadFunction<any>
   email?: FieldPolicy<any> | FieldReadFunction<any>

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -865,13 +865,7 @@ export type GetExercisesQuery = {
     description: string
     answer: string
     explanation?: string | null
-    author: {
-      __typename?: 'User'
-      id: number
-      username: string
-      email: string
-      discordUsername: string
-    }
+    author: { __typename?: 'User'; id: number; username: string; email: string }
     module: {
       __typename?: 'Module'
       name: string
@@ -3693,7 +3687,6 @@ export const GetExercisesDocument = gql`
         id
         username
         email
-        discordUsername
       }
       module {
         name

--- a/graphql/queries/getExercises.ts
+++ b/graphql/queries/getExercises.ts
@@ -20,6 +20,7 @@ const GET_EXERCISES = gql`
         id
         username
         email
+        discordId
       }
       module {
         name
@@ -30,6 +31,8 @@ const GET_EXERCISES = gql`
       description
       answer
       explanation
+      flaggedAt
+      flagReason
     }
     exerciseSubmissions {
       exerciseId

--- a/graphql/queries/getExercises.ts
+++ b/graphql/queries/getExercises.ts
@@ -20,7 +20,6 @@ const GET_EXERCISES = gql`
         id
         username
         email
-        discordUsername
       }
       module {
         name

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -189,6 +189,7 @@ export default gql`
     isAdmin: Boolean!
     isConnectedToDiscord: Boolean!
     cliToken: String
+    discordId: String
     discordUserId: String!
     discordUsername: String!
     discordAvatarUrl: String!


### PR DESCRIPTION
Related to #1990 

### Description

1. Remove `discordUsername` from the query because in the [exercises resolver](https://github.com/flacial/c0d3-app/blob/e56f5404ddfa49220c490163701e37addd90e64b/graphql/resolvers/exerciseCrud.ts#L16-L25), the returned user object doesn't have a `discordUsername` and the query end up throwing an error: 

```
Cannot return null for non-nullable field Author.discordUsername
```

2. Adds `discordId` so the admin can copy the exercise author discord id and quickly message them
3. Add `flaggedAt` and `flagReason` as they'll be used in the [Exercise card component](https://github.com/garageScript/c0d3-app/blob/master/components/admin/lessons/AdminLessonExerciseCard.tsx#L26) and [this line](https://github.com/garageScript/c0d3-app/blob/master/components/admin/lessons/AdminLessonExerciseCard.tsx#L169)