### PR TITLE
feat: Send a notification to reviewers on new comment

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+# #!/bin/sh
+# . "$(dirname "$0")/_/husky.sh"
 
-npm run type-check && npm test
+# npm run type-check && npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
-# #!/bin/sh
-# . "$(dirname "$0")/_/husky.sh"
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
 
-# npm run type-check && npm test
+npm run type-check && npm test

--- a/__tests__/pages/exercises/[lessonSlug].test.js
+++ b/__tests__/pages/exercises/[lessonSlug].test.js
@@ -1,5 +1,10 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import {
+  render,
+  screen,
+  fireEvent,
+  waitForElementToBeRemoved
+} from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Exercises from '../../../pages/exercises/[lessonSlug]'
 import { useRouter } from 'next/router'
@@ -342,6 +347,11 @@ describe('Exercises page', () => {
       </MockedProvider>
     )
 
-    await screen.findByText('Loading...')
+    // there are two spinners, one from withQueryLoader, another from useRouter, so we need to wait to test the second one
+    expect(
+      await waitForElementToBeRemoved(() => screen.queryByText('Loading...'), {
+        onTimeout: () => {}
+      })
+    ).toBeNull()
   })
 })

--- a/graphql/resolvers/addComment.test.js
+++ b/graphql/resolvers/addComment.test.js
@@ -118,10 +118,10 @@ describe('Should send required discord notifications', () => {
       ...mockAddCommentArgs
     })
 
-    // tests sending notification if the author ID is different from the comment author ID
+    // tests sending notification if the author ID is different from the comment author ID & submission author ID
     prismaMock.comment.findMany.mockResolvedValue([
       commentMock,
-      { ...commentMock, author: { ...commentMock.author, id: 2 } }
+      { ...commentMock, author: { ...commentMock.author, id: 3 } }
     ])
 
     await addComment({}, mockAddCommentArgs, mockCtx)

--- a/graphql/resolvers/addComment.test.js
+++ b/graphql/resolvers/addComment.test.js
@@ -111,13 +111,19 @@ describe('Should send required discord notifications', () => {
     await addComment({}, mockAddCommentArgs, mockCtx)
     expect(sendDirectMessage).not.toBeCalled()
   })
-  test('Should send a message embed to user with comment notification', async () => {
+  test('Should send a message embed to user with comment notification and send to all participants', async () => {
     prismaMock.comment.create.mockResolvedValue({
       author: authorMock,
       submission: submissionMock,
       ...mockAddCommentArgs
     })
-    prismaMock.comment.findMany.mockResolvedValue([commentMock])
+
+    // tests sending notification if the author ID is different from the comment author ID
+    prismaMock.comment.findMany.mockResolvedValue([
+      commentMock,
+      { ...commentMock, author: { ...commentMock.author, id: 2 } }
+    ])
+
     await addComment({}, mockAddCommentArgs, mockCtx)
     const mockEmbed = {
       color: PRIMARY_COLOR_HEX,

--- a/graphql/resolvers/addComment.ts
+++ b/graphql/resolvers/addComment.ts
@@ -54,7 +54,8 @@ const sendNotifications = async ({
           discordId: true
         }
       }
-    }
+    },
+    distinct: ['authorId']
   })
 
   const { submission, author } = comment

--- a/graphql/resolvers/addComment.ts
+++ b/graphql/resolvers/addComment.ts
@@ -46,8 +46,13 @@ const sendNotifications = async ({
       submissionId,
       fileName
     },
-    include: {
-      author: true
+    select: {
+      author: {
+        select: {
+          id: true,
+          discordId: true
+        }
+      }
     }
   })
 

--- a/graphql/resolvers/addComment.ts
+++ b/graphql/resolvers/addComment.ts
@@ -116,7 +116,7 @@ const sendNotifications = async ({
         const isSubmissionAuthor = participant.author.id === submission.user.id
         const hasDiscordId = participant.author.discordId
 
-        if ((!isCommentAuthor || !isSubmissionAuthor) && hasDiscordId) {
+        if (!isCommentAuthor && !isSubmissionAuthor && hasDiscordId) {
           acc.push(
             sendDirectMessage(
               participant.author.discordId,

--- a/graphql/resolvers/addComment.ts
+++ b/graphql/resolvers/addComment.ts
@@ -116,17 +116,15 @@ const sendNotifications = async ({
         const isSubmissionAuthor = participant.author.id === submission.user.id
         const hasDiscordId = participant.author.discordId
 
-        if (isCommentAuthor || isSubmissionAuthor || !hasDiscordId) {
-          return acc
-        }
-
-        acc.push(
-          sendDirectMessage(
-            participant.author.discordId,
-            '',
-            notificationEmbed(false)
+        if ((!isCommentAuthor || !isSubmissionAuthor) && hasDiscordId) {
+          acc.push(
+            sendDirectMessage(
+              participant.author.discordId,
+              '',
+              notificationEmbed(false)
+            )
           )
-        )
+        }
 
         return acc
       },

--- a/graphql/resolvers/addComment.ts
+++ b/graphql/resolvers/addComment.ts
@@ -107,7 +107,7 @@ const sendNotifications = async ({
   }
 
   // sends a notification to all of those who commented on
-  // the same submission line except the comment author
+  // the same submission line except the comment author and the student who made the submission
   const sendNotificationsToParticipants = async () => {
     const notifications = restOfComments.reduce(
       (acc: Promise<MessageResponse>[], participant) => {

--- a/graphql/resolvers/addComment.ts
+++ b/graphql/resolvers/addComment.ts
@@ -59,12 +59,12 @@ const sendNotifications = async ({
 
   const { submission, author } = comment
 
-  const notificationEmbed = (isSubmissionOwner: boolean): APIEmbed => {
+  const notificationEmbed = (forSubmissionOwner: boolean): APIEmbed => {
     const params = {
-      title: isSubmissionOwner
+      title: forSubmissionOwner
         ? `New comment by a reviewer on submission`
         : `New comment on submission`,
-      description: isSubmissionOwner
+      description: forSubmissionOwner
         ? 'commented on your submission to the'
         : 'added a comment on'
     }

--- a/graphql/resolvers/addComment.ts
+++ b/graphql/resolvers/addComment.ts
@@ -1,5 +1,5 @@
 import prisma from '../../prisma'
-import { MutationAddCommentArgs } from '../index'
+import { InputMaybe, MutationAddCommentArgs } from '../index'
 import { Context } from '../../@types/helpers'
 import { getDiscordMessageUserIdString } from '../../helpers/getDiscordMessageUserIdString'
 import { sendDirectMessage } from '../../helpers/discordBot'
@@ -11,6 +11,129 @@ import {
   PRIMARY_COLOR_HEX,
   PROFILE_URL
 } from '../../constants'
+import { Challenge, Comment, Lesson, Submission, User } from '@prisma/client'
+
+type CommentWithAuthorAndSubmission = Comment & {
+  author: {
+    id: number
+    username: string
+    discordId: string | null
+    name: string
+  }
+  submission: Submission & {
+    user: { id: number; username: string; discordId: string | null }
+    lesson: Lesson
+    challenge: Challenge
+  }
+}
+
+type SendNotificationsParams = {
+  line: InputMaybe<number> | undefined
+  fileName: InputMaybe<string> | undefined
+  submissionId: number
+  comment: CommentWithAuthorAndSubmission
+}
+
+const sendNotifications = async ({
+  line,
+  submissionId,
+  fileName,
+  comment
+}: SendNotificationsParams) => {
+  const restOfComments = await prisma.comment.findMany({
+    where: {
+      line,
+      submissionId,
+      fileName
+    },
+    include: {
+      author: true
+    }
+  })
+
+  const [uniqueParticipants] = restOfComments?.reduce(
+    (
+      acc: [(Comment & { author: User })[], { [key: string]: boolean }],
+      e: Comment & { author: User }
+    ) => {
+      const [arr, map] = acc
+
+      if (!map[e.authorId]) {
+        arr.push(e)
+        map[e.authorId] = true
+      }
+
+      return acc
+    },
+    [[], {}]
+  )
+
+  const { submission, author } = comment
+
+  const notificationEmbed = (isSubmissionOwner: boolean): APIEmbed => {
+    const params = {
+      title: isSubmissionOwner
+        ? `New comment by a reviewer on submission`
+        : `New comment on submission`,
+      description: isSubmissionOwner
+        ? 'commented on your submission to the'
+        : 'added a comment on'
+    }
+
+    return {
+      color: PRIMARY_COLOR_HEX,
+      title: params.title,
+      url: `${CURRICULUM_URL}/${submission.lesson.slug}`,
+      thumbnail: {
+        url: getLessonCoverPNG(submission.lesson.order)
+      },
+      author: {
+        name: author.name,
+        url: `${PROFILE_URL}/${author.username}`,
+        icon_url: C0D3_ICON_URL
+      },
+      description: `${getDiscordMessageUserIdString(author)} ${
+        params.description
+      } challenge **${submission.challenge.title}**${
+        comment.line ? ` on **Line ${comment.line}**` : ''
+      }.`,
+      fields: [
+        {
+          name: 'Comment',
+          value: comment.content
+        }
+      ]
+    }
+  }
+
+  // sends a notification to the submission author
+  if (author.id !== submission.user.id && submission.user.discordId) {
+    await sendDirectMessage(
+      submission.user.discordId,
+      '',
+      notificationEmbed(true)
+    )
+  }
+
+  // sends a notification to all of those who commented on
+  // the same submission line except the comment author
+  uniqueParticipants.forEach(participant => {
+    if (
+      participant.author.id !== author.id ||
+      participant.author.id === submission.user.id
+    ) {
+      return
+    }
+
+    if (participant.author.discordId) {
+      sendDirectMessage(
+        participant.author.discordId,
+        '',
+        notificationEmbed(false)
+      )
+    }
+  })
+}
 
 export const addComment = async (
   _parent: void,
@@ -54,36 +177,12 @@ export const addComment = async (
     }
   })
 
-  const { author, submission } = comment
-
-  if (author.id !== submission.user.id && submission.user.discordId) {
-    const notificationEmbed: APIEmbed = {
-      color: PRIMARY_COLOR_HEX,
-      title: 'New comment on submission',
-      url: `${CURRICULUM_URL}/${submission.lesson.slug}`,
-      thumbnail: {
-        url: getLessonCoverPNG(submission.lesson.order)
-      },
-      author: {
-        name: author.name,
-        url: `${PROFILE_URL}/${author.username}`,
-        icon_url: C0D3_ICON_URL
-      },
-      description: `${getDiscordMessageUserIdString(
-        author
-      )} commented on your submission to the challenge **${
-        submission.challenge.title
-      }**${comment.line ? ` on **Line ${comment.line}**` : ''}.`,
-      fields: [
-        {
-          name: 'Comment',
-          value: comment.content
-        }
-      ]
-    }
-
-    await sendDirectMessage(submission.user.discordId, '', notificationEmbed)
-  }
+  await sendNotifications({
+    line,
+    fileName,
+    submissionId,
+    comment: comment
+  })
 
   return comment
 }

--- a/graphql/resolvers/addComment.ts
+++ b/graphql/resolvers/addComment.ts
@@ -111,22 +111,21 @@ const sendNotifications = async ({
   const sendNotificationsToParticipants = async () => {
     const notifications = restOfComments.reduce(
       (acc: Promise<MessageResponse>[], participant) => {
-        if (
-          participant.author.id !== author.id ||
-          participant.author.id === submission.user.id
-        ) {
+        const isCommentAuthor = participant.author.id === author.id
+        const isSubmissionAuthor = participant.author.id === submission.user.id
+        const hasDiscordId = participant.author.discordId
+
+        if (isCommentAuthor || isSubmissionAuthor || !hasDiscordId) {
           return acc
         }
 
-        if (participant.author.discordId) {
-          acc.push(
-            sendDirectMessage(
-              participant.author.discordId,
-              '',
-              notificationEmbed(false)
-            )
+        acc.push(
+          sendDirectMessage(
+            participant.author.discordId,
+            '',
+            notificationEmbed(false)
           )
-        }
+        )
 
         return acc
       },


### PR DESCRIPTION
## Overview

Currently, when a student receives a comment from a reviewer on their submission and attempts to reply to it, the reviewer doesn't get a notification. This behavior introduces difficulty in communication between the student and the reviewer, as the reviewer's only way to find out about the new comments by the student is to frequently visit the website. It can quickly degrade productivity for both the student who is trying to learn and the reviewers who are trying to teach.

### Solution

Send a notification to all the people who wrote a comment on a certain submission's line except the comment author.

## Missing requirements

> comment section: comment(s) under a certain line in a submission

There are some things this PR does not introduce that are crucial for having an ideal notification system.

1. Participants in a comment section can't opt out of receiving notifications about it.
2. Participants cannot reply to or mention a user in a specific comment.

These shall be addressed in the project of adding a notification system (I could not find the issue for this project, but it did exist). @SlyBouhafs, any references?

### Changes

- Export the logic for sending a notification to a function in the `addComment` resolver.
- Update the logic of sending a notification to send multiple ones by querying all the users who comment on a certain line or submission and sending a notification to them as long as they have a Discord ID.
- Update the message. Discord embedding has two versions. One is for the reviewers, and the other is for the student.

### Unrelated changes

These changes are not related to this PR, but they were required in order for the CI/CD to pass

- Fix the flaky test in the `exercises/[lessonSlug].tsx` page by waiting for the router to be ready

## Ideal solution

I believe this is not the ideal solution because sending simultaneous requests to our Discord bot server could overload the server and, by extension, slow down the server for other users. As of now, we don't have a lot of active users, and the comment section is almost always 1:1.

## Related PR

- #2849 