### PR TITLE
fix: Incorrect message when there are no flagged exercises

### DIFF
--- a/__tests__/pages/admin/lessons/[lessonSlug]/[pageName]/lessons.test.js
+++ b/__tests__/pages/admin/lessons/[lessonSlug]/[pageName]/lessons.test.js
@@ -806,9 +806,9 @@ describe('exercises', () => {
       </MockedProvider>
     )
 
-    await act(() => new Promise(res => setTimeout(res, 0)))
-
-    expect(screen.getByText('addExercise page')).toBeInTheDocument()
+    expect(
+      await screen.findByText('No exercises are flagged!')
+    ).toBeInTheDocument()
   })
 
   it('Should refresh the exercises upon removing one', async () => {

--- a/pages/admin/lessons/[lessonSlug]/[pageName]/index.tsx
+++ b/pages/admin/lessons/[lessonSlug]/[pageName]/index.tsx
@@ -38,10 +38,7 @@ import {
 import QueryInfo from '../../../../../components/QueryInfo'
 import LoadingSpinner from '../../../../../components/LoadingSpinner'
 import AdminLessonExerciseCard from '../../../../../components/admin/lessons/AdminLessonExerciseCard'
-import Card from '../../../../../components/Card'
-import { Text } from '../../../../../components/theme/Text'
-import Link from 'next/link'
-import { CURRICULUM_PATH } from '../../../../../constants'
+import Alert from '../../../../../components/Alert'
 
 const MAIN_PATH = '/admin/lessons'
 
@@ -212,21 +209,9 @@ const ExercisesPage = ({ lessonSlug }: ExercisesProps) => {
 
   if (!mapExercisesToExerciseCard || !mapExercisesToExerciseCard.length) {
     return (
-      <Card title="No exercises found">
-        <Text component="p">
-          Exercises can be added from{' '}
-          <Link href={`${CURRICULUM_PATH}/${lessonSlug}/mentor/addExercise`}>
-            <a
-              data-testid="addExercise-link"
-              style={{ textDecoration: 'none' }}
-            >
-              <Text color="primary" component="span">
-                addExercise page
-              </Text>
-            </a>
-          </Link>
-        </Text>
-      </Card>
+      <Alert
+        alert={{ text: 'No exercises are flagged!', type: 'info', id: 1 }}
+      />
     )
   }
 


### PR DESCRIPTION
Closes #2594 

### Description

Previously, the message that shows up when there are no exercises is incorrect. It used to say: `Exercises can be added from addExercisePage`. It doesn't make sense to add flagged exercises. Instead, it should say there are no flagged exercises.

<details>
<summary>
Old
</summary>
<img width="993" alt="image" src="https://user-images.githubusercontent.com/35906419/207416761-05758423-c8d6-4934-b91a-0105924c599b.png">
</details>
<details>
<summary>
New
</summary>
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/35906419/207416857-19afda30-c282-4d4e-90fb-ef72a2daf783.png">
</details>

