### PR TITLE
fix: Cannot update user names only

### DIFF
--- a/graphql/resolvers/userDataCrud.test.js
+++ b/graphql/resolvers/userDataCrud.test.js
@@ -35,6 +35,27 @@ describe('User Data CRUD resolvers', () => {
       ).resolves.toStrictEqual(userMock)
     })
 
+    it('Should update the user and names only', async () => {
+      expect.assertions(1)
+
+      const userMock = {
+        username: mockUsername,
+        name: mockName,
+        id: 1
+      }
+
+      prismaMock.user.update.mockResolvedValueOnce(userMock)
+      prismaMock.user.findFirst.mockResolvedValueOnce(userMock)
+
+      expect(
+        updateUserNames(
+          null,
+          { username: mockUsername, mockName },
+          { req: { user: { id: 1 } } }
+        )
+      ).resolves.toStrictEqual(userMock)
+    })
+
     it('Should not update the user username and name if username already used', async () => {
       expect.assertions(1)
 

--- a/graphql/resolvers/userDataCrud.ts
+++ b/graphql/resolvers/userDataCrud.ts
@@ -20,7 +20,7 @@ export const updateUserNames = withUserContainer<
     }
   })
 
-  if (usernameAlreadyUsed) {
+  if (usernameAlreadyUsed && usernameAlreadyUsed.id !== req?.user?.id) {
     throw new Error('Username is already used')
   }
 


### PR DESCRIPTION
## Problem

When the user goes to the settings page under `/settings/account` and tries to update their name only (first name/last name), they're not able to do so. This is because the server compares the username of the user with the username of the other user present in the database, and if they are the same, it assumes that it's a different user. As a result, the server doesn't allow the user to update their name.

### Changes

- Check if the user that's present in the database has the same username and a different ID than the user associated with the request. Now, the server will only throw an error if a user with the same username and different ID is found in the database.
- Add a new test case to handle the new changes

### Testing

1. Go to `/settings/account`
2. Update one of the names
3. Save changes / update
4. Notice how it successfully updates them without the need to also update the username

### Related issues

- #2877 