### PR TITLE
Change init-preview-db workflow trigger to `pull_request_target`

### DIFF
--- a/.github/workflows/init-preview-db.yml
+++ b/.github/workflows/init-preview-db.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   ssh-and-update-preview-db:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: appleboy/ssh-action@master

--- a/.github/workflows/init-preview-db.yml
+++ b/.github/workflows/init-preview-db.yml
@@ -1,6 +1,6 @@
 name: init-preview-db
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     paths:


### PR DESCRIPTION
Closes #2618 

### Description

An event triggers a GitHub action workflow, it could be when a PR is created or closed, a commit has been pushed, or a new release.

In our case, we've the `pull_request:closed` trigger that start a workflow when a pull request is closed. [It doesn't allow write-access to the repo or read-access to the secrets.](https://github.com/garageScript/c0d3-app/actions/runs/3724767063/jobs/6334016390)

Since it prevents reading the secrets, the workflow for updating the preview DB fails because it needs to read the `PREVIEW_DB_KEY` secret key.

There's another trigger called [`pull_request_target:closed` ](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)that allow a PR executed workflow to read the secrets.

It also makes the workflow run only when a PR is merged.

### Solution

Update the trigger to be `pull_request_target`.