### PR TITLE
ci(github-actions): Update pass auth to SSH key auth

### DIFF
--- a/.github/workflows/init-preview-db.yml
+++ b/.github/workflows/init-preview-db.yml
@@ -4,7 +4,7 @@ on:
     types:
       - closed
     paths:
-      - '**.prisma'
+      - 'prisma/**'
 jobs:
   ssh-and-update-preview-db:
     runs-on: ubuntu-latest
@@ -13,7 +13,7 @@ jobs:
         with:
           host: ${{ secrets.PREVIEW_DB_HOST }}
           username: ${{ secrets.PREVIEW_DB_USERNAME }}
-          password: ${{ secrets.PREVIEW_DB_PW }}
+          key: ${{ secrets.PREVIEW_DB_KEY }}
           script: |
             cd c0d3-app
             git pull origin master

--- a/.github/workflows/init-preview-db.yml
+++ b/.github/workflows/init-preview-db.yml
@@ -5,6 +5,7 @@ on:
       - closed
     paths:
       - 'prisma/**'
+
 jobs:
   ssh-and-update-preview-db:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-app/issues/2566

### Description

This PR aims at updating the github-action responsible for seeding the database whenever new changes to `prisma/**` is introduced to use a private key to connect to the server.