### PR TITLE
fix: Calling a hook inside another hook

### DIFF
--- a/pages/review/[lesson].tsx
+++ b/pages/review/[lesson].tsx
@@ -39,8 +39,9 @@ const Review: React.FC<QueryDataProps<GetAppQuery>> = ({ queryData }) => {
   const slug = router.query.lesson as string
   const currentLesson = lessons.find(lesson => lesson.slug === slug)
 
+  redirectUnauthenticated(!session?.user)
+
   useEffect(() => {
-    redirectUnauthenticated(!session?.user)
     session && context.setContext(session)
   }, [session])
 

--- a/pages/settings/account/index.tsx
+++ b/pages/settings/account/index.tsx
@@ -276,9 +276,9 @@ const AccountSettings = () => {
   const unauthenticated = status === SessionStatus.Unauthenticated
   const { username, name, discordUsername } = data?.userInfo?.user || {}
 
-  useEffect(() => {
-    redirectUnauthenticated(unauthenticated)
+  redirectUnauthenticated(unauthenticated)
 
+  useEffect(() => {
     if (authenticated && session) {
       userInfoQuery({
         variables: {


### PR DESCRIPTION
## Problem

The [`redirectUnauthenticated`](https://github.com/garageScript/c0d3-app/blob/9428afe5b7d4b062d81f6e3fb02a8eb6113235d9/helpers/redirectUnauthenticated.ts) helper is used to redirect the user to the login page if they're unauthenticated. It uses the router API from the `useRouter` hook to push the path of the login page to the browser history. In the [settings page](https://github.com/garageScript/c0d3-app/blob/master/pages/settings/account/index.tsx#L279-L289C7) and the [review page](https://github.com/garageScript/c0d3-app/blob/master/pages/review/%5Blesson%5D.tsx#L42-L45), it's getting called inside a hook (`useEffect`). This breaks one of [React hook rules](https://legacy.reactjs.org/docs/hooks-rules.html) of not calling a hook inside another hook and causes a runtime error to occur.

## Changes

Move the helper `redirectUnauthenticated` outside of `useEffect`.

## Related issues

- #2865 