### PR TITLE
feat: Seed the database with modules and exercises

### DIFF
--- a/__dummy__/lessonData.ts
+++ b/__dummy__/lessonData.ts
@@ -1,4 +1,4 @@
-import { Lesson } from '../graphql'
+import { Lesson, Module } from '../graphql'
 
 const moduleAuthor = {
   id: 1,
@@ -12,7 +12,7 @@ const moduleAuthor = {
   discordAvatarUrl: ''
 }
 
-const modules = [
+export const modules: Module[] = [
   {
     id: 1,
     name: 'module1',

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,8 @@
 import type { Challenge, Lesson, User } from '@prisma/client'
 import { Prisma, PrismaClient } from '@prisma/client'
 import { SubmissionStatus } from '../graphql'
+import getExercisesData from '../__dummy__/getExercisesData'
+import { modules as modulesData } from '../__dummy__/lessonData'
 import {
   adminData,
   leetData,
@@ -21,12 +23,63 @@ async function main() {
   await seedSubmissions(leet, admin, lessons, SubmissionStatus.Passed)
   await seedSubmissions(noob, null, lessons.slice(0, 1), SubmissionStatus.Open)
   await seedStars(leet, admin, lessons)
+  await seedModules(admin)
+  await seedExercises(admin)
+  await seedExercisesWithoutExplanation(admin)
 }
 
 async function seedLessons() {
   return prisma.$transaction(
     lessonsData.map(data =>
       prisma.lesson.create({ data, include: { challenges: true } })
+    )
+  )
+}
+
+async function seedModules(admin: User) {
+  return prisma.$transaction(
+    modulesData.map(data =>
+      prisma.module.create({
+        data: {
+          content: data.content,
+          // JS0
+          lessonId: 1,
+          authorId: admin.id,
+          name: data.name,
+          order: data.order
+        }
+      })
+    )
+  )
+}
+
+async function seedExercises(admin: User) {
+  return prisma.$transaction(
+    getExercisesData.exercises.map(data =>
+      prisma.exercise.create({
+        data: {
+          moduleId: modulesData[0].id,
+          authorId: admin.id,
+          description: data.description,
+          answer: data.answer,
+          explanation: data.answer
+        }
+      })
+    )
+  )
+}
+
+async function seedExercisesWithoutExplanation(admin: User) {
+  return prisma.$transaction(
+    getExercisesData.exercises.map(data =>
+      prisma.exercise.create({
+        data: {
+          moduleId: modulesData[1].id,
+          authorId: admin.id,
+          description: data.description,
+          answer: data.answer
+        }
+      })
     )
   )
 }


### PR DESCRIPTION
Closes #2296 

### Description

This PR aims at seeding the database with dummy data for modules and exercises to make local development easier. Previously, whenever we work on an app aspect that's related to the modules or exercises, we'd have to manually create them through GraphQL playground.

### Testing

1. Go to `/admin/lessons/js0/modules` or `/admin/lessons/js0/exercises`
2. It should display some modules/exercises
3. Go to `/exercises/js0`
4. It should display some exercises