### PR TITLE
feat: Create the resolver for updating the user password

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -173,6 +173,7 @@ export type Mutation = {
   updateLesson: Array<Lesson>
   updateModule: Module
   updateUserNames?: Maybe<User>
+  updateUserPassword?: Maybe<SuccessResponse>
 }
 
 export type MutationAcceptSubmissionArgs = {
@@ -355,6 +356,12 @@ export type MutationUpdateModuleArgs = {
 export type MutationUpdateUserNamesArgs = {
   name: Scalars['String']
   username: Scalars['String']
+}
+
+export type MutationUpdateUserPasswordArgs = {
+  currentPassword: Scalars['String']
+  newPassword: Scalars['String']
+  newPasswordAgain: Scalars['String']
 }
 
 export type Query = {
@@ -1441,6 +1448,20 @@ export type UpdateUserNamesMutation = {
   } | null
 }
 
+export type UpdateUserPasswordMutationVariables = Exact<{
+  newPassword: Scalars['String']
+  newPasswordAgain: Scalars['String']
+  currentPassword: Scalars['String']
+}>
+
+export type UpdateUserPasswordMutation = {
+  __typename?: 'Mutation'
+  updateUserPassword?: {
+    __typename?: 'SuccessResponse'
+    success?: boolean | null
+  } | null
+}
+
 export type UserInfoQueryVariables = Exact<{
   username: Scalars['String']
 }>
@@ -2054,6 +2075,15 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationUpdateUserNamesArgs, 'name' | 'username'>
+  >
+  updateUserPassword?: Resolver<
+    Maybe<ResolversTypes['SuccessResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<
+      MutationUpdateUserPasswordArgs,
+      'currentPassword' | 'newPassword' | 'newPasswordAgain'
+    >
   >
 }>
 
@@ -6325,6 +6355,97 @@ export type UpdateUserNamesMutationOptions = Apollo.BaseMutationOptions<
   UpdateUserNamesMutation,
   UpdateUserNamesMutationVariables
 >
+export const UpdateUserPasswordDocument = gql`
+  mutation updateUserPassword(
+    $newPassword: String!
+    $newPasswordAgain: String!
+    $currentPassword: String!
+  ) {
+    updateUserPassword(
+      newPassword: $newPassword
+      newPasswordAgain: $newPasswordAgain
+      currentPassword: $currentPassword
+    ) {
+      success
+    }
+  }
+`
+export type UpdateUserPasswordMutationFn = Apollo.MutationFunction<
+  UpdateUserPasswordMutation,
+  UpdateUserPasswordMutationVariables
+>
+export type UpdateUserPasswordProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: Apollo.MutationFunction<
+    UpdateUserPasswordMutation,
+    UpdateUserPasswordMutationVariables
+  >
+} & TChildProps
+export function withUpdateUserPassword<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    UpdateUserPasswordMutation,
+    UpdateUserPasswordMutationVariables,
+    UpdateUserPasswordProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    UpdateUserPasswordMutation,
+    UpdateUserPasswordMutationVariables,
+    UpdateUserPasswordProps<TChildProps, TDataName>
+  >(UpdateUserPasswordDocument, {
+    alias: 'updateUserPassword',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useUpdateUserPasswordMutation__
+ *
+ * To run a mutation, you first call `useUpdateUserPasswordMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateUserPasswordMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateUserPasswordMutation, { data, loading, error }] = useUpdateUserPasswordMutation({
+ *   variables: {
+ *      newPassword: // value for 'newPassword'
+ *      newPasswordAgain: // value for 'newPasswordAgain'
+ *      currentPassword: // value for 'currentPassword'
+ *   },
+ * });
+ */
+export function useUpdateUserPasswordMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateUserPasswordMutation,
+    UpdateUserPasswordMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
+    UpdateUserPasswordMutation,
+    UpdateUserPasswordMutationVariables
+  >(UpdateUserPasswordDocument, options)
+}
+export type UpdateUserPasswordMutationHookResult = ReturnType<
+  typeof useUpdateUserPasswordMutation
+>
+export type UpdateUserPasswordMutationResult =
+  Apollo.MutationResult<UpdateUserPasswordMutation>
+export type UpdateUserPasswordMutationOptions = Apollo.BaseMutationOptions<
+  UpdateUserPasswordMutation,
+  UpdateUserPasswordMutationVariables
+>
 export const UserInfoDocument = gql`
   query userInfo($username: String!) {
     lessons {
@@ -6682,6 +6803,7 @@ export type MutationKeySpecifier = (
   | 'updateLesson'
   | 'updateModule'
   | 'updateUserNames'
+  | 'updateUserPassword'
   | MutationKeySpecifier
 )[]
 export type MutationFieldPolicy = {
@@ -6716,6 +6838,7 @@ export type MutationFieldPolicy = {
   updateLesson?: FieldPolicy<any> | FieldReadFunction<any>
   updateModule?: FieldPolicy<any> | FieldReadFunction<any>
   updateUserNames?: FieldPolicy<any> | FieldReadFunction<any>
+  updateUserPassword?: FieldPolicy<any> | FieldReadFunction<any>
 }
 export type QueryKeySpecifier = (
   | 'alerts'

--- a/graphql/queries/updateUserPassword.ts
+++ b/graphql/queries/updateUserPassword.ts
@@ -1,0 +1,19 @@
+import { gql } from '@apollo/client'
+
+const UPDATE_USER_PASSWORD = gql`
+  mutation updateUserPassword(
+    $newPassword: String!
+    $newPasswordAgain: String!
+    $currentPassword: String!
+  ) {
+    updateUserPassword(
+      newPassword: $newPassword
+      newPasswordAgain: $newPasswordAgain
+      currentPassword: $currentPassword
+    ) {
+      success
+    }
+  }
+`
+
+export default UPDATE_USER_PASSWORD

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -49,7 +49,7 @@ import {
   addExerciseComment,
   getChildComments
 } from './resolvers/exerciseCommentCrud'
-import { updateUserNames } from './resolvers/userDataCrud'
+import { updateUserNames, updateUserPassword } from './resolvers/userDataCrud'
 
 export default {
   Query: {
@@ -101,6 +101,7 @@ export default {
     removeExerciseFlag,
     unlinkDiscord,
     addExerciseComment,
-    updateUserNames
+    updateUserNames,
+    updateUserPassword
   }
 }

--- a/graphql/resolvers/userDataCrud.test.js
+++ b/graphql/resolvers/userDataCrud.test.js
@@ -2,50 +2,157 @@
  * @jest-environment node
  */
 
+jest.mock('bcrypt')
+
 import prismaMock from '../../__tests__/utils/prismaMock'
-import { updateUserNames } from './userDataCrud'
+import { updateUserNames, updateUserPassword } from './userDataCrud'
+import bcrypt from 'bcrypt'
 
 const mockUsername = 'birdCatcher'
 const mockName = 'bird spike'
+const mockPassword = 'password'
+const newPasswordMock = 'drowssap'
 
 describe('User Data CRUD resolvers', () => {
-  it('Should update the user username and name', async () => {
-    expect.assertions(1)
+  describe('Update user names resolver', () => {
+    it('Should update the user username and name', async () => {
+      expect.assertions(1)
 
-    const userMock = {
-      username: mockUsername,
-      name: mockName
-    }
+      const userMock = {
+        username: mockUsername,
+        name: mockName
+      }
 
-    prismaMock.user.update.mockResolvedValueOnce(userMock)
-    prismaMock.user.findFirst.mockResolvedValueOnce(null)
+      prismaMock.user.update.mockResolvedValueOnce(userMock)
+      prismaMock.user.findFirst.mockResolvedValueOnce(null)
 
-    expect(
-      updateUserNames(
-        null,
-        { username: mockUsername, mockName },
-        { req: { user: { id: 1 } } }
-      )
-    ).resolves.toStrictEqual(userMock)
+      expect(
+        updateUserNames(
+          null,
+          { username: mockUsername, mockName },
+          { req: { user: { id: 1 } } }
+        )
+      ).resolves.toStrictEqual(userMock)
+    })
+
+    it('Should not update the user username and name if username already used', async () => {
+      expect.assertions(1)
+
+      const userMock = {
+        username: mockUsername,
+        name: mockName
+      }
+
+      prismaMock.user.update.mockResolvedValueOnce(userMock)
+      prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+
+      expect(
+        updateUserNames(
+          null,
+          { username: mockUsername, mockName },
+          { req: { user: { id: 1 } } }
+        )
+      ).rejects.toEqual(Error('Username is already used'))
+    })
   })
+  describe('Update user password resolver', () => {
+    it('Should update the user password', async () => {
+      expect.assertions(1)
 
-  it('Should not update the user username and name if username already used', async () => {
-    expect.assertions(1)
+      const userMock = {
+        username: mockUsername,
+        name: mockName,
+        password: mockPassword
+      }
 
-    const userMock = {
-      username: mockUsername,
-      name: mockName
-    }
+      prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+      bcrypt.compare.mockResolvedValueOnce(true)
 
-    prismaMock.user.update.mockResolvedValueOnce(userMock)
-    prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+      expect(
+        updateUserPassword(
+          null,
+          {
+            newPassword: newPasswordMock,
+            currentPassword: mockPassword,
+            newPasswordAgain: newPasswordMock
+          },
+          { req: { user: { id: 1 } } }
+        )
+      ).resolves.toEqual({ success: true })
+    })
+    it('Should not update the user password if the new password and the re-entered one do not match', async () => {
+      expect.assertions(1)
 
-    expect(
-      updateUserNames(
-        null,
-        { username: mockUsername, mockName },
-        { req: { user: { id: 1 } } }
-      )
-    ).rejects.toEqual(Error('Username is already used'))
+      const userMock = {
+        username: mockUsername,
+        name: mockName,
+        password: mockPassword
+      }
+
+      prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+
+      expect(
+        updateUserPassword(
+          null,
+          {
+            newPassword: newPasswordMock,
+            currentPassword: mockPassword,
+            newPasswordAgain: newPasswordMock.slice(
+              0,
+              newPasswordMock.length - 2
+            )
+          },
+          { req: { user: { id: 1 } } }
+        )
+      ).rejects.toEqual(Error("Passwords don't match"))
+    })
+    it('Should not update the user password if the current password is invalid', async () => {
+      expect.assertions(1)
+
+      const userMock = {
+        username: mockUsername,
+        name: mockName,
+        password: mockPassword
+      }
+
+      prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+      bcrypt.compare.mockResolvedValueOnce(false)
+
+      expect(
+        updateUserPassword(
+          null,
+          {
+            newPassword: newPasswordMock,
+            currentPassword: 'someWrongPassword',
+            newPasswordAgain: newPasswordMock
+          },
+          { req: { user: { id: 1 } } }
+        )
+      ).rejects.toEqual(Error('Current password is invalid'))
+    })
+    it('Should not update the user password if the user password is not found', async () => {
+      expect.assertions(1)
+
+      const userMock = {
+        username: mockUsername,
+        name: mockName,
+        password: null
+      }
+
+      prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+      bcrypt.compare.mockResolvedValueOnce(false)
+
+      expect(
+        updateUserPassword(
+          null,
+          {
+            newPassword: newPasswordMock,
+            currentPassword: 'someWrongPassword',
+            newPasswordAgain: newPasswordMock
+          },
+          { req: { user: { id: 1 } } }
+        )
+      ).rejects.toEqual(Error('Current password is invalid'))
+    })
   })
 })

--- a/graphql/resolvers/userDataCrud.test.js
+++ b/graphql/resolvers/userDataCrud.test.js
@@ -65,7 +65,7 @@ describe('User Data CRUD resolvers', () => {
         password: mockPassword
       }
 
-      prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+      prismaMock.user.findUnique.mockResolvedValueOnce(userMock)
       bcrypt.compare.mockResolvedValueOnce(true)
 
       expect(
@@ -89,7 +89,7 @@ describe('User Data CRUD resolvers', () => {
         password: mockPassword
       }
 
-      prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+      prismaMock.user.findUnique.mockResolvedValueOnce(userMock)
 
       expect(
         updateUserPassword(
@@ -130,14 +130,10 @@ describe('User Data CRUD resolvers', () => {
         )
       ).rejects.toEqual(Error('Current password is invalid'))
     })
-    it('Should not update the user password if the user password is not found', async () => {
+    it('Should not update the user password if the user is not found', async () => {
       expect.assertions(1)
 
-      const userMock = {
-        username: mockUsername,
-        name: mockName,
-        password: null
-      }
+      const userMock = null
 
       prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
       bcrypt.compare.mockResolvedValueOnce(false)

--- a/graphql/resolvers/userDataCrud.ts
+++ b/graphql/resolvers/userDataCrud.ts
@@ -48,10 +48,10 @@ export const updateUserPassword = withUserContainer<
     throw new Error("Passwords don't match")
   }
 
-  const userFromDB = await prisma.user.findFirst({ where: { id: user.id } })
+  const userFromDB = await prisma.user.findUnique({ where: { id: user.id } })
 
-  const validLogin = userFromDB!.password
-    ? await bcrypt.compare(currentPassword, userFromDB?.password!)
+  const validLogin = userFromDB
+    ? await bcrypt.compare(currentPassword, userFromDB.password as string)
     : false
 
   if (!validLogin) {

--- a/graphql/resolvers/userDataCrud.ts
+++ b/graphql/resolvers/userDataCrud.ts
@@ -1,7 +1,12 @@
 import { User } from '@prisma/client'
-import { MutationUpdateUserNamesArgs } from '..'
+import {
+  MutationUpdateUserNamesArgs,
+  MutationUpdateUserPasswordArgs,
+  SuccessResponse
+} from '..'
 import { withUserContainer } from '../../containers/withUserContainer'
 import prisma from '../../prisma'
+import bcrypt from 'bcrypt'
 
 export const updateUserNames = withUserContainer<
   Promise<User>,
@@ -30,4 +35,39 @@ export const updateUserNames = withUserContainer<
   })
 
   return user
+})
+
+export const updateUserPassword = withUserContainer<
+  Promise<SuccessResponse>,
+  MutationUpdateUserPasswordArgs
+>(async (_, args, { req }) => {
+  const user = req.user!
+  const { currentPassword, newPassword, newPasswordAgain } = args
+
+  if (newPassword !== newPasswordAgain) {
+    throw new Error("Passwords don't match")
+  }
+
+  const userFromDB = await prisma.user.findFirst({ where: { id: user.id } })
+
+  const validLogin = userFromDB!.password
+    ? await bcrypt.compare(currentPassword, userFromDB?.password!)
+    : false
+
+  if (!validLogin) {
+    throw new Error('Current password is invalid')
+  }
+
+  const hash = await bcrypt.hash(newPassword, 10)
+
+  await prisma.user.update({
+    where: {
+      id: user.id
+    },
+    data: {
+      password: hash
+    }
+  })
+
+  return { success: true }
 })

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -138,6 +138,11 @@ export default gql`
     ): [Lesson]
     unlinkDiscord: User
     updateUserNames(name: String!, username: String!): User
+    updateUserPassword(
+      newPassword: String!
+      newPasswordAgain: String!
+      currentPassword: String!
+    ): SuccessResponse
   }
 
   type AuthResponse {


### PR DESCRIPTION
## Motivation
As part of the work on the [settings page](https://chat.openai.com/chat#1629), we need to add the ability for users to change their password. Currently, we have a backend function for resetting or setting a new password when a user signs up, but we don't have a way to allow users to update their password once they are already signed up. Adding this functionality will allow us to complete the section on the settings page for updating the user password.

## Changes
- Created the GraphQL resolver `updateUserPassword` to handle updating a user's password.
- Created the corresponding query file for `updateUserPassword` so that it can be called from the client.
- Added tests to ensure that the resolver is working as intended.
- Created the type definition for the `updateUserPassword` resolver.

## Resolver logic
The `updateUserPassword` resolver takes three arguments: the current password, the new password, and a re-entered version of the new password.

The resolver first checks that the new password and the re-entered password are the same. If they are not, it throws an error with the message Passwords do not match. If the passwords match, the resolver retrieves the user's password hash from the database and compares it to the current password provided by the user. If the current password is incorrect, it throws an error with the message Current password is invalid.

If all the checks pass, the user's password is updated with the new password.

## Testing results
Here are the results of testing the `updateUserPassword` resolver with different input:

**Executing `updateUserPassword` with an incorrect new password**
```gql
mutation {
  updateUserPassword(newPassword:"cat", currentPassword:"drowssap", newPasswordAgain:"password") {
    success
  }
}
```
Result:
```gql
{
  "errors": [
    {
      "message": "Passwords don't match",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
  "data": {
    "updateUserPassword": null
  }
}
```

**Executing `updateUserPassword` with an incorrect current password (assuming current password is `frenchfries`)**
```gql
mutation {
  updateUserPassword(newPassword:"password", currentPassword:"drowssap", newPasswordAgain:"password") {
    success
  }
}
```
Result:
```gql
{
  "errors": [
    {
      "message": "Current password is invalid",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
  "data": {
    "updateUserPassword": null
  }
}
```

**Executing `updateUserPassword` with correct arguments**
```gql
mutation {
  updateUserPassword(newPassword:"password", currentPassword:"drowssap", newPasswordAgain:"password") {
    success
  }
}
```
Result:
```gql
{
  "data": {
    "updateUserPassword": {
      "success": true
    }
  }
}
```

## Testing instructions
1. Go to `/api/graphql`.
2. Execute the queries from "Testing result" section.
3. Ensure it returns the correct result.

## Related issues
- #2641 