### PR TITLE
Add the ability to link challenges and submissions

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -15926,11 +15926,42 @@ exports[`Storyshots Components/ReviewCard Active Card 1`] = `
           fake user
            -
            
-          <span
-            className="text-primary"
+          <a
+            className="text-primary text-decoration-none"
+            href="/curriculum/undefined?challenge=undefined"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onTouchStart={[Function]}
+            target="_blank"
           >
-            fake challenge
-          </span>
+            <div
+              className="d-inline-flex gap-1"
+            >
+              fake challenge
+              <svg
+                aria-hidden="true"
+                className="octicon octicon-link-external"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                role="img"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "overflow": "visible",
+                    "userSelect": "none",
+                    "verticalAlign": "text-bottom",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <path
+                  d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                />
+              </svg>
+            </div>
+          </a>
         </h4>
         <div
           style={
@@ -17355,11 +17386,42 @@ exports[`Storyshots Components/ReviewCard No Last Name 1`] = `
           fake user
            -
            
-          <span
-            className="text-primary"
+          <a
+            className="text-primary text-decoration-none"
+            href="/curriculum/undefined?challenge=undefined"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onTouchStart={[Function]}
+            target="_blank"
           >
-            fake challenge
-          </span>
+            <div
+              className="d-inline-flex gap-1"
+            >
+              fake challenge
+              <svg
+                aria-hidden="true"
+                className="octicon octicon-link-external"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                role="img"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "overflow": "visible",
+                    "userSelect": "none",
+                    "verticalAlign": "text-bottom",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <path
+                  d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                />
+              </svg>
+            </div>
+          </a>
         </h4>
         <div
           style={
@@ -18782,11 +18844,42 @@ exports[`Storyshots Components/ReviewCard With Long Comment 1`] = `
           fake user
            -
            
-          <span
-            className="text-primary"
+          <a
+            className="text-primary text-decoration-none"
+            href="/curriculum/undefined?challenge=undefined"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onTouchStart={[Function]}
+            target="_blank"
           >
-            fake challenge
-          </span>
+            <div
+              className="d-inline-flex gap-1"
+            >
+              fake challenge
+              <svg
+                aria-hidden="true"
+                className="octicon octicon-link-external"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                role="img"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "overflow": "visible",
+                    "userSelect": "none",
+                    "verticalAlign": "text-bottom",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <path
+                  d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                />
+              </svg>
+            </div>
+          </a>
         </h4>
         <div
           style={
@@ -20209,11 +20302,42 @@ exports[`Storyshots Components/ReviewCard Without Comment 1`] = `
           fake user
            -
            
-          <span
-            className="text-primary"
+          <a
+            className="text-primary text-decoration-none"
+            href="/curriculum/undefined?challenge=undefined"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onTouchStart={[Function]}
+            target="_blank"
           >
-            fake challenge
-          </span>
+            <div
+              className="d-inline-flex gap-1"
+            >
+              fake challenge
+              <svg
+                aria-hidden="true"
+                className="octicon octicon-link-external"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                role="img"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "overflow": "visible",
+                    "userSelect": "none",
+                    "verticalAlign": "text-bottom",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <path
+                  d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                />
+              </svg>
+            </div>
+          </a>
         </h4>
         <div
           style={
@@ -21636,11 +21760,42 @@ exports[`Storyshots Components/ReviewCard Without Username 1`] = `
           fake user
            -
            
-          <span
-            className="text-primary"
+          <a
+            className="text-primary text-decoration-none"
+            href="/curriculum/undefined?challenge=undefined"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onTouchStart={[Function]}
+            target="_blank"
           >
-            fake challenge
-          </span>
+            <div
+              className="d-inline-flex gap-1"
+            >
+              fake challenge
+              <svg
+                aria-hidden="true"
+                className="octicon octicon-link-external"
+                fill="currentColor"
+                focusable="false"
+                height={16}
+                role="img"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "overflow": "visible",
+                    "userSelect": "none",
+                    "verticalAlign": "text-bottom",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <path
+                  d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                />
+              </svg>
+            </div>
+          </a>
         </h4>
         <div
           style={

--- a/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
+++ b/__tests__/pages/review/__snapshots__/[lesson].test.js.snap
@@ -713,11 +713,32 @@ exports[`Lesson Page Should render new submissions 1`] = `
                     newbie
                      -
                      
-                    <span
-                      class="text-primary"
+                    <a
+                      class="text-primary text-decoration-none"
+                      href="/curriculum/js1?challenge=2"
+                      target="_blank"
                     >
-                      Sum of 2 Numbers
-                    </span>
+                      <div
+                        class="d-inline-flex gap-1"
+                      >
+                        Sum of 2 Numbers
+                        <svg
+                          aria-hidden="true"
+                          class="octicon octicon-link-external"
+                          fill="currentColor"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <path
+                            d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                          />
+                        </svg>
+                      </div>
+                    </a>
                   </h4>
                   <div
                     style="color: rgb(142, 142, 142); font-size: 0.85rem;"

--- a/components/ChallengeMaterial/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial/ChallengeMaterial.tsx
@@ -16,7 +16,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 import GiveStarCard from '../GiveStarCard'
-import _, { toNumber } from 'lodash'
+import _ from 'lodash'
 import Modal from 'react-bootstrap/Modal'
 import { SubmissionStatus, useAddCommentMutation } from '../../graphql'
 import DiffView from '../DiffView'
@@ -387,7 +387,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
       }
     })
   const [currentChallengeID, setCurrentChallenge] =
-    useState<CurrentChallengeID>(toNumber(challenge))
+    useState<CurrentChallengeID>(_.toNumber(challenge))
 
   const finalChallenge = {
     title: 'Challenges Completed!',

--- a/components/ChallengeMaterial/ChallengeMaterial.tsx
+++ b/components/ChallengeMaterial/ChallengeMaterial.tsx
@@ -16,7 +16,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 import GiveStarCard from '../GiveStarCard'
-import _ from 'lodash'
+import _, { toNumber } from 'lodash'
 import Modal from 'react-bootstrap/Modal'
 import { SubmissionStatus, useAddCommentMutation } from '../../graphql'
 import DiffView from '../DiffView'
@@ -30,6 +30,8 @@ import Error, { StatusCode } from '../Error'
 import ReviewStatus from '../ReviewStatus'
 import useBreakpoint from '../../helpers/useBreakpoint'
 import HighlightMarkdown from '../mdx/HighlightMarkdown/HighlightMarkdown'
+import { useRouter } from 'next/router'
+import { CURRICULUM_PATH } from '../../constants'
 
 dayjs.extend(relativeTime)
 dayjs.extend(LocalizedFormat)
@@ -84,6 +86,9 @@ export const ChallengeTitleCard: React.FC<ChallengeTitleCardProps> = ({
   challengeNum,
   setCurrentChallenge
 }) => {
+  const router = useRouter()
+  const { lessonSlug } = router.query
+
   const cardStyles: string[] = ['challenge-title-card']
   if (active) {
     cardStyles.push('challenge-title-card--active')
@@ -94,11 +99,19 @@ export const ChallengeTitleCard: React.FC<ChallengeTitleCardProps> = ({
     cardStyles.push('shadow-sm', 'border-0')
   }
 
+  const handleChallengeClick = () => {
+    router.push(`${CURRICULUM_PATH}/${lessonSlug}?challenge=${id}`, undefined, {
+      shallow: true
+    })
+
+    setCurrentChallenge(id)
+  }
+
   return (
     <div
       data-testid="challenge-title"
       className={`card mb-2 ${cardStyles.join(' ')}`}
-      onClick={() => setCurrentChallenge(id)}
+      onClick={handleChallengeClick}
     >
       <div className="card-body d-flex justify-content-between">
         <div>{`${challengeNum}. ${title}`}</div>
@@ -348,6 +361,10 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
   if (!challenges.length) {
     return <h1>No Challenges for this lesson</h1>
   }
+
+  const router = useRouter()
+  const { challenge } = router.query
+
   //create an object to evaluate the student's status with a challenge
   const userSubmissionsObject: UserSubmissionsObject = userSubmissions.reduce(
     (acc: UserSubmissionsObject, submission: Submission) => {
@@ -370,7 +387,7 @@ const ChallengeMaterial: React.FC<ChallengeMaterialProps> = ({
       }
     })
   const [currentChallengeID, setCurrentChallenge] =
-    useState<CurrentChallengeID>(null)
+    useState<CurrentChallengeID>(toNumber(challenge))
 
   const finalChallenge = {
     title: 'Challenges Completed!',

--- a/components/ReviewCard/ReviewCard.tsx
+++ b/components/ReviewCard/ReviewCard.tsx
@@ -26,6 +26,10 @@ import SelectIteration from '../SelectIteration'
 import Error, { StatusCode } from '../Error'
 import ReviewStatus from '../ReviewStatus'
 import styles from './reviewCard.module.scss'
+import Link from 'next/link'
+import { CURRICULUM_PATH } from '../../constants'
+import { useRouter } from 'next/router'
+import { LinkExternalIcon } from '@primer/octicons-react'
 dayjs.extend(relativeTime)
 
 type ReviewCardProps = {
@@ -152,6 +156,8 @@ const ReviewButtons: React.FC<{
 }
 
 export const ReviewCard: React.FC<ReviewCardProps> = ({ submissionData }) => {
+  const { lesson } = useRouter().query
+
   const { id, diff, user, challenge, lessonId, challengeId, status } =
     submissionData
   const context = useContext(GlobalContext)
@@ -221,7 +227,19 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({ submissionData }) => {
               <div>
                 <h4>
                   {user?.username} -{' '}
-                  <span className="text-primary">{challenge?.title}</span>
+                  <Link
+                    href={`${CURRICULUM_PATH}/${lesson}?challenge=${challenge.id}`}
+                  >
+                    <a
+                      className="text-primary text-decoration-none"
+                      target="_blank"
+                    >
+                      <div className="d-inline-flex gap-1">
+                        {challenge?.title}
+                        <LinkExternalIcon size="small" />
+                      </div>
+                    </a>
+                  </Link>
                 </h4>
                 {submissionState.createdAt && (
                   <Text color="lightgrey" size="sm">

--- a/components/ReviewCard/__snapshots__/ReviewCard.test.js.snap
+++ b/components/ReviewCard/__snapshots__/ReviewCard.test.js.snap
@@ -16,11 +16,32 @@ exports[`ReviewCard Component Should be able to add comment 1`] = `
             newbie
              -
              
-            <span
-              class="text-primary"
+            <a
+              class="text-primary text-decoration-none"
+              href="/curriculum/undefined?challenge=1"
+              target="_blank"
             >
-              Functional 3 Sum
-            </span>
+              <div
+                class="d-inline-flex gap-1"
+              >
+                Functional 3 Sum
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-link-external"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                  />
+                </svg>
+              </div>
+            </a>
           </h4>
           <div
             style="color: rgb(142, 142, 142); font-size: 0.85rem;"
@@ -819,11 +840,32 @@ exports[`ReviewCard Component Should be able to select previous submissions 1`] 
             newbie
              -
              
-            <span
-              class="text-primary"
+            <a
+              class="text-primary text-decoration-none"
+              href="/curriculum/undefined?challenge=1"
+              target="_blank"
             >
-              Functional 3 Sum
-            </span>
+              <div
+                class="d-inline-flex gap-1"
+              >
+                Functional 3 Sum
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-link-external"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                  />
+                </svg>
+              </div>
+            </a>
           </h4>
           <div
             style="color: rgb(142, 142, 142); font-size: 0.85rem;"
@@ -1673,11 +1715,32 @@ exports[`ReviewCard Component Should not be able to add comment when comment val
             newbie
              -
              
-            <span
-              class="text-primary"
+            <a
+              class="text-primary text-decoration-none"
+              href="/curriculum/undefined?challenge=1"
+              target="_blank"
             >
-              Functional 3 Sum
-            </span>
+              <div
+                class="d-inline-flex gap-1"
+              >
+                Functional 3 Sum
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-link-external"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                  />
+                </svg>
+              </div>
+            </a>
           </h4>
           <div
             style="color: rgb(142, 142, 142); font-size: 0.85rem;"
@@ -2476,11 +2539,32 @@ exports[`ReviewCard Component Should render incomplete diff 1`] = `
             newbie
              -
              
-            <span
-              class="text-primary"
+            <a
+              class="text-primary text-decoration-none"
+              href="/curriculum/undefined?challenge=1"
+              target="_blank"
             >
-              Functional 3 Sum
-            </span>
+              <div
+                class="d-inline-flex gap-1"
+              >
+                Functional 3 Sum
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-link-external"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                  />
+                </svg>
+              </div>
+            </a>
           </h4>
           <div
             style="color: rgb(142, 142, 142); font-size: 0.85rem;"
@@ -4080,11 +4164,32 @@ exports[`ReviewCard Component Should render incorrect diff 1`] = `
             newbie
              -
              
-            <span
-              class="text-primary"
+            <a
+              class="text-primary text-decoration-none"
+              href="/curriculum/undefined?challenge=1"
+              target="_blank"
             >
-              Functional 3 Sum
-            </span>
+              <div
+                class="d-inline-flex gap-1"
+              >
+                Functional 3 Sum
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-link-external"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                  />
+                </svg>
+              </div>
+            </a>
           </h4>
           <div
             style="color: rgb(142, 142, 142); font-size: 0.85rem;"
@@ -5684,11 +5789,32 @@ exports[`ReviewCard Component Should render single path submission 1`] = `
             newbie
              -
              
-            <span
-              class="text-primary"
+            <a
+              class="text-primary text-decoration-none"
+              href="/curriculum/undefined?challenge=1"
+              target="_blank"
             >
-              Functional 3 Sum
-            </span>
+              <div
+                class="d-inline-flex gap-1"
+              >
+                Functional 3 Sum
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-link-external"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                  />
+                </svg>
+              </div>
+            </a>
           </h4>
           <div
             style="color: rgb(142, 142, 142); font-size: 0.85rem;"
@@ -6059,11 +6185,32 @@ exports[`ReviewCard Component Should render submissions in other languages 1`] =
             newbie
              -
              
-            <span
-              class="text-primary"
+            <a
+              class="text-primary text-decoration-none"
+              href="/curriculum/undefined?challenge=1"
+              target="_blank"
             >
-              Functional 3 Sum
-            </span>
+              <div
+                class="d-inline-flex gap-1"
+              >
+                Functional 3 Sum
+                <svg
+                  aria-hidden="true"
+                  class="octicon octicon-link-external"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <path
+                    d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"
+                  />
+                </svg>
+              </div>
+            </a>
           </h4>
           <div
             style="color: rgb(142, 142, 142); font-size: 0.85rem;"


### PR DESCRIPTION
### Overview

This pull request adds two key features to address the issue. It includes a dynamic link to the challenge page from submission names in the /review page and introduces bookmarking for the active challenge on the /curriculum/[lesson] page. Test snapshots have also been updated.

### Changes

- Added dynamic links to submission names on the `/review` page for quick access to the corresponding challenge page.
- Implemented bookmarking for the active challenge on the `/curriculum/[lessonSlug]` page to enable direct referencing.
- Updated test snapshots

### Screenshot

![image](https://github.com/garageScript/c0d3-app/assets/35906419/d2bf2ed1-c662-4b0b-a45f-e926646a695d)

### Testing

#### Challenge bookmark

1. Go to `curriculum/js0`
2. Click on one of the challenges
3. Copy the URL and paste it into a new tab or refresh the page
4. Make sure the bookmarked challenge is the active one

#### Submission challenge link

1. Go to `review/js0`
2. Click on the submission challenge's name
3. Make sure the submission's challenge is the activated one

### Related PRs

- #3033 