### PR TITLE
feat(settings/account): Show a meaningful msg on query error

### DIFF
--- a/constants/error-messages.ts
+++ b/constants/error-messages.ts
@@ -1,0 +1,3 @@
+export enum ErrorMsg {
+  RetrieveInfo = 'We encountered an issue while retrieving your information. Please try again.'
+}

--- a/pages/settings/account/index.tsx
+++ b/pages/settings/account/index.tsx
@@ -268,7 +268,7 @@ const LinkedAccountsSetting = ({
 
 const AccountSettings = () => {
   const { data: session, status } = useSession() as SessionContext
-  const [userInfoQuery, { data, loading: userInfoLoading }] =
+  const [userInfoQuery, { data, loading: userInfoLoading, error }] =
     useUserInfoLazyQuery()
 
   const loading = userInfoLoading || status === SessionStatus.Loading
@@ -298,6 +298,17 @@ const AccountSettings = () => {
       <div className={styles.container}>
         <div className={styles.container__child}>
           <h1>Settings</h1>
+          <QueryInfo
+            data={null}
+            loading={false}
+            error={error?.message || ''}
+            texts={{
+              loading: '',
+              data: '',
+              error:
+                'Oops, something went wrong when getting your info. Please try again'
+            }}
+          />
           <hr className="mb-4" />
           <div className={styles.container__sections}>
             <BasicSettings username={username} name={name} />

--- a/pages/settings/account/index.tsx
+++ b/pages/settings/account/index.tsx
@@ -25,6 +25,7 @@ import { SessionContext } from '../../../@types/auth'
 import { SessionStatus } from '../../../constants/auth-constants'
 import { useRouter } from 'next/router'
 import redirectUnauthenticated from '../../../helpers/redirectUnauthenticated'
+import { ErrorMsg } from '../../../constants/error-messages'
 
 const basicValues: (
   username?: string,
@@ -305,8 +306,7 @@ const AccountSettings = () => {
             texts={{
               loading: '',
               data: '',
-              error:
-                'Oops, something went wrong when getting your info. Please try again'
+              error: ErrorMsg.RetrieveInfo
             }}
           />
           <hr className="mb-4" />


### PR DESCRIPTION
## Changes

The `useUserInfoLazyQuery` hook has been modified to include an `error` property in its response object, which is then passed to `QueryInfo` to display any error messages. The `AccountSettings` component has also been updated to include the `QueryInfo` component.

These changes aim to improve the user experience by providing better feedback when there are issues with retrieving user information.