### PR TITLE
feat(apollo): Create removeExercise resolver

### DIFF
--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -163,6 +163,7 @@ export type Mutation = {
   logout?: Maybe<AuthResponse>
   rejectSubmission?: Maybe<Submission>
   removeAlert?: Maybe<SuccessResponse>
+  removeExercise: Exercise
   removeExerciseFlag: Exercise
   reqPwReset: SuccessResponse
   setStar: SuccessResponse
@@ -291,6 +292,10 @@ export type MutationRejectSubmissionArgs = {
 }
 
 export type MutationRemoveAlertArgs = {
+  id: Scalars['Int']
+}
+
+export type MutationRemoveExerciseArgs = {
   id: Scalars['Int']
 }
 
@@ -1275,6 +1280,15 @@ export type RemoveAlertMutation = {
   } | null
 }
 
+export type RemoveExerciseMutationVariables = Exact<{
+  id: Scalars['Int']
+}>
+
+export type RemoveExerciseMutation = {
+  __typename?: 'Mutation'
+  removeExercise: { __typename?: 'Exercise'; id: number }
+}
+
 export type RemoveExerciseFlagMutationVariables = Exact<{
   id: Scalars['Int']
 }>
@@ -1980,6 +1994,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationRemoveAlertArgs, 'id'>
+  >
+  removeExercise?: Resolver<
+    ResolversTypes['Exercise'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationRemoveExerciseArgs, 'id'>
   >
   removeExerciseFlag?: Resolver<
     ResolversTypes['Exercise'],
@@ -5435,6 +5455,87 @@ export type RemoveAlertMutationOptions = Apollo.BaseMutationOptions<
   RemoveAlertMutation,
   RemoveAlertMutationVariables
 >
+export const RemoveExerciseDocument = gql`
+  mutation removeExercise($id: Int!) {
+    removeExercise(id: $id) {
+      id
+    }
+  }
+`
+export type RemoveExerciseMutationFn = Apollo.MutationFunction<
+  RemoveExerciseMutation,
+  RemoveExerciseMutationVariables
+>
+export type RemoveExerciseProps<
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+> = {
+  [key in TDataName]: Apollo.MutationFunction<
+    RemoveExerciseMutation,
+    RemoveExerciseMutationVariables
+  >
+} & TChildProps
+export function withRemoveExercise<
+  TProps,
+  TChildProps = {},
+  TDataName extends string = 'mutate'
+>(
+  operationOptions?: ApolloReactHoc.OperationOption<
+    TProps,
+    RemoveExerciseMutation,
+    RemoveExerciseMutationVariables,
+    RemoveExerciseProps<TChildProps, TDataName>
+  >
+) {
+  return ApolloReactHoc.withMutation<
+    TProps,
+    RemoveExerciseMutation,
+    RemoveExerciseMutationVariables,
+    RemoveExerciseProps<TChildProps, TDataName>
+  >(RemoveExerciseDocument, {
+    alias: 'removeExercise',
+    ...operationOptions
+  })
+}
+
+/**
+ * __useRemoveExerciseMutation__
+ *
+ * To run a mutation, you first call `useRemoveExerciseMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveExerciseMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeExerciseMutation, { data, loading, error }] = useRemoveExerciseMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useRemoveExerciseMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    RemoveExerciseMutation,
+    RemoveExerciseMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useMutation<
+    RemoveExerciseMutation,
+    RemoveExerciseMutationVariables
+  >(RemoveExerciseDocument, options)
+}
+export type RemoveExerciseMutationHookResult = ReturnType<
+  typeof useRemoveExerciseMutation
+>
+export type RemoveExerciseMutationResult =
+  Apollo.MutationResult<RemoveExerciseMutation>
+export type RemoveExerciseMutationOptions = Apollo.BaseMutationOptions<
+  RemoveExerciseMutation,
+  RemoveExerciseMutationVariables
+>
 export const RemoveExerciseFlagDocument = gql`
   mutation removeExerciseFlag($id: Int!) {
     removeExerciseFlag(id: $id) {
@@ -6672,6 +6773,7 @@ export type MutationKeySpecifier = (
   | 'logout'
   | 'rejectSubmission'
   | 'removeAlert'
+  | 'removeExercise'
   | 'removeExerciseFlag'
   | 'reqPwReset'
   | 'setStar'
@@ -6706,6 +6808,7 @@ export type MutationFieldPolicy = {
   logout?: FieldPolicy<any> | FieldReadFunction<any>
   rejectSubmission?: FieldPolicy<any> | FieldReadFunction<any>
   removeAlert?: FieldPolicy<any> | FieldReadFunction<any>
+  removeExercise?: FieldPolicy<any> | FieldReadFunction<any>
   removeExerciseFlag?: FieldPolicy<any> | FieldReadFunction<any>
   reqPwReset?: FieldPolicy<any> | FieldReadFunction<any>
   setStar?: FieldPolicy<any> | FieldReadFunction<any>

--- a/graphql/queries/removeExercise.ts
+++ b/graphql/queries/removeExercise.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client'
+
+const REMOVE_EXERCISE = gql`
+  mutation removeExercise($id: Int!) {
+    removeExercise(id: $id) {
+      id
+    }
+  }
+`
+
+export default REMOVE_EXERCISE

--- a/graphql/resolvers.ts
+++ b/graphql/resolvers.ts
@@ -38,7 +38,8 @@ import {
   updateExercise,
   deleteExercise,
   flagExercise,
-  removeExerciseFlag
+  removeExerciseFlag,
+  removeExercise
 } from './resolvers/exerciseCrud'
 import {
   exerciseSubmissions,
@@ -99,6 +100,7 @@ export default {
     deleteComment,
     flagExercise,
     removeExerciseFlag,
+    removeExercise,
     unlinkDiscord,
     addExerciseComment,
     updateUserNames

--- a/graphql/resolvers/exerciseCrud.test.js
+++ b/graphql/resolvers/exerciseCrud.test.js
@@ -321,20 +321,33 @@ describe('It should test remove flag', () => {
 describe('It should test set removed flag', () => {
   test('it should set exercise removed flag', () => {
     prismaMock.exercise.update.mockResolvedValue({ success: true })
+    prismaMock.exercise.findUnique.mockResolvedValueOnce({
+      ...mockExercises[0]
+    })
     expect(removeExercise({}, { id: 1 }, AdminCtx)).resolves.toEqual({
       success: true
     })
   })
+
   test('it should throw error if the exercise is already removed', () => {
     prismaMock.exercise.update.mockResolvedValueOnce({ success: true })
     prismaMock.exercise.findUnique.mockResolvedValueOnce({
       ...mockExercises[0],
-      removed: true
+      removedAt: '26/08/2023 08:22:24'
     })
     expect(removeExercise({}, { id: 1 }, AdminCtx)).rejects.toThrow(
       new Error('Exercise is already removed')
     )
   })
+
+  test('it should throw error if the exercise is not found', () => {
+    prismaMock.exercise.update.mockResolvedValueOnce({ success: true })
+    prismaMock.exercise.findUnique.mockResolvedValueOnce(null)
+    expect(removeExercise({}, { id: 1 }, AdminCtx)).rejects.toThrow(
+      new Error('Exercise is not found')
+    )
+  })
+
   test('should check id when setting exercise removed flag', () => {
     expect(
       removeExercise(
@@ -348,7 +361,12 @@ describe('It should test set removed flag', () => {
       )
     ).rejects.toThrowError()
   })
+
   test('It should check if user can set the removed flag of their own exercise', () => {
+    prismaMock.exercise.findUnique.mockResolvedValueOnce({
+      ...mockExercises[0]
+    })
+
     expect(
       removeExercise(
         {},

--- a/graphql/resolvers/exerciseCrud.test.js
+++ b/graphql/resolvers/exerciseCrud.test.js
@@ -8,7 +8,8 @@ import {
   addExercise,
   updateExercise,
   flagExercise,
-  removeExerciseFlag
+  removeExerciseFlag,
+  removeExercise
 } from './exerciseCrud'
 
 const AdminCtx = {
@@ -128,7 +129,7 @@ describe('It should update an exercise', () => {
   })
 })
 describe('It should test delete', () => {
-  test('it should delete module', () => {
+  test('it should delete exercise', () => {
     prismaMock.exercise.delete.mockResolvedValue({ success: true })
     expect(deleteExercise({}, { id: 1 }, AdminCtx)).resolves.toEqual({
       success: true
@@ -147,7 +148,7 @@ describe('It should test delete', () => {
       )
     ).rejects.toThrowError()
   })
-  test('It should check if user can delte their own exercise', () => {
+  test('It should check if user can delete their own exercise', () => {
     expect(
       deleteExercise(
         {},
@@ -314,5 +315,44 @@ describe('It should test remove flag', () => {
         { req: { user: { id: 1 } } }
       )
     ).rejects.toThrow(new Error('Not authorized to unflag'))
+  })
+})
+
+describe('It should test set removed flag', () => {
+  test('it should set exercise removed flag', () => {
+    prismaMock.exercise.update.mockResolvedValue({ success: true })
+    expect(removeExercise({}, { id: 1 }, AdminCtx)).resolves.toEqual({
+      success: true
+    })
+  })
+  test('should check id when setting exercise removed flag', () => {
+    expect(
+      removeExercise(
+        {},
+        {
+          id: 1
+        },
+        {
+          req: { user: {} }
+        }
+      )
+    ).rejects.toThrowError()
+  })
+  test('It should check if user can set the removed flag of their own exercise', () => {
+    expect(
+      removeExercise(
+        {},
+        {
+          content: 'testing',
+          name: 'Using functions to make pie',
+          lessonId: 1,
+          testable: false,
+          authorId: 2
+        },
+        {
+          req: { user: { id: 333 } }
+        }
+      )
+    ).rejects.toThrow(new Error('Not authorized to remove'))
   })
 })

--- a/graphql/resolvers/exerciseCrud.test.js
+++ b/graphql/resolvers/exerciseCrud.test.js
@@ -325,6 +325,16 @@ describe('It should test set removed flag', () => {
       success: true
     })
   })
+  test('it should throw error if the exercise is already removed', () => {
+    prismaMock.exercise.update.mockResolvedValueOnce({ success: true })
+    prismaMock.exercise.findUnique.mockResolvedValueOnce({
+      ...mockExercises[0],
+      removed: true
+    })
+    expect(removeExercise({}, { id: 1 }, AdminCtx)).rejects.toThrow(
+      new Error('Exercise is already removed')
+    )
+  })
   test('should check id when setting exercise removed flag', () => {
     expect(
       removeExercise(

--- a/graphql/resolvers/exerciseCrud.ts
+++ b/graphql/resolvers/exerciseCrud.ts
@@ -133,7 +133,7 @@ export const removeExercise = withUserContainer<
   return prisma.exercise.update({
     where: { id },
     data: {
-      removedAt: new Date().toISOString(),
+      removedAt: new Date(),
       removedById: authorId as number
     },
     include: {

--- a/graphql/resolvers/exerciseCrud.ts
+++ b/graphql/resolvers/exerciseCrud.ts
@@ -120,8 +120,9 @@ export const removeExercise = withUserContainer<
 
   const authorId = req.user?.id
 
-  if (!isAdmin(req) && exercise?.authorId !== authorId)
+  if (!isAdmin(req) && exercise?.authorId !== authorId) {
     throw new Error('Not authorized to remove')
+  }
 
   if (exercise?.removed) {
     throw new Error('Exercise is already removed')

--- a/graphql/resolvers/exerciseCrud.ts
+++ b/graphql/resolvers/exerciseCrud.ts
@@ -77,7 +77,6 @@ export const updateExercise = withUserContainer<
   })
 })
 
-// will be removed in a following PR
 export const deleteExercise = withUserContainer<
   Promise<Exercise>,
   MutationDeleteExerciseArgs
@@ -104,7 +103,6 @@ export const deleteExercise = withUserContainer<
   })
 })
 
-// replaces deleteExercise
 export const removeExercise = withUserContainer<
   Promise<Exercise>,
   MutationRemoveExerciseArgs
@@ -118,20 +116,25 @@ export const removeExercise = withUserContainer<
     }
   })
 
+  if (!exercise) {
+    throw new Error('Exercise is not found')
+  }
+
   const authorId = req.user?.id
 
-  if (!isAdmin(req) && exercise?.authorId !== authorId) {
+  if (!isAdmin(req) && exercise.authorId !== authorId) {
     throw new Error('Not authorized to remove')
   }
 
-  if (exercise?.removed) {
+  if (exercise.removedAt) {
     throw new Error('Exercise is already removed')
   }
 
   return prisma.exercise.update({
     where: { id },
     data: {
-      removed: true
+      removedAt: new Date().toISOString(),
+      removedById: authorId as number
     },
     include: {
       author: true,

--- a/graphql/resolvers/exerciseCrud.ts
+++ b/graphql/resolvers/exerciseCrud.ts
@@ -123,6 +123,10 @@ export const removeExercise = withUserContainer<
   if (!isAdmin(req) && exercise?.authorId !== authorId)
     throw new Error('Not authorized to remove')
 
+  if (exercise?.removed) {
+    throw new Error('Exercise is already removed')
+  }
+
   return prisma.exercise.update({
     where: { id },
     data: {

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -81,6 +81,7 @@ export default gql`
       testStr: String
       explanation: String
     ): Exercise!
+    removeExercise(id: Int!): Exercise!
     updateExercise(
       id: Int!
       moduleId: Int!


### PR DESCRIPTION
## Motivation
Currently, there is no way to set the removed flag on an exercise when an admin wants to remove it. The removed flag is a field in the database that indicates whether an exercise has been removed or not.

The PR is adding a resolver that will allow an admin to set the removed flag to true when they want to remove an exercise. This will mark the exercise as removed in the database, and it will no longer be visible to users.

## Steps taken
1. Created the resolver `removeExercise`
2. Ensure everything is working as intended by adding tests for the resolver
3. Created the query file for `removeExercise` resolver so it can be easily used in the client-side
4. Update GraphQL `index.ts` with the new resolver and hooks.

### Unrelated steps
- Fixes some typos

## Resolver logic
1. It receives one argument, the user `id`.
2. It fetches the exercise to be removed from the database using the provided `id`.
3. It retrieves the `id` of the user making the request (`authorId`) from the request context (req).
4. If the user is not an admin and the `authorId` does not match the `authorId` of the exercise being removed, the resolver throws an error, indicating that the user is not authorized to remove the exercise.
6. If the exercise is already removed, the resolver throws an error, indicating that exercise is already flagged.
7. If the user is authorized to remove the exercise, the resolver updates the exercise in the database, setting the `removedAt` and `removedById` fields to new Date & the user ID. It also includes the author and module relations in the update.
8. The resolver returns the updated exercise.

## Testing results

Executes `removeExercise`:
```gql
mutation {
  removeExercise(id: 1) {
    id
  }
}
```

**Result:**
```gql
{
  "data": {
    "removeExercise": {
      "id": 1,
      "removedAt": "1672591865633",
      "removedById": 1
    }
  }
}
```

**Result if it's already removed:**
```gql
{
  "errors": [
    {
      "message": "Exercise is already removed",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
  "data": null
}
```

**Result if the exercise is not found:**
```gql
{
  "errors": [
    {
      "message": "Exercise is not found",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ]
  ],
  "data": null
}
```

## Testing instructions
1. Go to `/api/graphql`
2. Run the queries from `Testing result` section
3. Make sure they return the correct results

## Related issues
- #2630 