### PR TITLE
getExerciseComment and getChildComments GraphQL queries

### DIFF
--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -44,7 +44,11 @@ import {
   exerciseSubmissions,
   addExerciseSubmission
 } from './resolvers/exerciseSubmissionCrud'
-import { addExerciseComment } from './resolvers/exerciseCommentCrud'
+import {
+  getExerciseComments,
+  addExerciseComment,
+  getChildComments
+} from './resolvers/exerciseCommentCrud'
 
 export default {
   Query: {
@@ -60,7 +64,9 @@ export default {
     session,
     alerts,
     getPreviousSubmissions,
-    challenges
+    challenges,
+    getExerciseComments,
+    getChildComments
   },
 
   Mutation: {

--- a/graphql/resolvers/exerciseCommentCrud.test.js
+++ b/graphql/resolvers/exerciseCommentCrud.test.js
@@ -1,5 +1,9 @@
 import prismaMock from '../../__tests__/utils/prismaMock'
-import { addExerciseComment } from './exerciseCommentCrud'
+import {
+  addExerciseComment,
+  getExerciseComments,
+  getChildComments
+} from './exerciseCommentCrud'
 
 describe('addExerciseComment resolver tests', () => {
   test('Should throw error if user is invalid or not loggedin', async () => {
@@ -44,6 +48,78 @@ describe('addExerciseComment resolver tests', () => {
         exerciseId: 1,
         parentId: null,
         userPic: null
+      }
+    })
+  })
+})
+
+describe('getExerciseComment resolver test', () => {
+  test('should return exerciseComment with id 1', async () => {
+    const mockContext = { req: { user: { id: 1 } } }
+    const mockArgs = { exerciseId: 1 }
+    const mockExerciseComments = [
+      {
+        id: 1,
+        exerciseId: 1,
+        authorId: 1,
+        content: 'there is user',
+        userPic: null
+      },
+      {
+        id: 2,
+        exerciseId: 1,
+        authorId: 2,
+        content: 'there is user 2',
+        userPic: null
+      }
+    ]
+
+    prismaMock.exerciseComment.findMany.mockResolvedValue(mockExerciseComments)
+    await expect(
+      getExerciseComments(undefined, mockArgs, mockContext)
+    ).resolves.toEqual(mockExerciseComments)
+
+    expect(prismaMock.exerciseComment.findMany).toBeCalledWith({
+      where: { parentId: null, exerciseId: 1 },
+      include: {
+        replies: true
+      }
+    })
+  })
+})
+
+describe('getChildComments resolver tests', () => {
+  test('should return all comments with parent id 1', async () => {
+    const mockContext = { req: { user: { id: 1 } } }
+    const mockArgs = { parentId: 1 }
+    const mockExerciseComments = [
+      {
+        id: 2,
+        exerciseId: 1,
+        authorId: 1,
+        parentId: 1,
+        content: 'there is user',
+        userPic: null
+      },
+      {
+        id: 3,
+        exerciseId: 1,
+        authorId: 2,
+        parentId: 1,
+        content: 'there is user 2',
+        userPic: null
+      }
+    ]
+
+    prismaMock.exerciseComment.findMany.mockResolvedValue(mockExerciseComments)
+    await expect(
+      getChildComments(undefined, mockArgs, mockContext)
+    ).resolves.toEqual(mockExerciseComments)
+
+    expect(prismaMock.exerciseComment.findMany).toBeCalledWith({
+      where: { parentId: 1 },
+      include: {
+        replies: true
       }
     })
   })

--- a/graphql/resolvers/exerciseCommentCrud.ts
+++ b/graphql/resolvers/exerciseCommentCrud.ts
@@ -2,6 +2,32 @@ import { MutationAddExerciseCommentArgs } from '..'
 import { Context } from '../../@types/helpers'
 import prisma from '../../prisma'
 
+export const getExerciseComments = async (
+  _parent: void,
+  _args: { exerciseId: number }
+) => {
+  const exerciseId = _args.exerciseId
+  return prisma.exerciseComment.findMany({
+    where: { parentId: null, exerciseId },
+    include: {
+      replies: true
+    }
+  })
+}
+
+export const getChildComments = async (
+  _parent: void,
+  _args: { parentId: number }
+) => {
+  const parentId = _args.parentId
+  return prisma.exerciseComment.findMany({
+    where: { parentId },
+    include: {
+      replies: true
+    }
+  })
+}
+
 export const addExerciseComment = async (
   _parent: void,
   { content, exerciseId, parentId, userPic }: MutationAddExerciseCommentArgs,

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -15,6 +15,8 @@ export default gql`
     alerts: [Alert!]!
     getPreviousSubmissions(challengeId: Int!, userId: Int!): [Submission!]
     exerciseSubmissions: [ExerciseSubmission!]!
+    getExerciseComments(exerciseId: Int!): [ExerciseComment!]!
+    getChildComments(parentId: Int!): [ExerciseComment!]!
   }
 
   type TokenResponse {


### PR DESCRIPTION
**Description**: relates to https://github.com/garageScript/c0d3-app/issues/2400

This PR adds two GraphQL resolvers for getting exercise comments(filtered by exerciseId), and getting child comments(filtered by parentId). When implemented on the frontend, the `getExerciseComment` will get any main comments, and it's replies. Any nested replies beyond the first reply to main comments will be retrieved with `getChildComments`.

To test:
**First we need to add comments**
1. Go to 'api/graphql'
2. Write 3 mutations as follows:

`mutation AddExerciseComment{ addExerciseComment(exerciseId:1, content:"Cool"){ id exerciseId content } }`

`mutation AddExerciseComment{ addExerciseComment(exerciseId:1, parentId: 1, content:" Really Really COOL!"){ id exerciseId parentId content } }`

`mutation AddExerciseComment{ addExerciseComment(exerciseId:1, parentId: 1, content:"Cool bro"){ id exerciseId parentId content } }`

**Getting Exercise Comments**
3. Write a query to get all main comments with ExerciseId 1:
   `query GetExerciseComments{
  getExerciseComments(exerciseId:1){
    id
    createdAt
    exerciseId
    parentId
    content
    replies{
      id
      createdAt
      content
    }
  }
}
`

It should return something like this:
![getExerciseComments query](https://user-images.githubusercontent.com/77421872/199350629-14915efe-2e96-4b11-b19c-97bd5eb50b06.png)


**Getting Child Comments**
4. Write a query to get all `exerciseComment` with parentId of `1`:

`query GetChildComments{
  getChildComments(parentId:1){
    id
    createdAt
    exerciseId
    parentId
    content
  }
}`

It should return something like this:
![image](https://user-images.githubusercontent.com/77421872/199351157-2682134b-360b-474e-9dac-e9f1dda25d77.png)


