### PR TITLE
feat: Add a message indicating there are no exercises

### DIFF
--- a/pages/curriculum/[lessonSlug]/mentor/index.tsx
+++ b/pages/curriculum/[lessonSlug]/mentor/index.tsx
@@ -15,6 +15,7 @@ import styles from '../../../../scss/exercises.module.scss'
 import LessonTabs from '../../../../components/LessonTabs'
 import { LessonTab } from '../../../../components/LessonTabs/LessonTabs'
 import { ApolloQueryResult } from '@apollo/client'
+import Alert from '../../../../components/Alert'
 
 type ExerciseLesson = {
   title: string
@@ -134,6 +135,15 @@ const ExerciseList = ({
           </NewButton>
         </div>
       </div>
+      {!exercises.length && (
+        <Alert
+          alert={{
+            id: 0,
+            text: 'You have not created any exercises.',
+            type: 'info'
+          }}
+        />
+      )}
       <div className={styles.exerciseList__container}>
         {exercises.map((exercise, i) => (
           <ExercisePreviewCard

--- a/pages/curriculum/[lessonSlug]/mentor/index.tsx
+++ b/pages/curriculum/[lessonSlug]/mentor/index.tsx
@@ -139,7 +139,7 @@ const ExerciseList = ({
         <Alert
           alert={{
             id: 0,
-            text: 'You have not created any exercises.',
+            text: 'Sorry, but it seems like you have not created any exercises.',
             type: 'info'
           }}
         />


### PR DESCRIPTION
### Changes

- Add a message to the mentor page `/curriculum/mentor` to indicate that the user didn't create any exercises

### Screenshot

![image](https://github.com/garageScript/c0d3-app/assets/35906419/21506032-ba83-4d10-b88d-49e8f177420f)

## Related PRs

- Closes #2677 