### PR TITLE
build(deps/fix): Bump gitdiff-parser from 0.2.2 to 0.3.0

### DIFF
--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -89,7 +89,8 @@ const DiffView: React.FC<{
     if (!prismLanguages.includes(language)) language = 'javascript'
     hunks.forEach(hunk => {
       hunk.changes.forEach(change => {
-        if (!change.isDelete) newValue.push(change.content)
+        // If it's not a line that's supposed to look delete
+        if (!(change.type === 'delete')) newValue.push(change.content)
       })
     })
     const syntaxHighlight = (str: string, n: number) => {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "discord.js": "^12.5.3",
     "express-session": "^1.17.3",
     "formik": "^2.2.8",
-    "gitdiff-parser": "^0.2.2",
+    "gitdiff-parser": "0.3.0",
     "graphql": "^15.8.0",
     "graphql-request": "^5.1.0",
     "gray-matter": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1930,7 +1930,7 @@
     lodash "~4.17.0"
     tslib "~2.4.0"
 
-"@graphql-codegen/plugin-helpers@^4.0.0", "@graphql-codegen/plugin-helpers@^4.1.0":
+"@graphql-codegen/plugin-helpers@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-4.1.0.tgz#4b193c12d6bb458f1f2af48c200bc86617884f60"
   integrity sha512-xvSHJb9OGb5CODIls0AI1rCenLz+FuiaNPCsfHMCNsLDjOZK2u0jAQ9zUBdc/Wb+21YXZujBCc0Vm1QX+Zz0nw==
@@ -2018,22 +2018,6 @@
     "@graphql-tools/utils" "^8.8.0"
     auto-bind "~4.0.0"
     change-case-all "1.0.14"
-    dependency-graph "^0.11.0"
-    graphql-tag "^2.11.0"
-    parse-filepath "^1.0.2"
-    tslib "~2.4.0"
-
-"@graphql-codegen/visitor-plugin-common@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-3.0.0.tgz#527185eb3b1b06739702084bc6263713e167a166"
-  integrity sha512-ZoNlCmmkGClB137SpJT9og/nkihLN7Z4Ynl9Ir3OlbDuI20dbpyXsclpr9QGLcxEcfQeVfhGw9CooW7wZJJ8LA==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^4.0.0"
-    "@graphql-tools/optimize" "^1.3.0"
-    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
-    "@graphql-tools/utils" "^9.0.0"
-    auto-bind "~4.0.0"
-    change-case-all "1.0.15"
     dependency-graph "^0.11.0"
     graphql-tag "^2.11.0"
     parse-filepath "^1.0.2"
@@ -10130,10 +10114,10 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-gitdiff-parser@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/gitdiff-parser/-/gitdiff-parser-0.2.2.tgz#c393ce9caf385860d005ce758a5e03221a7fc6be"
-  integrity sha512-iUE5gWohbUm+hogg9c1Gg/pDoDyGlC15hTdsnW7AqZw9+F9mYAxfnMNDstFxuF+qjiZot2s+3L+K9CLdw1ttvA==
+gitdiff-parser@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/gitdiff-parser/-/gitdiff-parser-0.3.0.tgz#e6dbb07444405aee20835814a6787f072fd49425"
+  integrity sha512-vCQibCxIea4dxfuQEAzuStvGSLKeI+c48eBSEPgHy52TERXOQ/jKpp3ZTNcsuHpdarSZAcShdyXCpGNR/0GnLQ==
 
 github-slugger@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
## Changes

In the [latest changes](https://github.com/ecomfe/gitdiff-parser/commit/e4674f9dff4a27d21235be0bef02d346c1e98827#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8R3) of gitdiff-parser, the `InsertChange` type has been _refined_ and the property that we use to check whether a line should look deleted or inserted has been removed from the type. 

We use `change.type` to check if the line is `delete` or not.

## Original PR description

Bumps [gitdiff-parser](https://github.com/ecomfe/gitdiff-parser) from 0.2.2 to 0.3.0.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/ecomfe/gitdiff-parser/blob/master/CHANGELOG.md">gitdiff-parser's changelog</a>.</em></p>
<blockquote>
<h1>ChangeLog</h1>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/ecomfe/gitdiff-parser/commit/89a381cabfc8aa7449cfe983d59effee2bae8a11"><code>89a381c</code></a> bump 0.3.0</li>
<li><a href="https://github.com/ecomfe/gitdiff-parser/commit/e4674f9dff4a27d21235be0bef02d346c1e98827"><code>e4674f9</code></a> refine types</li>
<li>See full diff in <a href="https://github.com/ecomfe/gitdiff-parser/compare/0.2.2...v0.3.0">compare view</a></li>
</ul>
</details>
<details>
<summary>Maintainer changes</summary>
<p>This version was pushed to npm by <a href="https://www.npmjs.com/~otakustay">otakustay</a>, a new releaser for gitdiff-parser since your current version.</p>
</details>
<br />