### PR TITLE
content: Fix typos in JS2

### DIFF
--- a/content/lessons/js2/sublesson/map_reduce_and_filter_functions.mdx
+++ b/content/lessons/js2/sublesson/map_reduce_and_filter_functions.mdx
@@ -1059,7 +1059,7 @@ understand how it works before moving on.
        const result = fn.largest([9, 8, 16, 2, 3])
        expect(result).toEqual(16)
      })
-     it('should return 0 since given array is empty', () => {
+     it('should return undefined since given array is empty', () => {
        const result = fn.largest([])
        expect(result).toEqual(undefined)
      })
@@ -1556,7 +1556,7 @@ approach is called **prototype inheritance**. But why?
          "<p><img src='https://placebear.com/800/710'></p>"
        )
      })
-     it('should return 0 for an empty array', () => {
+     it('should return undefined for an empty array', () => {
        const result = [].sum()
        expect(result).toEqual(undefined)
      })


### PR DESCRIPTION
## Problem
Discrepancy between the test description and the test assertion. This can make the students confused.

## Changes
Changed the following texts from `return 0` to `return undefined`

- https://github.com/garageScript/c0d3-app/blob/13e67507b8b8f757ae790abe5d6ba0aa9c9e2464/content/lessons/js2/sublesson/map_reduce_and_filter_functions.mdx?plain=1#L1559-L1562
- https://github.com/garageScript/c0d3-app/blob/66fa226de24e86eb8b6b31ba448a99e00b23076e/content/lessons/js2/sublesson/map_reduce_and_filter_functions.mdx?plain=1#L1062-L1065

## Related issues
- #2658 
- #2659 

## Additional context
Reported by RickSA#3112 on Discord.