### PR TITLE
Improve MdInput stories and update snapshots

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -12904,16 +12904,16 @@ exports[`Storyshots Components/MdInput White 1`] = `
     onKeyDown={[Function]}
     onMouseDown={[Function]}
     placeholder="Type something..."
-    value=""
+    value="Did you notice the white background instead of the default light gray?"
   />
 </div>
 `;
 
-exports[`Storyshots Components/MdInput With Preset Value 1`] = `
+exports[`Storyshots Components/MdInput With HTML Strings 1`] = `
 <div
   style={
     Object {
-      "backgroundColor": "white",
+      "backgroundColor": "none",
     }
   }
 >
@@ -13231,359 +13231,689 @@ exports[`Storyshots Components/MdInput With Preset Value 1`] = `
     onKeyDown={[Function]}
     onMouseDown={[Function]}
     placeholder="Type something..."
-    value="HinGa DIngA dUrgEN"
+    value="What does the Preview look like...
+
+... if I wrap the HTML in backticks?
+
+\`<div style=\\"color: white; background-color: purple; >C0D3 C0D3 C0D3</div>\`
+
+... if I don't?
+
+<div style=\\"color: white; background-color: purple; padding: 10px\\">C0D3 C0D3 C0D3</div>"
   />
 </div>
 `;
 
-exports[`Storyshots Components/MdInput With Submission Buttons 1`] = `
-<div>
-  <div
-    style={
-      Object {
-        "backgroundColor": "white",
-      }
+exports[`Storyshots Components/MdInput With Markdown Input 1`] = `
+<div
+  style={
+    Object {
+      "backgroundColor": "none",
     }
+  }
+>
+  <div
+    className="nav nav-tabs"
+    onKeyDown={[Function]}
   >
     <div
-      className="nav nav-tabs"
-      onKeyDown={[Function]}
+      className="nav-item"
     >
-      <div
-        className="nav-item"
-      >
-        <a
-          className="nav-link active"
-          data-rr-ui-event-key="Write"
-          href="#"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="button"
-          style={
-            Object {
-              "color": "#292929",
-            }
+      <a
+        className="nav-link active"
+        data-rr-ui-event-key="Write"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#292929",
           }
-          tabIndex={0}
-        >
-          Write
-        </a>
-      </div>
-      <div
-        className="nav-item"
+        }
+        tabIndex={0}
       >
-        <a
-          className="nav-link"
-          data-rr-ui-event-key="Preview"
-          href="#"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="button"
-          style={
-            Object {
-              "color": "#8e8e8e",
-            }
-          }
-          tabIndex={0}
-        >
-          Preview
-        </a>
-      </div>
-      <div
-        className="ms-auto btn-toolbar"
-        role="toolbar"
-      >
-        <button
-          aria-label="Add header text"
-          className="btn"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="octicon octicon-heading"
-            fill="currentColor"
-            focusable="false"
-            height={16}
-            role="img"
-            style={
-              Object {
-                "display": "inline-block",
-                "overflow": "visible",
-                "userSelect": "none",
-                "verticalAlign": "text-bottom",
-              }
-            }
-            viewBox="0 0 16 16"
-            width={16}
-          >
-            <path
-              d="M3.75 2a.75.75 0 0 1 .75.75V7h7V2.75a.75.75 0 0 1 1.5 0v10.5a.75.75 0 0 1-1.5 0V8.5h-7v4.75a.75.75 0 0 1-1.5 0V2.75A.75.75 0 0 1 3.75 2Z"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="Add bold text <ctrl+b>"
-          className="btn"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="octicon octicon-bold"
-            fill="currentColor"
-            focusable="false"
-            height={16}
-            role="img"
-            style={
-              Object {
-                "display": "inline-block",
-                "overflow": "visible",
-                "userSelect": "none",
-                "verticalAlign": "text-bottom",
-              }
-            }
-            viewBox="0 0 16 16"
-            width={16}
-          >
-            <path
-              d="M4 2h4.5a3.501 3.501 0 0 1 2.852 5.53A3.499 3.499 0 0 1 9.5 14H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1Zm1 7v3h4.5a1.5 1.5 0 0 0 0-3Zm3.5-2a1.5 1.5 0 0 0 0-3H5v3Z"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="Add italic text <ctrl+i>"
-          className="btn"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="octicon octicon-italic"
-            fill="currentColor"
-            focusable="false"
-            height={16}
-            role="img"
-            style={
-              Object {
-                "display": "inline-block",
-                "overflow": "visible",
-                "userSelect": "none",
-                "verticalAlign": "text-bottom",
-              }
-            }
-            viewBox="0 0 16 16"
-            width={16}
-          >
-            <path
-              d="M6 2.75A.75.75 0 0 1 6.75 2h6.5a.75.75 0 0 1 0 1.5h-2.505l-3.858 9H9.25a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5h2.505l3.858-9H6.75A.75.75 0 0 1 6 2.75Z"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="Insert a quote <ctrl+shift+.>"
-          className="btn"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="octicon octicon-quote"
-            fill="currentColor"
-            focusable="false"
-            height={16}
-            role="img"
-            style={
-              Object {
-                "display": "inline-block",
-                "overflow": "visible",
-                "userSelect": "none",
-                "verticalAlign": "text-bottom",
-              }
-            }
-            viewBox="0 0 16 16"
-            width={16}
-          >
-            <path
-              d="M1.75 2.5h10.5a.75.75 0 0 1 0 1.5H1.75a.75.75 0 0 1 0-1.5Zm4 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2.5 7.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 1.5 0Z"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="Insert code <ctrl+e>"
-          className="btn"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="octicon octicon-code"
-            fill="currentColor"
-            focusable="false"
-            height={16}
-            role="img"
-            style={
-              Object {
-                "display": "inline-block",
-                "overflow": "visible",
-                "userSelect": "none",
-                "verticalAlign": "text-bottom",
-              }
-            }
-            viewBox="0 0 16 16"
-            width={16}
-          >
-            <path
-              d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="Add a link <ctrl+k>"
-          className="btn"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="octicon octicon-link"
-            fill="currentColor"
-            focusable="false"
-            height={16}
-            role="img"
-            style={
-              Object {
-                "display": "inline-block",
-                "overflow": "visible",
-                "userSelect": "none",
-                "verticalAlign": "text-bottom",
-              }
-            }
-            viewBox="0 0 16 16"
-            width={16}
-          >
-            <path
-              d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="Add a bulleted list <ctrl+shift+8>"
-          className="btn"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="octicon octicon-list-unordered"
-            fill="currentColor"
-            focusable="false"
-            height={16}
-            role="img"
-            style={
-              Object {
-                "display": "inline-block",
-                "overflow": "visible",
-                "userSelect": "none",
-                "verticalAlign": "text-bottom",
-              }
-            }
-            viewBox="0 0 16 16"
-            width={16}
-          >
-            <path
-              d="M5.75 2.5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2 14a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-6a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM2 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"
-            />
-          </svg>
-        </button>
-        <button
-          aria-label="Add a numbered list <ctrl+shift+7>"
-          className="btn"
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-        >
-          <svg
-            aria-hidden="true"
-            className="octicon octicon-list-ordered"
-            fill="currentColor"
-            focusable="false"
-            height={16}
-            role="img"
-            style={
-              Object {
-                "display": "inline-block",
-                "overflow": "visible",
-                "userSelect": "none",
-                "verticalAlign": "text-bottom",
-              }
-            }
-            viewBox="0 0 16 16"
-            width={16}
-          >
-            <path
-              d="M5 3.25a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5A.75.75 0 0 1 5 3.25Zm0 5a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5A.75.75 0 0 1 5 8.25Zm0 5a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1-.75-.75ZM.924 10.32a.5.5 0 0 1-.851-.525l.001-.001.001-.002.002-.004.007-.011c.097-.144.215-.273.348-.384.228-.19.588-.392 1.068-.392.468 0 .858.181 1.126.484.259.294.377.673.377 1.038 0 .987-.686 1.495-1.156 1.845l-.047.035c-.303.225-.522.4-.654.597h1.357a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5c0-1.005.692-1.52 1.167-1.875l.035-.025c.531-.396.8-.625.8-1.078a.57.57 0 0 0-.128-.376C1.806 10.068 1.695 10 1.5 10a.658.658 0 0 0-.429.163.835.835 0 0 0-.144.153ZM2.003 2.5V6h.503a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1h.503V3.308l-.28.14a.5.5 0 0 1-.446-.895l1.003-.5a.5.5 0 0 1 .723.447Z"
-            />
-          </svg>
-        </button>
-      </div>
+        Write
+      </a>
     </div>
-    <textarea
-      className="textarea"
-      data-testid="textbox"
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDown={[Function]}
-      placeholder="Type something..."
-      value=""
-    />
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link"
+        data-rr-ui-event-key="Preview"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#8e8e8e",
+          }
+        }
+        tabIndex={0}
+      >
+        Preview
+      </a>
+    </div>
+    <div
+      className="ms-auto btn-toolbar"
+      role="toolbar"
+    >
+      <button
+        aria-label="Add header text"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-heading"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M3.75 2a.75.75 0 0 1 .75.75V7h7V2.75a.75.75 0 0 1 1.5 0v10.5a.75.75 0 0 1-1.5 0V8.5h-7v4.75a.75.75 0 0 1-1.5 0V2.75A.75.75 0 0 1 3.75 2Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add bold text <ctrl+b>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-bold"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M4 2h4.5a3.501 3.501 0 0 1 2.852 5.53A3.499 3.499 0 0 1 9.5 14H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1Zm1 7v3h4.5a1.5 1.5 0 0 0 0-3Zm3.5-2a1.5 1.5 0 0 0 0-3H5v3Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add italic text <ctrl+i>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-italic"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M6 2.75A.75.75 0 0 1 6.75 2h6.5a.75.75 0 0 1 0 1.5h-2.505l-3.858 9H9.25a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5h2.505l3.858-9H6.75A.75.75 0 0 1 6 2.75Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Insert a quote <ctrl+shift+.>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-quote"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M1.75 2.5h10.5a.75.75 0 0 1 0 1.5H1.75a.75.75 0 0 1 0-1.5Zm4 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2.5 7.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 1.5 0Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Insert code <ctrl+e>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-code"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add a link <ctrl+k>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-link"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add a bulleted list <ctrl+shift+8>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-list-unordered"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M5.75 2.5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2 14a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-6a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM2 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add a numbered list <ctrl+shift+7>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-list-ordered"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M5 3.25a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5A.75.75 0 0 1 5 3.25Zm0 5a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5A.75.75 0 0 1 5 8.25Zm0 5a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1-.75-.75ZM.924 10.32a.5.5 0 0 1-.851-.525l.001-.001.001-.002.002-.004.007-.011c.097-.144.215-.273.348-.384.228-.19.588-.392 1.068-.392.468 0 .858.181 1.126.484.259.294.377.673.377 1.038 0 .987-.686 1.495-1.156 1.845l-.047.035c-.303.225-.522.4-.654.597h1.357a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5c0-1.005.692-1.52 1.167-1.875l.035-.025c.531-.396.8-.625.8-1.078a.57.57 0 0 0-.128-.376C1.806 10.068 1.695 10 1.5 10a.658.658 0 0 0-.429.163.835.835 0 0 0-.144.153ZM2.003 2.5V6h.503a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1h.503V3.308l-.28.14a.5.5 0 0 1-.446-.895l1.003-.5a.5.5 0 0 1 .723.447Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
-  <button
-    className="btn borderless btn-success m-1"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#fff",
-      }
+  <textarea
+    className="textarea"
+    data-testid="textbox"
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDown={[Function]}
+    placeholder="Type something..."
+    value="## This component supports [Markdown](https://www.markdownguide.org/)
+
+### Let's make a numbered list
+1. This is *item one*
+2. This is item two \`with some inline code\`
+3. Don't forget **item three**
+
+### Let's make a bullet list
+- Here's a list item
+- Another list item followed by a horizontal rule
+
+___
+
+## The text area expands with the size of the content
+
+You can attach an image too:
+
+![cute kitten](https://placekitten.com/200/300)"
+  />
+</div>
+`;
+
+exports[`Storyshots Components/MdInput With Preset Value 1`] = `
+<div
+  style={
+    Object {
+      "backgroundColor": "none",
     }
+  }
+>
+  <div
+    className="nav nav-tabs"
+    onKeyDown={[Function]}
   >
-    Accept
-  </button>
-  <button
-    className="btn borderless btn-danger m-1"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#fff",
-      }
-    }
-  >
-    Reject
-  </button>
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link active"
+        data-rr-ui-event-key="Write"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#292929",
+          }
+        }
+        tabIndex={0}
+      >
+        Write
+      </a>
+    </div>
+    <div
+      className="nav-item"
+    >
+      <a
+        className="nav-link"
+        data-rr-ui-event-key="Preview"
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        style={
+          Object {
+            "color": "#8e8e8e",
+          }
+        }
+        tabIndex={0}
+      >
+        Preview
+      </a>
+    </div>
+    <div
+      className="ms-auto btn-toolbar"
+      role="toolbar"
+    >
+      <button
+        aria-label="Add header text"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-heading"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M3.75 2a.75.75 0 0 1 .75.75V7h7V2.75a.75.75 0 0 1 1.5 0v10.5a.75.75 0 0 1-1.5 0V8.5h-7v4.75a.75.75 0 0 1-1.5 0V2.75A.75.75 0 0 1 3.75 2Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add bold text <ctrl+b>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-bold"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M4 2h4.5a3.501 3.501 0 0 1 2.852 5.53A3.499 3.499 0 0 1 9.5 14H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1Zm1 7v3h4.5a1.5 1.5 0 0 0 0-3Zm3.5-2a1.5 1.5 0 0 0 0-3H5v3Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add italic text <ctrl+i>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-italic"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M6 2.75A.75.75 0 0 1 6.75 2h6.5a.75.75 0 0 1 0 1.5h-2.505l-3.858 9H9.25a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5h2.505l3.858-9H6.75A.75.75 0 0 1 6 2.75Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Insert a quote <ctrl+shift+.>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-quote"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M1.75 2.5h10.5a.75.75 0 0 1 0 1.5H1.75a.75.75 0 0 1 0-1.5Zm4 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2.5 7.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 1.5 0Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Insert code <ctrl+e>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-code"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add a link <ctrl+k>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-link"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add a bulleted list <ctrl+shift+8>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-list-unordered"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M5.75 2.5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2 14a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-6a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM2 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Add a numbered list <ctrl+shift+7>"
+        className="btn"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+      >
+        <svg
+          aria-hidden="true"
+          className="octicon octicon-list-ordered"
+          fill="currentColor"
+          focusable="false"
+          height={16}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <path
+            d="M5 3.25a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5A.75.75 0 0 1 5 3.25Zm0 5a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5A.75.75 0 0 1 5 8.25Zm0 5a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1-.75-.75ZM.924 10.32a.5.5 0 0 1-.851-.525l.001-.001.001-.002.002-.004.007-.011c.097-.144.215-.273.348-.384.228-.19.588-.392 1.068-.392.468 0 .858.181 1.126.484.259.294.377.673.377 1.038 0 .987-.686 1.495-1.156 1.845l-.047.035c-.303.225-.522.4-.654.597h1.357a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5c0-1.005.692-1.52 1.167-1.875l.035-.025c.531-.396.8-.625.8-1.078a.57.57 0 0 0-.128-.376C1.806 10.068 1.695 10 1.5 10a.658.658 0 0 0-.429.163.835.835 0 0 0-.144.153ZM2.003 2.5V6h.503a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1h.503V3.308l-.28.14a.5.5 0 0 1-.446-.895l1.003-.5a.5.5 0 0 1 .723.447Z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <textarea
+    className="textarea"
+    data-testid="textbox"
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDown={[Function]}
+    placeholder="Type something..."
+    value="Well done! Keep up the good work :)
+
+Info: there is a \`Array.prototype.reduceRight\` function which you could have used"
+  />
 </div>
 `;
 

--- a/stories/components/MdInput.stories.tsx
+++ b/stories/components/MdInput.stories.tsx
@@ -1,31 +1,64 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Story } from '@storybook/react'
 import { MdInput } from '../../components/MdInput'
-import { Button } from '../../components/theme/Button'
 
 export default {
   component: MdInput,
   title: 'Components/MdInput'
 }
 
-export const Basic: React.FC = () => <MdInput />
-
-export const White: React.FC = () => <MdInput bgColor={'white'} />
-
-export const _WithPresetValue: React.FC = () => {
-  return <MdInput bgColor={'white'} value="HinGa DIngA dUrgEN" />
+const Template: Story = (args: { presetValue?: string }) => {
+  const [commentValue, setCommentValue] = useState(args.presetValue || '')
+  return <MdInput value={commentValue} onChange={setCommentValue} {...args} />
 }
 
-export const _WithSubmissionButtons: React.FC = () => {
-  return (
-    <div>
-      <MdInput bgColor={'white'} />
-      <Button m="1" btnType="success" color="white">
-        Accept
-      </Button>
+export const Basic = Template.bind({})
 
-      <Button m="1" btnType="danger" color="white">
-        Reject
-      </Button>
-    </div>
-  )
+export const White = Template.bind({})
+White.args = {
+  bgColor: 'white',
+  presetValue:
+    'Did you notice the white background instead of the default light gray?'
+}
+
+export const WithPresetValue = Template.bind({})
+WithPresetValue.args = {
+  presetValue: `Well done! Keep up the good work :)
+
+Info: there is a \`Array.prototype.reduceRight\` function which you could have used`
+}
+
+export const WithMarkdownInput = Template.bind({})
+WithMarkdownInput.args = {
+  presetValue: `## This component supports [Markdown](https://www.markdownguide.org/)
+
+### Let's make a numbered list
+1. This is *item one*
+2. This is item two \`with some inline code\`
+3. Don't forget **item three**
+
+### Let's make a bullet list
+- Here's a list item
+- Another list item followed by a horizontal rule
+
+___
+
+## The text area expands with the size of the content
+
+You can attach an image too:
+
+![cute kitten](https://placekitten.com/200/300)`
+}
+
+export const WithHTMLStrings = Template.bind({})
+WithHTMLStrings.args = {
+  presetValue: `What does the Preview look like...
+
+... if I wrap the HTML in backticks?
+
+\`<div style="color: white; background-color: purple; >C0D3 C0D3 C0D3</div>\`
+
+... if I don't?
+
+<div style="color: white; background-color: purple; padding: 10px">C0D3 C0D3 C0D3</div>`
 }


### PR DESCRIPTION
### Overview
This PR fixes the broken input on the `MdInput` component's stories, and also add new stories.

The `MdInput`'s `value` and `onChange` props are passed from the parent component's state. The parent component is `ReviewCard`, and the `ReviewCard` stories **do** allow for user input in the MdInput component.

### Changes
- Added a [Template](https://storybook.js.org/docs/react/writing-stories/introduction#using-args) to the MdInput.stories.tsx file which has a state hook to mock the parent component state.
- Added a new stories, which better showcase how the component will render markdown input and HTML input.

### Notes
- Snapshots also updated.
- This PR replaces #2868

### Related issues
- Closes #2870