### PR TITLE
Add resolver for updating user names

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -172,6 +172,7 @@ export type Mutation = {
   updateExercise: Exercise
   updateLesson: Array<Lesson>
   updateModule: Module
+  updateUserNames?: Maybe<User>
 }
 
 export type MutationAcceptSubmissionArgs = {
@@ -349,6 +350,11 @@ export type MutationUpdateModuleArgs = {
   lessonId: Scalars['Int']
   name: Scalars['String']
   order: Scalars['Int']
+}
+
+export type MutationUpdateUserNamesArgs = {
+  name: Scalars['String']
+  username: Scalars['String']
 }
 
 export type Query = {
@@ -1420,6 +1426,21 @@ export type ChangePwMutation = {
   changePw?: { __typename?: 'AuthResponse'; success?: boolean | null } | null
 }
 
+export type UpdateUserNamesMutationVariables = Exact<{
+  username: Scalars['String']
+  name: Scalars['String']
+}>
+
+export type UpdateUserNamesMutation = {
+  __typename?: 'Mutation'
+  updateUserNames?: {
+    __typename?: 'User'
+    id: number
+    username: string
+    name: string
+  } | null
+}
+
 export type UserInfoQueryVariables = Exact<{
   username: Scalars['String']
 }>
@@ -2027,6 +2048,12 @@ export type MutationResolvers<
       MutationUpdateModuleArgs,
       'content' | 'id' | 'lessonId' | 'name' | 'order'
     >
+  >
+  updateUserNames?: Resolver<
+    Maybe<ResolversTypes['User']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateUserNamesArgs, 'name' | 'username'>
   >
 }>
 
@@ -6214,6 +6241,90 @@ export type ChangePwMutationOptions = Apollo.BaseMutationOptions<
   ChangePwMutation,
   ChangePwMutationVariables
 >
+export const UpdateUserNamesDocument = gql`
+  mutation updateUserNames($username: String!, $name: String!) {
+    updateUserNames(username: $username, name: $name) {
+      id
+      username
+      name
+    }
+  }
+`
+export type UpdateUserNamesMutationFn = Apollo.MutationFunction<
+  UpdateUserNamesMutation,
+  UpdateUserNamesMutationVariables
+>
+export type UpdateUserNamesProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: Apollo.MutationFunction<
+    UpdateUserNamesMutation,
+    UpdateUserNamesMutationVariables
+  >
+} & TChildProps
+export function withUpdateUserNames<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UpdateUserNamesMutation,
+    UpdateUserNamesMutationVariables,
+    UpdateUserNamesProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    UpdateUserNamesMutation,
+    UpdateUserNamesMutationVariables,
+    UpdateUserNamesProps<TChildProps, TDataName>
+  >(UpdateUserNamesDocument, {
+    alias: 'updateUserNames',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useUpdateUserNamesMutation__
+ *
+ * To run a mutation, you first call `useUpdateUserNamesMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateUserNamesMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateUserNamesMutation, { data, loading, error }] = useUpdateUserNamesMutation({
+ *   variables: {
+ *      username: // value for 'username'
+ *      name: // value for 'name'
+ *   },
+ * });
+ */
+export function useUpdateUserNamesMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateUserNamesMutation,
+    UpdateUserNamesMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
+    UpdateUserNamesMutation,
+    UpdateUserNamesMutationVariables
+  >(UpdateUserNamesDocument, options)
+}
+export type UpdateUserNamesMutationHookResult = ReturnType<
+  typeof useUpdateUserNamesMutation
+>
+export type UpdateUserNamesMutationResult =
+  Apollo.MutationResult<UpdateUserNamesMutation>
+export type UpdateUserNamesMutationOptions = Apollo.BaseMutationOptions<
+  UpdateUserNamesMutation,
+  UpdateUserNamesMutationVariables
+>
 export const UserInfoDocument = gql`
   query userInfo($username: String!) {
     lessons {
@@ -6570,6 +6681,7 @@ export type MutationKeySpecifier = (
   | 'updateExercise'
   | 'updateLesson'
   | 'updateModule'
+  | 'updateUserNames'
   | MutationKeySpecifier
 )[]
 export type MutationFieldPolicy = {
@@ -6603,6 +6715,7 @@ export type MutationFieldPolicy = {
   updateExercise?: FieldPolicy<any> | FieldReadFunction<any>
   updateLesson?: FieldPolicy<any> | FieldReadFunction<any>
   updateModule?: FieldPolicy<any> | FieldReadFunction<any>
+  updateUserNames?: FieldPolicy<any> | FieldReadFunction<any>
 }
 export type QueryKeySpecifier = (
   | 'alerts'

--- a/graphql/queries/updateUserNames.ts
+++ b/graphql/queries/updateUserNames.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client'
+
+const UPDATE_USER_NAMES = gql`
+  mutation updateUserNames($username: String!, $name: String!) {
+    updateUserNames(username: $username, name: $name) {
+      id
+      username
+      name
+    }
+  }
+`
+
+export default UPDATE_USER_NAMES

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -49,6 +49,7 @@ import {
   addExerciseComment,
   getChildComments
 } from './resolvers/exerciseCommentCrud'
+import { updateUserNames } from './resolvers/userDataCrud'
 
 export default {
   Query: {
@@ -99,6 +100,7 @@ export default {
     flagExercise,
     removeExerciseFlag,
     unlinkDiscord,
-    addExerciseComment
+    addExerciseComment,
+    updateUserNames
   }
 }

--- a/graphql/resolvers/userDataCrud.test.js
+++ b/graphql/resolvers/userDataCrud.test.js
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+
+import prismaMock from '../../__tests__/utils/prismaMock'
+import { updateUserNames } from './userDataCrud'
+
+const mockUsername = 'birdCatcher'
+const mockName = 'bird spike'
+
+describe('User Data CRUD resolvers', () => {
+  it('Should update the user username and name', async () => {
+    expect.assertions(1)
+
+    const userMock = {
+      username: mockUsername,
+      name: mockName
+    }
+
+    prismaMock.user.update.mockResolvedValueOnce(userMock)
+
+    expect(
+      updateUserNames(
+        null,
+        { username: mockUsername, mockName },
+        { req: { user: { id: 1 } } }
+      )
+    ).resolves.toStrictEqual(userMock)
+  })
+})

--- a/graphql/resolvers/userDataCrud.ts
+++ b/graphql/resolvers/userDataCrud.ts
@@ -1,0 +1,23 @@
+import { User } from '@prisma/client'
+import { MutationUpdateUserNamesArgs } from '..'
+import { withUserContainer } from '../../containers/withUserContainer'
+import prisma from '../../prisma'
+
+export const updateUserNames = withUserContainer<
+  Promise<User>,
+  MutationUpdateUserNamesArgs
+>(async (_, args, { req }) => {
+  const { username, name } = args
+
+  const user = await prisma.user.update({
+    where: {
+      id: req.user!.id
+    },
+    data: {
+      username,
+      name
+    }
+  })
+
+  return user
+})

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -137,6 +137,7 @@ export default gql`
       id: Int!
     ): [Lesson]
     unlinkDiscord: User
+    updateUserNames(name: String!, username: String!): User
   }
 
   type AuthResponse {


### PR DESCRIPTION
## Summary

This PR adds a new GraphQL mutation resolver called `userDataNames` that allows a user to update their username and name in the database using Prisma.

## Changes

- Declared `userDataNames` mutation type in the GraphQL type definitions file.
- Added the `userDataNames` mutation resolver to the appropriate file.
- Tested the resolver to ensure it is working as expected.
- Created the hooks for the `userDataNames` mutation to be used in the client.

## Test Results

I have tested the `userDataNames` resolver, and it is functioning correctly.

**Before changing the names:**
  
  ```gql
  query {
    userInfo(username: "admin") {
      user {
        username
        name
      }
    }
  }
  ```
  
  **Result:**
  
  ```
  {
    "data": {
      "userInfo": {
        "user": {
          "username": "admin",
          "name": "Admin Administrator"
        }
      }
    }
  }
  ```
  
  **After changing the names:**
  
  ```gql
  mutation {
    updateUserNames(name: "bird spike", username: "birdCatcher") {
      username
      name
    }
  }
  ```
  
  **Result:**
  
  ```
  {
    "data": {
      "updateUserNames": {
        "username": "birdCatcher",
        "name": "bird spike"
      }
    }
  }
  ```
  
  Executing `userInfo` queyr again with `birdCatcher` as the username outputs:
  
  ```gql
  {
    "data": {
      "userInfo": {
        "user": {
          "username": "birdCatcher",
          "name": "bird spike"
        }
      }
    }
  }
  ```

## Testing instructions

0. Login with `leetcoder` account by executing the mutation `login` or by going to the page `/login`
1. Head to the [Apollo playground](https://c0d3-app-git-fork-flacial-2641-create-the-reso-1e4762-c0d3-prod.vercel.app/api/graphql).
2. Run the above test mutations in order.
3. Notice how the user's username and name changed.

## Related issues

- #1629 