### PR TITLE
fix(component): Align text & icon to the center

### DIFF
--- a/scss/adminLessonSideNav.module.scss
+++ b/scss/adminLessonSideNav.module.scss
@@ -36,7 +36,6 @@ $light-border: hsla(0, 0%, 85%);
 
   line-height: 22px;
   text-align: center;
-  margin-bottom: 15px;
 }
 
 .container__itemsList {


### PR DESCRIPTION
Closes #2143 

### Description

Align the error message to the center

### Before

<details>
<summary>
Not aligned to the center
</summary>
<img width="358" alt="image" src="https://user-images.githubusercontent.com/35906419/203134560-9a9c086d-cc3e-48ff-a394-51e83ccfd6d9.png">

</details>

### After

<details>
<summary>
Aligned to the center
</summary>
<img width="364" alt="image" src="https://user-images.githubusercontent.com/35906419/203134728-1d9bdadf-cf32-4dd0-b750-2387e48fc6b1.png">
</details>

