### PR TITLE
Fix malformed .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -220,6 +220,7 @@
         "code"
       ]
      },
+     {
       "login": "bryanjenningz",
       "name": "Bryan Jennings",
       "avatar_url": "https://avatars.githubusercontent.com/u/7637655?v=4",


### PR DESCRIPTION
Fix un matched `{` brace in `.all-contributors.rc` , malformed config preventing the all-contributors bot from working.

https://github.com/garageScript/c0d3-app/pull/2871#issuecomment-1493383731