### PR TITLE
Revert "build(deps): Bump next-auth from 4.18.0 to 4.18.3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "markdown-to-jsx": "^7.1.8",
     "nanoid": "^3.3.4",
     "next": "12",
-    "next-auth": "^4.18.3",
+    "next-auth": "^4.18.0",
     "next-connect": "^0.13.0",
     "next-mdx-remote": "^3.0.8",
     "nodemailer": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13588,10 +13588,10 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-auth@^4.18.3:
-  version "4.18.3"
-  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.18.3.tgz#d5e9fa8649567877632cd3bdb6adfa63c75ebc0b"
-  integrity sha512-oZrTPnaF7YCMm4T6+FY47+1wHacE7V6YX+MCuvRTZMca7zHAc2WPMdTED6eV3hkqp2znEdilhD4aXQ5BuCpYIw==
+next-auth@^4.18.0:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.18.0.tgz#f6fb4d2a1bfd6e90650755c13324e24d1f44b0d4"
+  integrity sha512-lqJtusYqUwDiwzO4+B+lx/vKCuf/akcdhxT5R47JmS5gvI9O6Y4CZYc8coysY7XaMGHCxfttvTSEw76RA8gNTg==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@panva/hkdf" "^1.0.1"


### PR DESCRIPTION
Reverts garageScript/c0d3-app#2591

v4.18.* causes issues because in [this commit](https://github.com/nextauthjs/next-auth/commit/f3291025e6dd15abfbd837ea2f7e6099e06fbab1) and [this one](https://github.com/nextauthjs/next-auth/commit/221bc8e99cd2058fd7cb3db65515363885bba10e), the way to construct the URL has changed.