### PR TITLE
feat: Allow using password inputs

### DIFF
--- a/components/FormCard.tsx
+++ b/components/FormCard.tsx
@@ -17,6 +17,7 @@ export type TextField = Omit<Option, 'value'> & { value: string }
 export type Option = {
   title: string
   type?: string
+  valueType?: 'password'
   error?: string
   placeHolder?: string
   value?: string | number | Item[]
@@ -48,7 +49,7 @@ type OptionInfoProps = {
   mdInputBg?: 'white' | 'none'
 }
 
-const displayInputType = (
+const displayvalueType = (
   index: number,
   onChange: Function,
   option: Option,
@@ -57,7 +58,7 @@ const displayInputType = (
   const [cursorInput, setCursorInput] = useState<number | null>(0)
   const [cursorMdInput, setCursorMdInput] = useState<number | null>(0)
 
-  const { placeHolder, type } = option
+  const { placeHolder, type, valueType } = option
   const value: any = option.value
   switch (type) {
     case MD_INPUT:
@@ -79,7 +80,7 @@ const displayInputType = (
     default:
       return (
         <input
-          type="text"
+          type={valueType || 'text'}
           className={`form-control ${styles.optionInfo__input}`}
           data-testid={`input${index}`}
           value={`${value || ''}`}
@@ -120,7 +121,7 @@ const OptionInfo: React.FC<OptionInfoProps> = ({
       >
         {`${(capitalizeTitle && _.capitalize(title)) || title}`}
       </span>
-      {displayInputType(index, onChange, option, mdInputBg)}
+      {displayvalueType(index, onChange, option, mdInputBg)}
       {error && <ErrorMessage error={error} />}
     </div>
   )

--- a/stories/components/FormCard.stories.tsx
+++ b/stories/components/FormCard.stories.tsx
@@ -7,7 +7,6 @@ import {
 } from '../../components/FormCard'
 import { Item } from '../../components/DropdownMenu'
 import { formChange } from '../../helpers/formChange'
-import { title } from 'process'
 
 export default {
   component: FormCard,

--- a/stories/components/FormCard.stories.tsx
+++ b/stories/components/FormCard.stories.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../components/FormCard'
 import { Item } from '../../components/DropdownMenu'
 import { formChange } from '../../helpers/formChange'
+import { title } from 'process'
 
 export default {
   component: FormCard,
@@ -23,6 +24,10 @@ const mockValues: Option[] = [
   { title: 'description', value: 'Amazing farm of chicken' },
   { title: 'title', value: 'oheuhehe', type: MD_INPUT },
   { title: 'level', value: 'noob' }
+]
+
+const mockValuesWithPassword: Option[] = [
+  { title: 'password', value: 'somePassword', valueType: 'password' }
 ]
 
 const MockBasic: React.FC = () => {
@@ -54,6 +59,22 @@ const MockBasic: React.FC = () => {
   }
 
   return <FormCard onChange={onChange} values={options} onSubmit={mockBtn} />
+}
+
+const MockWithPassword: React.FC = () => {
+  const mockedDropdown = mockValuesWithPassword
+  const [options, setOptions] = useState(mockedDropdown)
+  const onChange = (value: string, index: number) => {
+    formChange(value, index, options, setOptions)
+  }
+
+  return (
+    <FormCard
+      onChange={onChange}
+      values={options}
+      onSubmit={{ ...mockBtn, title: 'Save Changes' }}
+    />
+  )
 }
 
 const MockWithTitle: React.FC = () => {
@@ -170,6 +191,12 @@ const MockWithNewButton: React.FC = () => {
 export const Basic: React.FC = () => (
   <div className="col-5 m-auto">
     <MockBasic />
+  </div>
+)
+
+export const _WithPassword: React.FC = () => (
+  <div className="col-5 m-auto">
+    <MockWithPassword />
   </div>
 )
 


### PR DESCRIPTION
## Motivation
Currently, there's no way to make an input type `password`. This is preventing us from completing the [password section (2nd task)](#1629).

## Changes
- Update `FormCard` component's `option` type to take an optional `inputValue` which is set to `password`

## Screenshot
<img width="655" alt="image" src="https://user-images.githubusercontent.com/35906419/210735066-5f604576-cbde-4a24-8dea-e4abb3362bd8.png">

## View changes
- Storybook/FormCard