### PR TITLE
deps: Upgrade next-connect from v0.13.0 to v1.0.0

### DIFF
--- a/__tests__/pages/api/graphql.test.js
+++ b/__tests__/pages/api/graphql.test.js
@@ -8,7 +8,8 @@ jest.mock('apollo-server-micro')
 jest.mock('next-connect')
 jest.mock('@quixo3/prisma-session-store')
 jest.mock('express-session')
-import nextConnect from 'next-connect'
+jest.mock('@sentry/nextjs')
+import { createRouter } from 'next-connect'
 import session from 'express-session'
 const asm = require('apollo-server-micro')
 
@@ -31,11 +32,12 @@ describe('Graphql Api', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    nextConnect.mockImplementation(() => {
+    createRouter.mockImplementation(() => {
       return {
         use: returnHandler,
         get: returnHandler,
-        post: returnHandler
+        post: returnHandler,
+        handler: () => {}
       }
     })
     asm.ApolloServer = function (data) {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "nanoid": "^3.3.4",
     "next": "12",
     "next-auth": "^4.22.1",
-    "next-connect": "^0.13.0",
+    "next-connect": "1.0.0",
     "next-mdx-remote": "^3.0.8",
     "nodemailer": "^6.9.1",
     "posthog-js": "^1.56.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,6 +4815,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@tsconfig/node16@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@types/accepts@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -13862,12 +13867,13 @@ next-auth@^4.22.1:
     preact-render-to-string "^5.1.19"
     uuid "^8.3.2"
 
-next-connect@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/next-connect/-/next-connect-0.13.0.tgz#dff835d2f5eab1f65503dae747dfef23c43020f0"
-  integrity sha512-f2G4edY01XomjCECSrgOpb/zzQinJO6Whd8Zds0+rLUYhj5cLwkh6FVvZsQCSSbxSc4k9nCwNuk5NLIhvO1gUA==
+next-connect@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-connect/-/next-connect-1.0.0.tgz#49361a92b2d22db1cce73f94dfe793cd4b9e0106"
+  integrity sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==
   dependencies:
-    trouter "^3.2.0"
+    "@tsconfig/node16" "^1.0.3"
+    regexparam "^2.0.1"
 
 next-mdx-remote@^3.0.8:
   version "3.0.8"
@@ -15717,10 +15723,10 @@ regexp.prototype.flags@^1.4.3:
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
 
-regexparam@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/regexparam/-/regexparam-1.3.0.tgz#2fe42c93e32a40eff6235d635e0ffa344b92965f"
-  integrity sha512-6IQpFBv6e5vz1QAqI+V4k8P2e/3gRrqfCJ9FI+O1FLQTO+Uz6RXZEZOPmTJ6hlGj7gkERzY5BRCv09whKP96/g==
+regexparam@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexparam/-/regexparam-2.0.1.tgz#c912f5dae371e3798100b3c9ce22b7414d0889fa"
+  integrity sha512-zRgSaYemnNYxUv+/5SeoHI0eJIgTL/A2pUtXUPLHQxUldagouJ9p+K6IbIZ/JiQuCEv2E2B1O11SjVQy3aMCkw==
 
 regexpp@^3.1.0:
   version "3.2.0"
@@ -17541,13 +17547,6 @@ trough@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.0.2.tgz#94a3aa9d5ce379fc561f6244905b3f36b7458d96"
   integrity sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w==
-
-trouter@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/trouter/-/trouter-3.2.0.tgz#a9c510fce21b8e659a28732c9de9d82871efe8df"
-  integrity sha512-rLLXbhTObLy2MBVjLC+jTnoIKw99n0GuJs9ov10J870vDw5qhTurPzsDrudNtBf5w/CZ9ctZy2p2IMmhGcel2w==
-  dependencies:
-    regexparam "^1.3.0"
 
 ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
### Changes

Fixes https://github.com/garageScript/c0d3-app/pull/2959 by refactoring the code to use the new API methods.

### Original PR

Bumps [next-connect](https://github.com/hoangvvo/next-connect) from 0.13.0 to 1.0.0.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/hoangvvo/next-connect/releases">next-connect's releases</a>.</em></p>
<blockquote>
<h2>v1.0.0</h2>
<p>Published v1</p>
<h2>v1.0.0-next.4</h2>
<h2>What's Changed</h2>
<ul>
<li>fix: correct clone() type by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://github.com/hoangvvo/next-connect/commit/da2a5b19b471a8ff893825c6f7e03fba26617ed8">https://github.com/hoangvvo/next-connect/commit/da2a5b19b471a8ff893825c6f7e03fba26617ed8</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/hoangvvo/next-connect/compare/v1.0.0-next.3...v1.0.0-next.4">https://github.com/hoangvvo/next-connect/compare/v1.0.0-next.3...v1.0.0-next.4</a></p>
<h2>v1.0.0-next.3</h2>
<h2>What's Changed</h2>
<ul>
<li>router class rearchitecture by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/207">hoangvvo/next-connect#207</a></li>
<li>feat: add expressWrapper util by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/208">hoangvvo/next-connect#208</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/hoangvvo/next-connect/compare/v1.0.0-next.2...v1.0.0-next.3">https://github.com/hoangvvo/next-connect/compare/v1.0.0-next.2...v1.0.0-next.3</a></p>
<h2>v1.0.0-next.2</h2>
<h2>What's Changed</h2>
<ul>
<li>Edge Runtime Router by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/200">hoangvvo/next-connect#200</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/hoangvvo/next-connect/compare/v1.0.0-next.1...v1.0.0-next.2">https://github.com/hoangvvo/next-connect/compare/v1.0.0-next.1...v1.0.0-next.2</a></p>
<h2>v1.0.0-next.1</h2>
<h2>What's Changed</h2>
<ul>
<li>security: always return generic 500 error by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/197">hoangvvo/next-connect#197</a></li>
<li>Always attach req.params by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/198">hoangvvo/next-connect#198</a></li>
<li>Add benchmark and update readme by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/199">hoangvvo/next-connect#199</a></li>
</ul>
<p><strong>Full Changelog</strong>: <a href="https://github.com/hoangvvo/next-connect/compare/v1.0.0-next.0...v1.0.0-next.1">https://github.com/hoangvvo/next-connect/compare/v1.0.0-next.0...v1.0.0-next.1</a></p>
<h2>v1.0.0-next.0</h2>
<p>This is the rewrite of next-connect. Most APIs may not be backward-compatible.</p>
<ul>
<li><strong>breaking</strong>: Drop built-in support for Express.js middleware. You can always create a <em>tiny</em> wrapper function to maintain this functionality. <a href="https://github.com/hoangvvo/next-connect#expressjs-compatibility">https://github.com/hoangvvo/next-connect#expressjs-compatibility</a>
<ul>
<li>Remove <code>next(err)</code> pattern</li>
</ul>
</li>
<li><strong>improvement</strong> More straight-forward implementation and avoid patchy solutions. Now the handler will resolve based on pure promise resolution. One should expect a boost in perf as well.</li>
<li><strong>feature</strong> Async middleware paradigm like Koa</li>
</ul>
<pre lang="js"><code>router
  .use(async (req, res, next) =&gt; {
    const start = Date.now();
    await next(); // call next in chain
    const end = Date.now();
    console.log(`Request took ${end - start}ms`);
  })
  .use(authy)
  .use(databasey)
&lt;/tr&gt;&lt;/table&gt; 
</code></pre>
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/hoangvvo/next-connect/blob/main/CHANGELOG.md">next-connect's changelog</a>.</em></p>
<blockquote>
<h1>Changelog</h1>
<h2>1.0.0-next.4</h2>
<ul>
<li>fix: correct clone() type by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://github.com/hoangvvo/next-connect/commit/da2a5b19b471a8ff893825c6f7e03fba26617ed8">https://github.com/hoangvvo/next-connect/commit/da2a5b19b471a8ff893825c6f7e03fba26617ed8</a></li>
</ul>
<h2>1.0.0-next.3</h2>
<ul>
<li>router class rearchitecture by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/207">hoangvvo/next-connect#207</a></li>
<li>feat: add expressWrapper util by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/208">hoangvvo/next-connect#208</a></li>
</ul>
<h2>1.0.0-next.2</h2>
<ul>
<li>Edge Runtime Router by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/200">hoangvvo/next-connect#200</a></li>
</ul>
<h2>1.0.0-next.1</h2>
<ul>
<li>security: always return generic 500 error by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/197">hoangvvo/next-connect#197</a></li>
<li>Always attach req.params by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/198">hoangvvo/next-connect#198</a></li>
<li>Add benchmark and update readme by <a href="https://github.com/hoangvvo"><code>@​hoangvvo</code></a> in <a href="https://redirect.github.com/hoangvvo/next-connect/pull/199">hoangvvo/next-connect#199</a></li>
</ul>
<h2>1.0.0-next.0</h2>
<p>See <a href="https://github.com/hoangvvo/next-connect/releases/tag/v1.0.0-next.0">https://github.com/hoangvvo/next-connect/releases/tag/v1.0.0-next.0</a>.</p>
<h2>0.12.2</h2>
<ul>
<li>Add back next() in error handler</li>
</ul>
<h2>0.12.1</h2>
<ul>
<li>breaking: flow change: handle() does not use onError (ad857bedb0996312ad3a5ea966ce3a60417429a6)</li>
<li>fix: make sure handler is resolvable (<a href="https://redirect.github.com/hoangvvo/next-connect/issues/178">#178</a>)</li>
</ul>
<h2>0.11.1</h2>
<ul>
<li>Bump deps and switch to NPM</li>
<li>typescript: added export for types (<a href="https://redirect.github.com/hoangvvo/next-connect/issues/176">#176</a>)</li>
</ul>
<h2>0.11.0</h2>
<ul>
<li>Allow regular expressions to be used for route. (<a href="https://redirect.github.com/hoangvvo/next-connect/issues/157">#157</a>)</li>
</ul>
<h2>0.10.2</h2>
<ul>
<li>Export the options interface (<a href="https://redirect.github.com/hoangvvo/next-connect/issues/152">#152</a>)</li>
</ul>
<h2>0.10.1</h2>
<ul>
<li>Make NextConnect compatible with NextApiHandler (<a href="https://redirect.github.com/hoangvvo/next-connect/issues/128">#128</a>)</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/hoangvvo/next-connect/commit/3741ae68416242b054c6eb774861cc827935715c"><code>3741ae6</code></a> Published as 1.0.0</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/2f675bba2029e1fc0f3d25d418895fbc26367126"><code>2f675bb</code></a> 1.0.0-next.4</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/fc88bd96aac681b5c565fd684a093b4e98e3e3f5"><code>fc88bd9</code></a> Update CHANGELOG.md</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/da2a5b19b471a8ff893825c6f7e03fba26617ed8"><code>da2a5b1</code></a> fix: correct clone() type</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/594cc6c326f34c7384ca06caa7d0a3580f6f9d89"><code>594cc6c</code></a> add nextjs 13 app router example</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/22a29250b2f26c7594707910e652252f116fdf27"><code>22a2925</code></a> chore: update README</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/5a37f19c077bf9a15c09594f7fee0cbc3065b0d8"><code>5a37f19</code></a> chore: update README and example</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/1bbaa402ff8d981024c5ab48db26a77024c90e9b"><code>1bbaa40</code></a> chore: bump dependencies</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/e5ac7faf380a73114a2b6b07b0a43a01f8c1be36"><code>e5ac7fa</code></a> 1.0.0-next.3</li>
<li><a href="https://github.com/hoangvvo/next-connect/commit/8596b7d99a0bb639f467ad29ecd131b19c0dea7c"><code>8596b7d</code></a> Add Examples</li>
<li>Additional commits viewable in <a href="https://github.com/hoangvvo/next-connect/compare/v0.13.0...v1.0.0">compare view</a></li>
</ul>
</details>
<br />