### PR TITLE
Bump yup from 0.32.11 to 1.1.1

### DIFF
--- a/helpers/admin/adminHelpers.ts
+++ b/helpers/admin/adminHelpers.ts
@@ -1,4 +1,4 @@
-import { reach, ValidationError } from 'yup'
+import { ISchema, reach, ValidationError } from 'yup'
 import _ from 'lodash'
 import { DROP_DOWN, TEXT_AREA, MD_INPUT } from '../../components/FormCard'
 
@@ -81,7 +81,9 @@ export const errorCheckSingleField = async (
   // title is the name of field being checked
   const { title } = properties[propertyIndex]
   try {
-    await reach(schema, title, null, null).validate(data[title])
+    await (reach(schema, title, null, null) as ISchema<{}>).validate(
+      data[title]
+    )
   } catch (err) {
     valid = false
     properties[propertyIndex].error = (err as Error).message

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "sass": "^1.62.0",
     "use-undo": "^1.1.1",
     "winston": "^3.8.2",
-    "yup": "^0.32.11"
+    "yup": "1.1.1"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,7 +1578,7 @@
     core-js-pure "^3.14.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.20.13", "@babel/runtime@^7.21.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.20.13", "@babel/runtime@^7.21.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -5045,7 +5045,7 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.167", "@types/lodash@^4.14.175", "@types/lodash@^4.14.194":
+"@types/lodash@^4.14.167", "@types/lodash@^4.14.194":
   version "4.14.194"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
   integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
@@ -13707,11 +13707,6 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoclone@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
-  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
-
 nanoid@^3.3.1, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
@@ -15041,10 +15036,10 @@ prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, 
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-property-expr@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
-  integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
+property-expr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
 
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"
@@ -17265,6 +17260,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
@@ -17577,6 +17577,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-fest@^2.5.2:
   version "2.8.0"
@@ -18722,18 +18727,15 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-yup@^0.32.11:
-  version "0.32.11"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
-  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
+yup@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.1.1.tgz#49dbcf5ae7693ed0a36ed08a9e9de0a09ac18e6b"
+  integrity sha512-KfCGHdAErqFZWA5tZf7upSUnGKuTOnsI3hUsLr7fgVtx+DK04NPV01A68/FslI4t3s/ZWpvXJmgXhd7q6ICnag==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@types/lodash" "^4.14.175"
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
-    nanoclone "^0.2.1"
-    property-expr "^2.0.4"
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
     toposort "^2.0.2"
+    type-fest "^2.19.0"
 
 zen-observable-ts@^0.8.21:
   version "0.8.21"


### PR DESCRIPTION
### Fix

Original PR: https://github.com/garageScript/c0d3-app/pull/2922

Cast the type from `Reference | ISchema` to `ISchema`. For some reason, the maintainers went from setting the type of `Schema.reach` from `any` to `Reference | ISchema` and this caused the error: 

```sh
Error: helpers/admin/adminHelpers.ts(84,44): error TS2339: Property 'validate' does not exist on type 'ISchema<any, any, any, any> | Reference<any>'.
  Property 'validate' does not exist on type 'Reference<any>'.
```

### Bot description

Bumps [yup](https://github.com/jquense/yup) from 0.32.11 to 1.1.1.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/jquense/yup/releases">yup's releases</a>.</em></p>
<blockquote>
<h2>v1 Because I finally got around to it</h2>
<p><a href="https://redirect.github.com/jquense/yup/issues/1906">jquense/yup#1906</a></p>
<h2>v1.0.0-beta.7</h2>
<p>Fixes published artifacts for the <code>main</code> field</p>
<h2>v1.0.0-beta.5 - partial fixes and cast migration path</h2>
<p>Beta 5 fixes <code>partial</code> and <code>deepPartial</code> making it work correctly with <code>lazy</code> schema. Specifically the optionality is added <em>after</em> lazy is evaluated but before any other <code>when</code> conditions are added. This makes it consistent with other conditional schema, where runtime conditions always supersede previous schema configuration. This allows for optional overrides if necessary.</p>
<pre lang="ts"><code>const person = object({
  name: string().required(),
  age: number().required(),
  legalGuardian:  string().when('age', {
    is: (age) =&gt; age != null &amp;&amp; age &lt; 18,
    then: (schema) =&gt; schema.required(),
  }),
});
<p>const optionalPerson = person.partial()</p>
<p>person.cast({name: 'James', age: 6 }) // =&gt; TypeError legalGuardian required</p>
<p>// age is still required b/c it's applied after the <code>partial</code>
optionalPerson.cast({name: 'James',  age: 6 }) // =&gt; TypeError legalGuardian required
</code></pre></p>
<p>This works slightly differently for <code>lazy</code> which have no schema to &quot;start&quot; with:</p>
<pre lang="ts"><code>const config = object({
  nameOrIdNumber:  lazy((value) =&gt; {
     if (typeof value === 'number') return number().required()
     return string().required()
  }),
});
<p>const opti = config.partial()</p>
<p>config.cast({}) // =&gt; TypeError nameOrIdNumber is required</p>
<p>config.partial().cast({}) // =&gt; {}
</code></pre></p>
<h2>Cast optionality migration path</h2>
<p>A larger breaking change in v1 is the assertion of optionality during <code>cast</code>, making previous patterns like <code>string().nullable().required()</code> no longer possible. Generally this pattern is used when deserialized data is not valid to start, but will become valid through user input such as with an HTML form. v1 no longer allows this, but in order to make migration easier we've added an option to <code>cast</code> that mimics the previous behavior (not exactly but closely).</p>
<pre lang="ts"><code>const name = string().required()
&lt;/tr&gt;&lt;/table&gt; 
</code></pre>
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/jquense/yup/blob/master/CHANGELOG.md">yup's changelog</a>.</em></p>
<blockquote>
<h2><a href="https://github.com/jquense/yup/compare/v1.1.0...v1.1.1">1.1.1</a> (2023-04-14)</h2>
<h3>Bug Fixes</h3>
<ul>
<li><strong>docs:</strong> Broken anchores (<a href="https://redirect.github.com/jquense/yup/issues/1979">#1979</a>) (<a href="https://github.com/jquense/yup/commit/4ed45762e955ac6af0dec935a91e815a5a1cf5b9">4ed4576</a>)</li>
<li>make null validation errors consistent across schema (<a href="https://redirect.github.com/jquense/yup/issues/1982">#1982</a>) (<a href="https://github.com/jquense/yup/commit/f99949747456d7bf55da3dd38dcf86bbddba3169">f999497</a>)</li>
<li><strong>object:</strong> excluded edges are merged when concating schema (<a href="https://github.com/jquense/yup/commit/c07b08f033be8eea00d74a5da1cf735cf97e69df">c07b08f</a>), closes <a href="https://redirect.github.com/jquense/yup/issues/1969">#1969</a></li>
</ul>
<h1><a href="https://github.com/jquense/yup/compare/v1.0.2...v1.1.0">1.1.0</a> (2023-04-12)</h1>
<h3>Bug Fixes</h3>
<ul>
<li>tuple describe() method (<a href="https://redirect.github.com/jquense/yup/issues/1947">#1947</a>) (<a href="https://github.com/jquense/yup/commit/297f1682296ee0b53e5e252477d5a6d7d82df707">297f168</a>)</li>
</ul>
<h3>Features</h3>
<ul>
<li>only resolve &quot;strip()&quot; for schema when used as an object field (<a href="https://redirect.github.com/jquense/yup/issues/1977">#1977</a>) (<a href="https://github.com/jquense/yup/commit/2ba1104798dcf3b9385997e5fbaa41b4d711472d">2ba1104</a>)</li>
<li>respect context for object's children (<a href="https://redirect.github.com/jquense/yup/issues/1971">#1971</a>) (<a href="https://github.com/jquense/yup/commit/edfe6acde9e11ec2bfe2ad41aad867daae7041ce">edfe6ac</a>)</li>
</ul>
<h2><a href="https://github.com/jquense/yup/compare/v1.0.0...v1.0.2">1.0.2</a> (2023-02-27)</h2>
<h3>Bug Fixes</h3>
<ul>
<li>fix array describe not including conditions (<a href="https://github.com/jquense/yup/commit/4040592ccd068ab71e06417b4d355007636cb78c">4040592</a>), closes <a href="https://redirect.github.com/jquense/yup/issues/1920">#1920</a></li>
</ul>
<h2><a href="https://github.com/jquense/yup/compare/v1.0.0...v1.0.1">1.0.1</a> (2023-02-25)</h2>
<h1><a href="https://github.com/jquense/yup/compare/v1.0.0-beta.8...v1.0.0">1.0.0</a> (2023-02-08)</h1>
<h3>Migrating from 0.x to 1.0.0: <a href="https://redirect.github.com/jquense/yup/issues/1906">#1906</a></h3>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/jquense/yup/commit/1086aa93fdd08a554936a409c30788058dbc7c32"><code>1086aa9</code></a> Publish v1.1.1</li>
<li><a href="https://github.com/jquense/yup/commit/11d860a37bb3a7329436404dca2b8a2d0de8b638"><code>11d860a</code></a> add test</li>
<li><a href="https://github.com/jquense/yup/commit/c07b08f033be8eea00d74a5da1cf735cf97e69df"><code>c07b08f</code></a> fix(object): excluded edges are merged when concating schema</li>
<li><a href="https://github.com/jquense/yup/commit/f99949747456d7bf55da3dd38dcf86bbddba3169"><code>f999497</code></a> fix: make null validation errors consistent across schema (<a href="https://redirect.github.com/jquense/yup/issues/1982">#1982</a>)</li>
<li><a href="https://github.com/jquense/yup/commit/4ed45762e955ac6af0dec935a91e815a5a1cf5b9"><code>4ed4576</code></a> fix(docs): Broken anchores (<a href="https://redirect.github.com/jquense/yup/issues/1979">#1979</a>)</li>
<li><a href="https://github.com/jquense/yup/commit/d8748732f6f4afbab271e427028525209623c5ac"><code>d874873</code></a> Publish v1.1.0</li>
<li><a href="https://github.com/jquense/yup/commit/2ba1104798dcf3b9385997e5fbaa41b4d711472d"><code>2ba1104</code></a> feat: only resolve &quot;strip()&quot; for schema when used as an object field (<a href="https://redirect.github.com/jquense/yup/issues/1977">#1977</a>)</li>
<li><a href="https://github.com/jquense/yup/commit/edfe6acde9e11ec2bfe2ad41aad867daae7041ce"><code>edfe6ac</code></a> feat: respect context for object's children (<a href="https://redirect.github.com/jquense/yup/issues/1971">#1971</a>)</li>
<li><a href="https://github.com/jquense/yup/commit/297f1682296ee0b53e5e252477d5a6d7d82df707"><code>297f168</code></a> fix: tuple describe() method (<a href="https://redirect.github.com/jquense/yup/issues/1947">#1947</a>)</li>
<li><a href="https://github.com/jquense/yup/commit/f37a53f45048eefe445c14b27b1b031583f9585d"><code>f37a53f</code></a> Publish v1.0.2</li>
<li>Additional commits viewable in <a href="https://github.com/jquense/yup/compare/v0.32.11...v1.1.1">compare view</a></li>
</ul>
</details>
<br />