### PR TITLE
Prevent Bootstrap from overriding our styles

### DIFF
--- a/scss/index.scss
+++ b/scss/index.scss
@@ -1,5 +1,4 @@
 @use '_variables.module';
-@use '_text.module';
 
 // Override default variables before the import
 $body-bg: rgba(84, 56, 220, 0.03);
@@ -83,3 +82,4 @@ p {
 @import './prism.scss';
 @import './modalImage.module.scss';
 @import './globalMDX.scss';
+@import '_text.module';


### PR DESCRIPTION
## Motivation

We want to prevent Bootstrap `_reboot` file (that's a collection of element-specific CSS changes in a single file that aims at making a website use Bootstrap standards for elements) from overriding our styles in [`_texts.module.scss`](https://github.com/garageScript/c0d3-app/blob/master/scss/_text.module.scss) so our design remain consistent and unchanged.

## Solution

Import our styles file [`_texts.module.scss`](https://github.com/garageScript/c0d3-app/blob/master/scss/_text.module.scss) after importing Bootstrap, so it can override Bootstrap styles.

## Steps taken

1. Inspected the [h1 element](https://github.com/flacial/c0d3-app/blob/bba71c2a6c45814027b8bdf408129c040fd4e44d/pages/settings/account/index.tsx#L42) element in the browser developer tools to identify the issue with the overridden styles.
2. Moved the import of [`_texts.module.scss`](https://github.com/garageScript/c0d3-app/blob/master/scss/_text.module.scss) to the end of the file
```scss
@import '~bootstrap/scss/bootstrap.scss';
...
@import '_texts.module.scss'
```

## Testing instructions

0. Login by going to [login page](https://c0d3-app-git-fork-flacial-2632-bootstrap-reboo-64411e-c0d3-prod.vercel.app/login)
1. Open [`settings/account` page](https://c0d3-app-git-fork-flacial-2632-bootstrap-reboo-64411e-c0d3-prod.vercel.app//settings/account) in the browser
2. Verify the headings Setting (h1) and Basics (h3) have the right properties from [`_texts.module.scss`](https://github.com/garageScript/c0d3-app/blob/master/scss/_text.module.scss)

## Screenshots

**Before:**
<img width="264" alt="image" src="https://user-images.githubusercontent.com/35906419/209351369-c2b03d21-f6b7-4e65-9e45-8347cec5a4f1.png">

**After:**
<img width="282" alt="image" src="https://user-images.githubusercontent.com/35906419/209351117-c66ac158-ddec-4a4d-87f8-0c0284a39221.png">

## Related issues

- Fixes #2632 
