### PR TITLE
Remove `removed`, adds `removedAt`, `removedBy`, and `removedAt` fields to Exercise model

### DIFF
--- a/__dummy__/getExercisesData.ts
+++ b/__dummy__/getExercisesData.ts
@@ -70,7 +70,7 @@ const getExercisesData: GetExercisesQuery = {
         email: 'noob@c0d3.com',
         discordId: '8321'
       },
-      removed: false,
+      removedAt: null,
       description: '```\nlet a = 5\na = a + 10\n// what is a?\n```',
       answer: '15',
       explanation: 'You can reassign variables that were created with "let".',
@@ -91,7 +91,7 @@ const getExercisesData: GetExercisesQuery = {
         email: 'noob@c0d3.com',
         discordId: '8321'
       },
-      removed: false,
+      removedAt: null,
       description: '```\nlet a = 1\na += 2\n// what is a?\n```',
       answer: '3',
       explanation: '`a += 2` is a shorter way to write `a = a + 2`',
@@ -112,7 +112,7 @@ const getExercisesData: GetExercisesQuery = {
         email: 'noob@c0d3.com',
         discordId: '8321'
       },
-      removed: false,
+      removedAt: null,
       description: '```\nlet a = 1\na -= 2\n// what is a?\n```',
       answer: '-1',
       explanation: null,

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -86,9 +86,6 @@ export type Exercise = {
   id: Scalars['Int']
   module: Module
   removed?: Maybe<Scalars['Boolean']>
-  removedAt?: Maybe<Scalars['String']>
-  removedBy?: Maybe<User>
-  removedById?: Maybe<Scalars['Int']>
   testStr?: Maybe<Scalars['String']>
 }
 
@@ -1750,9 +1747,6 @@ export type ExerciseResolvers<
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
   module?: Resolver<ResolversTypes['Module'], ParentType, ContextType>
   removed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
-  removedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-  removedBy?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
-  removedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
   testStr?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
@@ -6549,9 +6543,6 @@ export type ExerciseKeySpecifier = (
   | 'id'
   | 'module'
   | 'removed'
-  | 'removedAt'
-  | 'removedBy'
-  | 'removedById'
   | 'testStr'
   | ExerciseKeySpecifier
 )[]
@@ -6567,9 +6558,6 @@ export type ExerciseFieldPolicy = {
   id?: FieldPolicy<any> | FieldReadFunction<any>
   module?: FieldPolicy<any> | FieldReadFunction<any>
   removed?: FieldPolicy<any> | FieldReadFunction<any>
-  removedAt?: FieldPolicy<any> | FieldReadFunction<any>
-  removedBy?: FieldPolicy<any> | FieldReadFunction<any>
-  removedById?: FieldPolicy<any> | FieldReadFunction<any>
   testStr?: FieldPolicy<any> | FieldReadFunction<any>
 }
 export type ExerciseCommentKeySpecifier = (

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -86,6 +86,9 @@ export type Exercise = {
   id: Scalars['Int']
   module: Module
   removed?: Maybe<Scalars['Boolean']>
+  removedAt?: Maybe<Scalars['String']>
+  removedBy?: Maybe<User>
+  removedById?: Maybe<Scalars['Int']>
   testStr?: Maybe<Scalars['String']>
 }
 
@@ -1747,6 +1750,9 @@ export type ExerciseResolvers<
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
   module?: Resolver<ResolversTypes['Module'], ParentType, ContextType>
   removed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  removedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  removedBy?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  removedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
   testStr?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
@@ -6543,6 +6549,9 @@ export type ExerciseKeySpecifier = (
   | 'id'
   | 'module'
   | 'removed'
+  | 'removedAt'
+  | 'removedBy'
+  | 'removedById'
   | 'testStr'
   | ExerciseKeySpecifier
 )[]
@@ -6558,6 +6567,9 @@ export type ExerciseFieldPolicy = {
   id?: FieldPolicy<any> | FieldReadFunction<any>
   module?: FieldPolicy<any> | FieldReadFunction<any>
   removed?: FieldPolicy<any> | FieldReadFunction<any>
+  removedAt?: FieldPolicy<any> | FieldReadFunction<any>
+  removedBy?: FieldPolicy<any> | FieldReadFunction<any>
+  removedById?: FieldPolicy<any> | FieldReadFunction<any>
   testStr?: FieldPolicy<any> | FieldReadFunction<any>
 }
 export type ExerciseCommentKeySpecifier = (

--- a/graphql/index.tsx
+++ b/graphql/index.tsx
@@ -85,7 +85,9 @@ export type Exercise = {
   flaggedById?: Maybe<Scalars['Int']>
   id: Scalars['Int']
   module: Module
-  removed?: Maybe<Scalars['Boolean']>
+  removedAt?: Maybe<Scalars['String']>
+  removedBy?: Maybe<User>
+  removedById?: Maybe<Scalars['Int']>
   testStr?: Maybe<Scalars['String']>
 }
 
@@ -1007,7 +1009,7 @@ export type GetExercisesQuery = {
   exercises: Array<{
     __typename?: 'Exercise'
     id: number
-    removed?: boolean | null
+    removedAt?: string | null
     description: string
     answer: string
     explanation?: string | null
@@ -1746,7 +1748,9 @@ export type ExerciseResolvers<
   flaggedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
   id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
   module?: Resolver<ResolversTypes['Module'], ParentType, ContextType>
-  removed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>
+  removedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  removedBy?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>
+  removedById?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>
   testStr?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }>
@@ -4354,7 +4358,7 @@ export const GetExercisesDocument = gql`
           slug
         }
       }
-      removed
+      removedAt
       description
       answer
       explanation
@@ -6542,7 +6546,9 @@ export type ExerciseKeySpecifier = (
   | 'flaggedById'
   | 'id'
   | 'module'
-  | 'removed'
+  | 'removedAt'
+  | 'removedBy'
+  | 'removedById'
   | 'testStr'
   | ExerciseKeySpecifier
 )[]
@@ -6557,7 +6563,9 @@ export type ExerciseFieldPolicy = {
   flaggedById?: FieldPolicy<any> | FieldReadFunction<any>
   id?: FieldPolicy<any> | FieldReadFunction<any>
   module?: FieldPolicy<any> | FieldReadFunction<any>
-  removed?: FieldPolicy<any> | FieldReadFunction<any>
+  removedAt?: FieldPolicy<any> | FieldReadFunction<any>
+  removedBy?: FieldPolicy<any> | FieldReadFunction<any>
+  removedById?: FieldPolicy<any> | FieldReadFunction<any>
   testStr?: FieldPolicy<any> | FieldReadFunction<any>
 }
 export type ExerciseCommentKeySpecifier = (

--- a/graphql/queries/getExercises.ts
+++ b/graphql/queries/getExercises.ts
@@ -28,7 +28,7 @@ const GET_EXERCISES = gql`
           slug
         }
       }
-      removed
+      removedAt
       description
       answer
       explanation

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -278,6 +278,9 @@ export default gql`
     testStr: String
     explanation: String
     removed: Boolean
+    removedAt: String
+    removedBy: User
+    removedById: Int
     flaggedAt: String
     flagReason: String
     flaggedBy: User

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -278,9 +278,6 @@ export default gql`
     testStr: String
     explanation: String
     removed: Boolean
-    removedAt: String
-    removedBy: User
-    removedById: Int
     flaggedAt: String
     flagReason: String
     flaggedBy: User

--- a/graphql/typeDefs.ts
+++ b/graphql/typeDefs.ts
@@ -277,7 +277,9 @@ export default gql`
     answer: String!
     testStr: String
     explanation: String
-    removed: Boolean
+    removedAt: String
+    removedBy: User
+    removedById: Int
     flaggedAt: String
     flagReason: String
     flaggedBy: User

--- a/prisma/migrations/20230101045032_add_removed_column_date_and_user_to_exercise/migration.sql
+++ b/prisma/migrations/20230101045032_add_removed_column_date_and_user_to_exercise/migration.sql
@@ -1,6 +1,0 @@
--- AlterTable
-ALTER TABLE "exercises" ADD COLUMN     "removedAt" TIMESTAMP(3),
-ADD COLUMN     "removedById" INTEGER;
-
--- AddForeignKey
-ALTER TABLE "exercises" ADD CONSTRAINT "exercises_removedById_fkey" FOREIGN KEY ("removedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20230101045032_add_removed_column_date_and_user_to_exercise/migration.sql
+++ b/prisma/migrations/20230101045032_add_removed_column_date_and_user_to_exercise/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "exercises" ADD COLUMN     "removedAt" TIMESTAMP(3),
+ADD COLUMN     "removedById" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "exercises" ADD CONSTRAINT "exercises_removedById_fkey" FOREIGN KEY ("removedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20230101050656_add_removed_column_date_and_user_to_exercise/migration.sql
+++ b/prisma/migrations/20230101050656_add_removed_column_date_and_user_to_exercise/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `removed` on the `exercises` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "exercises" DROP COLUMN "removed",
+ADD COLUMN     "removedAt" TIMESTAMP(3),
+ADD COLUMN     "removedById" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "exercises" ADD CONSTRAINT "exercises_removedById_fkey" FOREIGN KEY ("removedById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,7 +149,8 @@ model User {
   comments                  Comment[]
   exercises                 Exercise[]
   exerciseSubmissions       ExerciseSubmission[]
-  Exercise                  Exercise[]           @relation("flaggedExercises")
+  FlaggedExercise           Exercise[]           @relation("flaggedExercises")
+  RemovedExercise           Exercise[]           @relation("removedExercises")
   modules                   Module[]
   starsMentor               Star[]               @relation("starMentor")
   starsGiven                Star[]               @relation("starStudent")
@@ -187,7 +188,9 @@ model Exercise {
   answer           String
   testStr          String?
   explanation      String?
-  removed          Boolean?             @default(false)
+  removedAt        DateTime?
+  removedById      Int?
+  removedBy        User?                @relation("removedExercises", fields: [removedById], references: [id])
   flagReason       String?
   flaggedAt        DateTime?
   flaggedById      Int?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,8 +149,7 @@ model User {
   comments                  Comment[]
   exercises                 Exercise[]
   exerciseSubmissions       ExerciseSubmission[]
-  FlaggedExercise           Exercise[]           @relation("flaggedExercises")
-  RemovedExercise           Exercise[]           @relation("removedExercises")
+  Exercise                  Exercise[]           @relation("flaggedExercises")
   modules                   Module[]
   starsMentor               Star[]               @relation("starMentor")
   starsGiven                Star[]               @relation("starStudent")
@@ -189,9 +188,6 @@ model Exercise {
   testStr          String?
   explanation      String?
   removed          Boolean?             @default(false)
-  removedAt        DateTime?
-  removedById      Int?
-  removedBy        User?                @relation("removedExercises", fields: [removedById], references: [id])
   flagReason       String?
   flaggedAt        DateTime?
   flaggedById      Int?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,7 +149,8 @@ model User {
   comments                  Comment[]
   exercises                 Exercise[]
   exerciseSubmissions       ExerciseSubmission[]
-  Exercise                  Exercise[]           @relation("flaggedExercises")
+  FlaggedExercise           Exercise[]           @relation("flaggedExercises")
+  RemovedExercise           Exercise[]           @relation("removedExercises")
   modules                   Module[]
   starsMentor               Star[]               @relation("starMentor")
   starsGiven                Star[]               @relation("starStudent")
@@ -188,6 +189,9 @@ model Exercise {
   testStr          String?
   explanation      String?
   removed          Boolean?             @default(false)
+  removedAt        DateTime?
+  removedById      Int?
+  removedBy        User?                @relation("removedExercises", fields: [removedById], references: [id])
   flagReason       String?
   flaggedAt        DateTime?
   flaggedById      Int?


### PR DESCRIPTION
## Motivation
In a [recent comment](https://github.com/garageScript/c0d3-app/pull/2657#issuecomment-1368216145), it was addressed that the fields for handling removing an exercise could be improved, and this PR reflects the suggested changes.

## Changes
This PR updates the Exercise model to improve how the removed field is handled.

**The changes include:**
1. Renaming `removed` to `removedAt` to match the naming conventions of other date fields in the model.
2. Making `removedAt` a required field with a default value of null. This ensures that there are only two possible values for the field: null or a date.
3. Adding a new field called `removedBy` to track the user who removed the exercise.
4. Removing the `removed` field.

These changes will make it easier to track when an exercise is removed and who removed it, and will improve the overall consistency of the model.

**Related issues**
- #2630 