### PR TITLE
Fix overlapping act() calls error on `SubmissionComments.test.js`

### DIFF
--- a/components/SubmissionComments.test.js
+++ b/components/SubmissionComments.test.js
@@ -177,6 +177,7 @@ describe('Test SubmissionComments Component', () => {
     fireEvent.click(discardButton)
     expect(editButton).toBeInTheDocument()
   })
+
   it('should update comment when save changes button is clicked', async () => {
     const cache = new InMemoryCache({ addTypename: false })
 

--- a/components/SubmissionComments.test.js
+++ b/components/SubmissionComments.test.js
@@ -160,27 +160,22 @@ describe('Test SubmissionComments Component', () => {
 
     const editButton = container.querySelector('.btn-outline-info.btn-sm')
     fireEvent.click(editButton)
+    const discardButton = container.querySelector('.btn-light')
 
     await waitFor(() => {
-      const discardButton = container.querySelector('.btn-light')
       expect(discardButton).toBeInTheDocument()
       expect(container.querySelector('.btn-info')).toBeInTheDocument()
 
       const editButtonTwo = container.querySelector('.btn-outline-info.btn-sm')
       fireEvent.click(editButtonTwo)
-
-      const warningText =
-        'You can only edit one comment in a single comment chain at a time.'
-
-      waitFor(() => {
-        expect(findByText(warningText)).toBeTruthy()
-      })
-
-      fireEvent.click(discardButton)
-      waitFor(() => {
-        expect(editButton).toBeInTheDocument()
-      })
     })
+
+    const warningText =
+      'You can only edit one comment in a single comment chain at a time.'
+    expect(await findByText(warningText)).toBeTruthy()
+
+    fireEvent.click(discardButton)
+    expect(editButton).toBeInTheDocument()
   })
   it('should update comment when save changes button is clicked', async () => {
     const cache = new InMemoryCache({ addTypename: false })

--- a/components/SubmissionComments.test.js
+++ b/components/SubmissionComments.test.js
@@ -149,7 +149,7 @@ describe('Test SubmissionComments Component', () => {
       variables: { userId: 3, challengeId: 6 },
       data: { getPreviousSubmissions: submissionsData }
     })
-    expect.assertions(4)
+
     const { container, findByText } = render(
       <MockedProvider cache={cache} addTypename={false} mocks={mocks}>
         <Wrapper>
@@ -162,20 +162,22 @@ describe('Test SubmissionComments Component', () => {
     fireEvent.click(editButton)
     const discardButton = container.querySelector('.btn-light')
 
-    await waitFor(() => {
-      expect(discardButton).toBeInTheDocument()
-      expect(container.querySelector('.btn-info')).toBeInTheDocument()
+    expect(discardButton).toBeInTheDocument()
+    expect(container.querySelector('.btn-info')).toBeInTheDocument()
 
-      const editButtonTwo = container.querySelector('.btn-outline-info.btn-sm')
-      fireEvent.click(editButtonTwo)
-    })
+    const editButtonTwo = container.querySelector('.btn-outline-info.btn-sm')
+    fireEvent.click(editButtonTwo)
 
-    const warningText =
-      'You can only edit one comment in a single comment chain at a time.'
-    expect(await findByText(warningText)).toBeTruthy()
+    expect(
+      await findByText(
+        'You can only edit one comment in a single comment chain at a time.'
+      )
+    ).toBeTruthy()
 
     fireEvent.click(discardButton)
     expect(editButton).toBeInTheDocument()
+
+    expect.assertions(4)
   })
 
   it('should update comment when save changes button is clicked', async () => {


### PR DESCRIPTION
### Overview
When running the test suites, `SubmissionComments.test.js` logs two identical console errors:

<img width="708" alt="Screenshot 2023-04-05 at 10 56 45 AM" src="https://user-images.githubusercontent.com/121207468/230226035-6c26c597-b058-4ac1-bcfb-96c8df3a8275.png">

### Changes
- In the `it('should allow user to edit comment and discard changes when edit button is pressed, but not edit more than 1 comment in a chain', ... )` test, remove the unneccessary nested `waitFor()` calls.
- The `findByText()` gets an `await` keyword in front of it because it is async
- The test suite no longer logs errors on the console:

<img width="867" alt="Screenshot 2023-04-05 at 6 22 11 PM" src="https://user-images.githubusercontent.com/121207468/230226462-ae7e047f-dbbc-4cf9-8369-a39db90de424.png">

### Notes
- We can be certain all 4 tests are running because of `expects.assertions(4)`
- [Related conversation about overlapping act calls](https://github.com/testing-library/react-testing-library/issues/605), and needing to `await` the `findBy*` queries.