### PR TITLE
Fix bad setState call causing error in `pages/reset.test.js`

### DIFF
--- a/pages/confirm/[token].tsx
+++ b/pages/confirm/[token].tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { Formik, Form, Field } from 'formik'
 import Link from 'next/link'
@@ -53,14 +53,14 @@ export const ResetPassword = ({
     } catch {} // catch error thrown by default from apollo mutations
   }
 
-  if (confirmToken?.ok) {
-    return <ConfirmSuccess />
-  }
+  useEffect(() => {
+    if (confirmToken?.status === 401 && !confirmToken.error) {
+      onServerError()
+    }
+  })
 
-  if (confirmToken?.status === 401 && !confirmToken.error) {
-    onServerError()
-    return <></>
-  }
+  if (confirmToken?.ok) return <ConfirmSuccess />
+
   if (confirmToken?.error) return <ExpiredToken />
 
   return (


### PR DESCRIPTION
### Overview

When running the test suites, `pages/reset.test.js` logs a console error. This PR fixes the bad setState() call so that the error is fixed.

The error:
> Cannot update a component (`ResetPasswordContainer`) while rendering a different component (`ResetPassword`). To locate the bad setState() call inside `ResetPassword`, follow the stack trace ...

<img width="789" alt="Screenshot 2023-04-05 at 10 11 29 PM" src="https://user-images.githubusercontent.com/121207468/230258277-8305eb48-90f9-44a8-aeec-a9d3c41c8d34.png">

### Changes

- Wrap the setState() call (`setServerError()`) inside of a useEffect so that it runs *after* the `ResetPassword` component renders instead of *during* the render.
- The useEffect call is not given a 2nd argument. We want it to run every time `ResetPassword` renders.
- The "Cannot update a component while render a different component" error is fixed.

<img width="490" alt="Screenshot 2023-04-05 at 10 19 13 PM" src="https://user-images.githubusercontent.com/121207468/230259581-9d4b5f19-4dda-4db5-8bed-fdf2a9c1578f.png">

### Notes
- [Related conversation about this error](https://stackoverflow.com/questions/62336340/cannot-update-a-component-while-rendering-a-different-component-warning)