### PR TITLE
fix: Multiple dropdown items are active

### DIFF
--- a/components/ProfileDropdownMenu/ProfileDropdownMenu.tsx
+++ b/components/ProfileDropdownMenu/ProfileDropdownMenu.tsx
@@ -100,7 +100,7 @@ const ProfileDropdownMenu: React.FC<ProfileDropDownMenuProps> = ({
           </Dropdown.Item>
           <Dropdown.Item
             className={`${styles['dropdown-item']} `}
-            bsPrefix={isActive(userProfilePath)}
+            bsPrefix={isActive(SETTINGS_ACCOUNT_PATH)}
             href={SETTINGS_ACCOUNT_PATH}
           >
             Settings


### PR DESCRIPTION
### Changes

- Make the Settings page dropdown item active based on the settings page path instead of the profile page path


### Related PRs

- Closes #3026
