### PR TITLE
Update elements to use Inter font

### DIFF
--- a/scss/_text.module.scss
+++ b/scss/_text.module.scss
@@ -33,6 +33,11 @@ p {
   line-height: 160%;
 }
 
+li,
+span {
+  font-family: 'Inter';
+}
+
 code,
 kbd,
 pre,

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -67,11 +67,6 @@ html {
   }
 }
 
-p {
-  line-height: 1.6;
-  font-size: 15px;
-}
-
 .text-danger {
   color: #721c24 !important;
 }


### PR DESCRIPTION
### Changes

- li and span elements to use `Inter` font
- Remove redundant `p` ruleset in the `index.scss` file

### Issues

I encountered an issue while attempting to set the html and body elements to use the Inter font. Despite expecting the styles to cascade and override the Bootstrap styles, they were being overwritten by Bootstrap. As a potential solution, we can manually select and apply the necessary Bootstrap modules instead of including the entire library. However, implementing this approach would require significant modifications to our application's CSS, as our app and Bootstrap are tightly coupled.

### Related PRs

- Closes #2820 