### PR TITLE
fix: Prevent users from setting an already used username

### DIFF
--- a/graphql/resolvers/userDataCrud.test.js
+++ b/graphql/resolvers/userDataCrud.test.js
@@ -18,6 +18,7 @@ describe('User Data CRUD resolvers', () => {
     }
 
     prismaMock.user.update.mockResolvedValueOnce(userMock)
+    prismaMock.user.findFirst.mockResolvedValueOnce(null)
 
     expect(
       updateUserNames(
@@ -26,5 +27,25 @@ describe('User Data CRUD resolvers', () => {
         { req: { user: { id: 1 } } }
       )
     ).resolves.toStrictEqual(userMock)
+  })
+
+  it('Should not update the user username and name if username already used', async () => {
+    expect.assertions(1)
+
+    const userMock = {
+      username: mockUsername,
+      name: mockName
+    }
+
+    prismaMock.user.update.mockResolvedValueOnce(userMock)
+    prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+
+    expect(
+      updateUserNames(
+        null,
+        { username: mockUsername, mockName },
+        { req: { user: { id: 1 } } }
+      )
+    ).rejects.toEqual(Error('Username is already used'))
   })
 })

--- a/graphql/resolvers/userDataCrud.ts
+++ b/graphql/resolvers/userDataCrud.ts
@@ -9,6 +9,16 @@ export const updateUserNames = withUserContainer<
 >(async (_, args, { req }) => {
   const { username, name } = args
 
+  const usernameAlreadyUsed = await prisma.user.findFirst({
+    where: {
+      username
+    }
+  })
+
+  if (usernameAlreadyUsed) {
+    throw new Error('Username is already used')
+  }
+
   const user = await prisma.user.update({
     where: {
       id: req.user!.id

--- a/pages/settings/account/index.tsx
+++ b/pages/settings/account/index.tsx
@@ -40,7 +40,8 @@ const BasicSettings = ({
         error={error?.message || ''}
         texts={{
           loading: 'Updating your names...',
-          data: `Updated your names successfully!`
+          data: `Updated your names successfully!`,
+          error: error?.message
         }}
         dismiss={{
           onDismissData: () => {},


### PR DESCRIPTION
## Description
This PR aims to prevent users from setting an already used username when trying to change their username to avoid introducing bugs in the system.

Currently, there is no way to prevent users from setting their username to one that is already in use by another user. This can lead to bugs in the system because the system expects unique usernames. For example, when a user changes their username to an already used one and then goes to their profile page, the `userInfo` data returned may be for a different user.

This PR adds a check to ensure that a user cannot set their username to an already used one.

## Changes Made
- Added a check to ensure that a user cannot set their username to an already used one.

## Testing instructions
0. Login in
1. Navigate to the `settings/account` page.
2. Attempt to change your username to one that is already in use by another user.
3. Observe that the username change is not allowed, and an error message is displayed.

## Related issues
- Closes #2650