### PR TITLE
fix: Mismatching item names in AdminLessonSIdeNav component

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -1737,13 +1737,14 @@ exports[`Storyshots Components/AdminLessonSideNav Basic 1`] = `
     className="container__heading"
   >
     Existing 
-    modules
+    module
+    s
   </span>
   <ol
-    className="container__modulesList"
+    className="container__itemsList"
   >
     <li
-      className="container__modulesList__module--active"
+      className="container__itemsList__item--active"
       onClick={[Function]}
     >
       <span>
@@ -1751,7 +1752,7 @@ exports[`Storyshots Components/AdminLessonSideNav Basic 1`] = `
       </span>
     </li>
     <li
-      className="container__modulesList__module"
+      className="container__itemsList__item"
       onClick={[Function]}
     >
       <span>
@@ -1782,7 +1783,7 @@ exports[`Storyshots Components/AdminLessonSideNav Basic 1`] = `
       </svg>
     </li>
     <li
-      className="container__modulesList__module"
+      className="container__itemsList__item"
       onClick={[Function]}
     >
       <span>
@@ -1813,7 +1814,7 @@ exports[`Storyshots Components/AdminLessonSideNav Basic 1`] = `
       </svg>
     </li>
     <li
-      className="container__modulesList__module"
+      className="container__itemsList__item"
       onClick={[Function]}
     >
       <span>
@@ -1848,7 +1849,8 @@ exports[`Storyshots Components/AdminLessonSideNav Basic 1`] = `
     className="container--button"
     onClick={[Function]}
   >
-    ADD NEW MODULE
+    ADD NEW 
+    MODULE
   </button>
 </div>
 `;

--- a/__tests__/pages/admin/lessons/[lessonSlug]/[pageName]/lessons.test.js
+++ b/__tests__/pages/admin/lessons/[lessonSlug]/[pageName]/lessons.test.js
@@ -523,7 +523,7 @@ describe('challenges', () => {
     await act(() => new Promise(res => setTimeout(res, 0)))
 
     // Will be changed to ADD NEW CHALLENGE in a subsequent PR
-    await userEvent.click(screen.getByText('ADD NEW MODULE'))
+    await userEvent.click(screen.getByText('ADD NEW CHALLENGE'))
 
     // Challenge name
     await userEvent.type(screen.getByTestId('input0'), 'Asset deletion', {
@@ -566,7 +566,7 @@ describe('challenges', () => {
     await act(() => new Promise(res => setTimeout(res, 0)))
 
     // Will be changed to ADD NEW CHALLENGE in a subsequent PR
-    await userEvent.click(screen.getByText('ADD NEW MODULE'))
+    await userEvent.click(screen.getByText('ADD NEW CHALLENGE'))
 
     expect(screen.getByTestId('input0').value).toBe('')
     expect(screen.getByTestId('input2').value).toBe('')

--- a/components/admin/lessons/AdminLessonSideNav.test.js
+++ b/components/admin/lessons/AdminLessonSideNav.test.js
@@ -37,7 +37,7 @@ describe('AdminLessonSideNav component', () => {
   it('Should display the items', () => {
     expect.assertions(1)
 
-    render(<AdminLessonSideNav title="modules" items={items} />)
+    render(<AdminLessonSideNav items={items} />)
 
     expect(screen.getByText('First module')).toBeInTheDocument()
   })
@@ -45,23 +45,17 @@ describe('AdminLessonSideNav component', () => {
   it('Should display the items with one active item', () => {
     expect.assertions(1)
 
-    render(
-      <AdminLessonSideNav
-        title="modules"
-        items={filteredItems}
-        selectedIndex={0}
-      />
-    )
+    render(<AdminLessonSideNav items={filteredItems} selectedIndex={0} />)
 
     expect(screen.getByText('First module')).toBeInTheDocument()
   })
 
-  it('Should display a message if there is no modules', () => {
+  it('Should display a message if there is no items', () => {
     expect.assertions(1)
 
-    render(<AdminLessonSideNav title="modules" items={[]} />)
+    render(<AdminLessonSideNav items={[]} />)
 
-    expect(screen.getByText('No modules in this lesson')).toBeInTheDocument()
+    expect(screen.getByText('No items in this lesson')).toBeInTheDocument()
   })
 
   it('Should set active item', async () => {
@@ -72,7 +66,6 @@ describe('AdminLessonSideNav component', () => {
 
     render(
       <AdminLessonSideNav
-        title="modules"
         items={filteredItems}
         selectedIndex={active}
         onSelect={item => setActive(item.id)}
@@ -84,21 +77,20 @@ describe('AdminLessonSideNav component', () => {
     expect(active).toBe(0)
   })
 
-  it('Should call onAddItem on ADD NEW MODULE button click', async () => {
+  it('Should call onAddItem on ADD NEW ITEM button click', async () => {
     expect.assertions(1)
 
     const onAddItem = jest.fn()
 
     render(
       <AdminLessonSideNav
-        title="modules"
         items={filteredItems}
         onAddItem={onAddItem}
         selectedIndex={0}
       />
     )
 
-    await userEvent.click(screen.getByText('ADD NEW MODULE'))
+    await userEvent.click(screen.getByText('ADD NEW ITEM'))
 
     expect(onAddItem).toBeCalled()
   })

--- a/components/admin/lessons/AdminLessonSideNav.tsx
+++ b/components/admin/lessons/AdminLessonSideNav.tsx
@@ -15,26 +15,26 @@ type Items = Item[]
 
 type Props = {
   items: Items
-  title: string
   onAddItem: (m?: Item) => void
   selectedIndex?: number
   onSelect: (item: Item) => void
+  itemName?: string
 }
 
 const AdminLessonSideNav = ({
   items,
   onAddItem,
   selectedIndex,
-  title,
-  onSelect
+  onSelect,
+  itemName = 'item'
 }: Props) => {
   const itemsList = items.map(item => {
     const isActive = selectedIndex === item.id
     const className =
       styles[
         isActive
-          ? 'container__modulesList__module--active'
-          : 'container__modulesList__module'
+          ? 'container__itemsList__item--active'
+          : 'container__itemsList__item'
       ]
     const withChevron = !isActive && <ChevronRightIcon size={16} />
 
@@ -47,29 +47,29 @@ const AdminLessonSideNav = ({
   })
 
   // Used isNumber to treat zeros as truthy values
-  const onAddNewModuleClick = () =>
+  const onAddNewItemClick = () =>
     isNumber(selectedIndex) && onAddItem(get(items, selectedIndex))
 
   return (
     <div className={styles.container}>
-      <span className={styles.container__heading}>Existing {title}</span>
-      <ol className={styles.container__modulesList}>
+      <span className={styles.container__heading}>Existing {itemName}s</span>
+      <ol className={styles.container__itemsList}>
         {itemsList.length ? (
           itemsList
         ) : (
           <div className={styles.container__error}>
             <AlertFillIcon />
             <span className={styles.container__heading}>
-              No modules in this lesson
+              No {itemName}s in this lesson
             </span>
           </div>
         )}
       </ol>
       <button
-        onClick={onAddNewModuleClick}
+        onClick={onAddNewItemClick}
         className={styles['container--button']}
       >
-        ADD NEW MODULE
+        ADD NEW {itemName.toUpperCase()}
       </button>
     </div>
   )

--- a/pages/admin/lessons/[lessonSlug]/[pageName]/index.tsx
+++ b/pages/admin/lessons/[lessonSlug]/[pageName]/index.tsx
@@ -160,7 +160,6 @@ const ModulesPage = ({ modules, lessonId, refetch }: ModulesPageProps) => {
   return (
     <div className={styles.container__modulesPanel}>
       <AdminLessonSideNav
-        title="Modules"
         items={modules.map(module => ({
           id: module.id!,
           content: module.content,
@@ -170,6 +169,7 @@ const ModulesPage = ({ modules, lessonId, refetch }: ModulesPageProps) => {
         onAddItem={onAddItem}
         onSelect={onSelect}
         selectedIndex={selectedIndex}
+        itemName="module"
       />
       <div className={styles.container__modulesPanel__inputs}>
         <AdminLessonInputs
@@ -276,7 +276,7 @@ const ChallengesPage = ({
   return (
     <div className={styles.container__modulesPanel}>
       <AdminLessonSideNav
-        title="Challenges"
+        itemName="challenge"
         items={challenges.map(challenge => ({
           id: challenge.id,
           name: challenge.title,

--- a/scss/adminLessonSideNav.module.scss
+++ b/scss/adminLessonSideNav.module.scss
@@ -3,7 +3,7 @@
 // Not available in the design spec colors
 $light-border: hsla(0, 0%, 85%);
 
-@mixin module {
+@mixin item {
   padding: 20px 16px;
   border-radius: 10px;
   cursor: pointer;
@@ -39,7 +39,7 @@ $light-border: hsla(0, 0%, 85%);
   margin-bottom: 15px;
 }
 
-.container__modulesList {
+.container__itemsList {
   padding: 0px;
   flex: 1;
   list-style: none;
@@ -53,19 +53,19 @@ $light-border: hsla(0, 0%, 85%);
   font-size: 14px;
 }
 
-.container__modulesList--loading {
+.container__itemsList--loading {
   align-items: center;
   justify-content: center;
 }
 
-.container__modulesList__module--active {
-  @include module;
+.container__itemsList__item--active {
+  @include item;
   background-color: colors.$bg-white;
   border: 1px solid $light-border;
 }
 
-.container__modulesList__module {
-  @include module;
+.container__itemsList__item {
+  @include item;
   display: flex;
   justify-content: space-between;
   background-color: transparent;

--- a/stories/components/AdminlessonSideNav.stories.tsx
+++ b/stories/components/AdminlessonSideNav.stories.tsx
@@ -41,10 +41,10 @@ export const Basic = () => {
   return (
     <AdminLessonSideNav
       items={items}
-      title={'modules'}
       onAddItem={() => {}}
       selectedIndex={selectedIndex}
       onSelect={onSelect}
+      itemName="module"
     />
   )
 }


### PR DESCRIPTION
Related to #2081 

### Description

Previously, the [AdminLessonSideNav](https://github.com/garageScript/c0d3-app/blob/master/components/admin/lessons/AdminLessonSideNav.tsx) looked like this for any type of items (challenges or modules):

<img width="408" alt="image" src="https://user-images.githubusercontent.com/35906419/201728025-a37f39e7-d830-41a4-bf93-3517630233f9.png">

It had wrong names for the button that's used to add a new item. 

The component now takes an argument called `itemName` that'll be used to set the item name in the title and button:

<img width="391" alt="image" src="https://user-images.githubusercontent.com/35906419/201728337-55de0274-b707-4ed8-8e01-6636fa16ddd8.png">

Notice how `Existing challenges` and `ADD NEW CHALLENGE` text refer to the same item and not something different like a module.
