### PR TITLE
feat(WIP): Create part of User Settings page

### DIFF
--- a/__tests__/pages/settings/account/index.test.js
+++ b/__tests__/pages/settings/account/index.test.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AccountSettings from '../../../../pages/settings/account/index'
+import { MockedProvider } from '@apollo/client/testing'
+import GetApp from '../../../../graphql/queries/getApp.ts'
+import dummyLessonData from '../../../../__dummy__/lessonData'
+import dummySessionData from '../../../../__dummy__/sessionData'
+import dummyAlertData from '../../../../__dummy__/alertData'
+
+// Imported to be able to use expect(...).toBeInTheDocument()
+import '@testing-library/jest-dom'
+
+const mocks = [
+  {
+    request: { query: GetApp },
+    result: {
+      data: {
+        session: dummySessionData,
+        lessons: dummyLessonData,
+        alerts: dummyAlertData
+      }
+    }
+  }
+]
+
+describe('Account settings page', () => {
+  it('Should render the page', async () => {
+    expect.assertions(1)
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <AccountSettings />
+      </MockedProvider>
+    )
+
+    expect(await screen.findByText('Settings')).toBeInTheDocument()
+  })
+
+  it('Should update basics section inputs and submit', async () => {
+    expect.assertions(3)
+
+    const inputValues = {
+      username: 'taco',
+      firstName: 'ta',
+      lastName: 'co'
+    }
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <AccountSettings />
+      </MockedProvider>
+    )
+
+    // Waiting for the query to resolve
+    await screen.findByText('Settings')
+
+    const getInputs = () => [
+      screen.getByTestId('input0'),
+      screen.getByTestId('input1'),
+      screen.getByTestId('input2')
+    ]
+
+    const [usernameInput, firstNameInput, lastNameInput] = getInputs()
+
+    await userEvent.type(usernameInput, inputValues.username)
+    await userEvent.type(firstNameInput, inputValues.firstName)
+    await userEvent.type(lastNameInput, inputValues.lastName)
+
+    const inputsWithNewValues = getInputs()
+
+    // Will be covered in a different test
+    await userEvent.click(screen.getByText('Save Changes'))
+
+    expect(inputsWithNewValues[0].value).toEqual(inputValues.username)
+    expect(inputsWithNewValues[1].value).toEqual(inputValues.firstName)
+    expect(inputsWithNewValues[2].value).toEqual(inputValues.lastName)
+  })
+})

--- a/pages/settings/account/index.tsx
+++ b/pages/settings/account/index.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react'
+import Layout from '../../../components/Layout'
+import { FormCard, Option } from '../../../components/FormCard'
+import { formChange } from '../../../helpers/formChange'
+import { useGetAppQuery } from '../../../graphql/index'
+import LoadingSpinner from '../../../components/LoadingSpinner'
+import styles from '../../../scss/accountSettings.module.scss'
+
+const values: (
+  username?: string,
+  firstName?: string,
+  lastName?: string
+) => Option[] = (username, firstName, lastName) => [
+  { title: 'username', value: username || '' },
+  { title: 'first name', value: firstName },
+  { title: 'last name', value: lastName }
+]
+
+const AccountSettings = () => {
+  const { data, loading } = useGetAppQuery()
+  const { username, name } = data?.session.user || {}
+  const [firstName, lastName] = name?.split(' ') || []
+
+  const [options, setOptions] = useState(values(username, firstName, lastName))
+
+  useEffect(() => {
+    setOptions(values(username, firstName, lastName))
+  }, [data])
+
+  if (loading || !data) {
+    return <LoadingSpinner />
+  }
+
+  const onChange = (value: string, index: number) => {
+    formChange(value, index, options, setOptions)
+  }
+
+  return (
+    <Layout>
+      <div className={styles.container}>
+        <div className={styles.container__child}>
+          <h1>Settings</h1>
+          <hr />
+          <FormCard
+            title="Basics"
+            onChange={onChange}
+            values={options}
+            onSubmit={{
+              title: 'Save Changes',
+              onClick: () => {}
+            }}
+            noBg
+            newBtn
+          />
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+export default AccountSettings

--- a/scss/accountSettings.module.scss
+++ b/scss/accountSettings.module.scss
@@ -1,0 +1,9 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.container__child {
+  min-width: 600px;
+}


### PR DESCRIPTION
Related to #1629 

### Changes

- Create the files (style, test, and index) for the User Settings page
- Add the first section "Basics", but it's not functional. It'll be functional in a subsequent PR.

## Testing

Login and go to `/settings/account` and make sure it fills the inputs with the account info (username, first name, and last name).