### PR TITLE
feat: Include session in GraphQL Playground requests

### DIFF
--- a/__tests__/pages/api/graphql.test.js
+++ b/__tests__/pages/api/graphql.test.js
@@ -29,7 +29,7 @@ describe('Graphql Api', () => {
   let apolloServerInput
 
   beforeEach(() => {
-    process.env = { ...OLD_ENV, VERCEL_ENV: 'preview' }
+    process.env = { ...OLD_ENV }
 
     nextConnect.mockImplementation(() => {
       return {
@@ -51,15 +51,53 @@ describe('Graphql Api', () => {
   })
 
   test('Should have correct config object', async () => {
-    const { config } = require('../../../pages/api/graphql.ts')
-    expect(config).toEqual({
-      api: {
-        bodyParser: false
-      }
+    jest.isolateModules(() => {
+      expect(require('../../../pages/api/graphql.ts').config).toEqual({
+        api: {
+          bodyParser: false
+        }
+      })
     })
   })
 
-  test('Should have correct config object when deployed as a preview deployment', async () => {
+  test('Should have correct config object when deployed as a preview', async () => {
+    jest.isolateModules(() => {
+      process.env = {
+        ...OLD_ENV,
+        VERCEL_ENV: 'preview',
+        NODE_ENV: 'production'
+      }
+
+      require('../../../pages/api/graphql.ts')
+
+      expect(
+        apolloServerInput.playground && apolloServerInput.introspection
+      ).toBeTruthy()
+    })
+  })
+
+  test('Should not have correct config object when deployed as a preview', async () => {
+    jest.isolateModules(() => {
+      process.env = {
+        ...OLD_ENV,
+        VERCEL_ENV: '',
+        NODE_ENV: ''
+      }
+
+      require('../../../pages/api/graphql.ts')
+      expect(
+        apolloServerInput.playground && apolloServerInput.introspection
+      ).toBeFalsy()
+    })
+  })
+
+  test('Should have correct config object when deployed as a dev deployment', async () => {
+    process.env = {
+      ...OLD_ENV,
+      VERCEL_ENV: 'production',
+      NODE_ENV: 'development'
+    }
+
     require('../../../pages/api/graphql.ts')
     expect(
       apolloServerInput.playground && apolloServerInput.introspection

--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -9,7 +9,8 @@ import userMiddleware from '../../helpers/middleware/user'
 import sessionMiddleware from '../../helpers/middleware/session'
 
 // VERCEL_ENV is a reserved env key by Vercel that specify the deployment type: "preview", "production", or "deployment"
-const isPreview = process.env.VERCEL_ENV === 'preview'
+const isDevEnv =
+  process.env.VERCEL_ENV === 'preview' || process.env.NODE_ENV === 'development'
 
 const handler = nextConnect()
 const apolloServer = new ApolloServer({
@@ -20,9 +21,13 @@ const apolloServer = new ApolloServer({
   By default apolloServer accepts uploads, while schema-generated server does not.*/
   uploads: false,
   plugins: [apolloLogPlugin],
-  ...(isPreview && {
-    playground: isPreview,
-    introspection: isPreview
+  ...(isDevEnv && {
+    playground: {
+      settings: {
+        'request.credentials': 'include'
+      }
+    },
+    introspection: isDevEnv
   })
 })
 


### PR DESCRIPTION
Closes #2467 

# Description

Merging this PR will config the requests that are sent from the GraphQL playground to include the credentials (session) with the request. We no longer need to set this setting manually every time we'd like to test a query.

# Testing

1. Go to `/api/graphql`
2. Go to the settings
3. Make sure `request.credentials` is set to `include`

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/35906419/199233174-3ea231ef-bfc0-4332-9a5b-40e68337094f.png">

