### PR TITLE
fix inconsistent font styles

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -28775,9 +28775,10 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
         className="col-md-10 offset-md-1"
       >
         <p
-          className="fw-light h4"
+          className="fw-light"
           style={
             Object {
+              "fontSize": "1.5rem",
               "lineHeight": 1.5,
             }
           }
@@ -28824,9 +28825,10 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
         className="col-md-10 offset-md-1"
       >
         <p
-          className="fw-light h4"
+          className="fw-light"
           style={
             Object {
+              "fontSize": "1.5rem",
               "lineHeight": 1.5,
             }
           }
@@ -28925,9 +28927,10 @@ exports[`Storyshots Pages/Landing Landing 1`] = `
         Your Learning Journey
       </h1>
       <p
-        className="mt-5 fw-light col-md-8 offset-md-2 pb-5 text-center h4"
+        className="mt-5 fw-light col-md-8 offset-md-2 pb-5 text-center"
         style={
           Object {
+            "fontSize": "1.5rem",
             "lineHeight": 1.5,
           }
         }

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -109,8 +109,8 @@ exports[`Index Page Should render index page 1`] = `
           class="col-md-10 offset-md-1"
         >
           <p
-            class="fw-light h4"
-            style="line-height: 1.5;"
+            class="fw-light"
+            style="line-height: 1.5; font-size: 1.5rem;"
           >
             Learn the right foundations you need to become a full stack software engineer. Our curriculum takes no shortcuts and effectively trains students with no technical background to become great software engineers.
           </p>
@@ -151,8 +151,8 @@ exports[`Index Page Should render index page 1`] = `
           class="col-md-10 offset-md-1"
         >
           <p
-            class="fw-light h4"
-            style="line-height: 1.5;"
+            class="fw-light"
+            style="line-height: 1.5; font-size: 1.5rem;"
           >
             Our learning process is interactive and follows the same practice as a well functioning engineering team. From the first line of code you write, you will be code reviewed by engineers to ensure you are always following industry best practices.
           </p>
@@ -240,8 +240,8 @@ exports[`Index Page Should render index page 1`] = `
           Your Learning Journey
         </h1>
         <p
-          class="mt-5 fw-light col-md-8 offset-md-2 pb-5 text-center h4"
-          style="line-height: 1.5;"
+          class="mt-5 fw-light col-md-8 offset-md-2 pb-5 text-center"
+          style="line-height: 1.5; font-size: 1.5rem;"
         >
           Our learning process is interactive and follows the same practice as a well functioning engineering team. From the first line of code you write, you will be code reviewed by engineers to ensure you are always following industry best practice
         </p>

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -25,7 +25,10 @@ const LandingPage: React.FC = () => {
         </div>
         <div className="row justify-center mt-4">
           <div className="col-md-10 offset-md-1">
-            <p style={{ lineHeight: 1.5 }} className="fw-light h4">
+            <p
+              style={{ lineHeight: 1.5, fontSize: '1.5rem' }}
+              className="fw-light"
+            >
               Learn the right foundations you need to become a full stack
               software engineer. Our curriculum takes no shortcuts and
               effectively trains students with no technical background to become
@@ -49,7 +52,10 @@ const LandingPage: React.FC = () => {
         </div>
         <div className="row mt-5">
           <div className="col-md-10 offset-md-1">
-            <p className="fw-light h4" style={{ lineHeight: 1.5 }}>
+            <p
+              style={{ lineHeight: 1.5, fontSize: '1.5rem' }}
+              className="fw-light"
+            >
               Our learning process is interactive and follows the same practice
               as a well functioning engineering team. From the first line of
               code you write, you will be code reviewed by engineers to ensure
@@ -116,8 +122,8 @@ const LandingPage: React.FC = () => {
             Your Learning Journey
           </h1>
           <p
-            className="mt-5 fw-light col-md-8 offset-md-2 pb-5 text-center h4"
-            style={{ lineHeight: 1.5 }}
+            className="mt-5 fw-light col-md-8 offset-md-2 pb-5 text-center"
+            style={{ lineHeight: 1.5, fontSize: '1.5rem' }}
           >
             Our learning process is interactive and follows the same practice as
             a well functioning engineering team. From the first line of code you


### PR DESCRIPTION
 ## Overview

This PR fixes an inconsistent UI issue raised in #2824:
 - Large paragraphs have `bold Rubik` font
 - Small paragraphs have `normal Inter` font

## Changes
- On the landing page (`components/LandingPage.tsx`)
  - remove the "h4" class on the `<p>` elements
  - add `fontSize: '1.5rem'` to styles of `<p>` elements that are associated with `<h1>` headings
    - the last `<p>` element on this page ("Become a full stack software engineer - 100% Free") already had this style
  - After these changes:
    - the font of the headings is `bold Rubik` (unchanged)
    - the font of all paragraph elements is `normal Inter`
  
### Before:
![Screenshot 2023-04-10 at 3 56 00 PM](https://user-images.githubusercontent.com/121207468/230999723-d47757ae-b948-4edb-a77f-d41da6001da7.png)
![Screenshot 2023-04-10 at 3 58 01 PM](https://user-images.githubusercontent.com/121207468/230999748-f274ec42-8ce2-41e1-872d-1b81e527587a.png)

### After:
![Screenshot 2023-04-10 at 3 55 41 PM](https://user-images.githubusercontent.com/121207468/230999780-9d03071d-6b01-4109-b8e2-ba0e0a2bc475.png)
![Screenshot 2023-04-10 at 3 58 16 PM](https://user-images.githubusercontent.com/121207468/230999792-e873e592-5d32-4ac5-ab9c-2ce05a383b46.png)


## Notes
- Closes #2824 