### PR TITLE
fix: Remove exercise deletion query info

### DIFF
--- a/__tests__/pages/curriculum/[lessonSlug]/mentor/index.test.js
+++ b/__tests__/pages/curriculum/[lessonSlug]/mentor/index.test.js
@@ -9,6 +9,7 @@ import GET_EXERCISES from '../../../../../graphql/queries/getExercises'
 import DELETE_EXERCISE from '../../../../../graphql/queries/deleteExercise'
 import GET_SESSION from '../../../../../graphql/queries/getSession'
 import dummySessionData from '../../../../../__dummy__/sessionData'
+import userEvent from '@testing-library/user-event'
 
 import '@testing-library/jest-dom'
 
@@ -81,7 +82,15 @@ describe('Mentor page', () => {
   })
 
   test('Should delete exercise', async () => {
+    expect.assertions(1)
+
     const mocks = [
+      {
+        request: { query: GET_EXERCISES },
+        result: {
+          data: getExercisesData
+        }
+      },
       {
         request: { query: GET_EXERCISES },
         result: {
@@ -133,9 +142,77 @@ describe('Mentor page', () => {
     )
 
     // dropdown toggle
-    fireEvent.click(screen.getAllByTestId('dropdown-lesson')[0])
+    await userEvent.click(screen.getAllByTestId('dropdown-lesson')[0])
     // first item in the dropdown options
-    fireEvent.click(screen.getByText('Delete'))
+    await userEvent.click(screen.getByText('Delete'))
+
+    expect(mocks.at(-1).newData).toBeCalled()
+  })
+
+  test('Should delete exercise item and its QUERY INFO', async () => {
+    expect.assertions(1)
+
+    const mocks = [
+      {
+        request: { query: GET_EXERCISES },
+        result: {
+          data: getExercisesData
+        }
+      },
+      {
+        request: { query: GET_EXERCISES },
+        result: {
+          data: getExercisesData
+        }
+      },
+      {
+        request: { query: GET_SESSION },
+        result: {
+          data: {
+            session: {
+              ...dummySessionData
+            }
+          }
+        }
+      },
+      {
+        request: {
+          query: DELETE_EXERCISE,
+          variables: {
+            id: 1
+          }
+        },
+        result: {
+          data: {
+            deleteExercise: {
+              id: 1
+            }
+          }
+        },
+        newData: jest.fn(() => ({
+          data: {
+            deleteExercise: {
+              id: 2
+            }
+          }
+        }))
+      }
+    ]
+
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <AddExercises />
+      </MockedProvider>
+    )
+
+    await waitFor(() =>
+      screen.getByRole('heading', { name: /Foundations of JavaScript/i })
+    )
+
+    // dropdown toggle
+    await userEvent.click(screen.getAllByTestId('dropdown-lesson')[0])
+    // first item in the dropdown options
+    await userEvent.click(screen.getByText('Delete'))
 
     expect(mocks.at(-1).newData).toBeCalled()
   })

--- a/components/ExercisePreviewCard/ExercisePreviewCard.tsx
+++ b/components/ExercisePreviewCard/ExercisePreviewCard.tsx
@@ -42,16 +42,20 @@ const ExercisePreviewCard = ({
     >
       {state && <div className={topBorderStyle} />}
       <div className={styles.header__container}>
-        <QueryInfo
-          data={data}
-          loading={loading}
-          error={error?.message || ''}
-          texts={{
-            loading: 'Deleting the exercise...',
-            data: 'Deleted the exercise successfully!',
-            error: 'Oops, failed to delete the exercise. Please try again!'
-          }}
-        />
+        {data && data.deleteExercise.id !== id ? (
+          <></>
+        ) : (
+          <QueryInfo
+            data={data}
+            loading={loading}
+            error={error?.message || ''}
+            texts={{
+              loading: 'Deleting the exercise...',
+              data: 'Deleted the exercise successfully!',
+              error: 'Oops, failed to delete the exercise. Please try again!'
+            }}
+          />
+        )}
         <div className={styles.header__container__module__state}>
           <div className="d-flex align-items-center mb-3">
             <h2 className="fw-bold fs-6 my-2 me-4">


### PR DESCRIPTION
Closes #2599 

### Description

Previously, when an exercise is deleted and removed from the list, its query info goes to the element next to it instead of being deleted.


https://user-images.githubusercontent.com/35906419/206873192-765b1364-b03b-4a64-9bda-fb4ebb1f4fb5.mov



It now gets removed completely because it now renders it as long as the current exercise ID is equal to the returned exercise ID from the request of deleting the exercise.

If they're not equal, it won't render the query info.


https://user-images.githubusercontent.com/35906419/206873225-c7906ca5-40f3-496a-801d-8a57b9e6c427.mov

