### PR TITLE
Fixes an overflow caused by the CodeBlock component

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -10847,6 +10847,7 @@ exports[`Storyshots Components/HighlightMarkdown Basic 1`] = `
         "marginBlock": 20,
         "marginBottom": 0,
         "padding": "20px 20px 0 20px",
+        "wordBreak": "break-all",
       }
     }
   >
@@ -10936,6 +10937,7 @@ exports[`Storyshots Components/HighlightMarkdown With Language 1`] = `
         "marginBlock": 20,
         "marginBottom": 0,
         "padding": "20px 20px 0 20px",
+        "wordBreak": "break-all",
       }
     }
   >
@@ -31228,6 +31230,7 @@ exports[`Storyshots mdx/Codeblock  Component 1`] = `
       "marginBlock": 20,
       "marginBottom": 0,
       "padding": "20px 20px 0 20px",
+      "wordBreak": "break-all",
     }
   }
 >

--- a/__tests__/pages/curriculum/__snapshots__/[lessonSlug].test.js.snap
+++ b/__tests__/pages/curriculum/__snapshots__/[lessonSlug].test.js.snap
@@ -459,7 +459,7 @@ exports[`Lesson Page Should correctly render challenges page for students who ha
                       </p>
                       <pre
                         class="prism-code language-"
-                        style="color: rgb(36, 41, 46); background-color: rgb(247, 246, 243); padding: 20px 20px 0px 20px; margin-bottom: 0px; font-size: 14px; border-radius: 4px; margin-block: 20px;"
+                        style="color: rgb(36, 41, 46); background-color: rgb(247, 246, 243); padding: 20px 20px 0px 20px; margin-bottom: 0px; font-size: 14px; border-radius: 4px; margin-block: 20px; word-break: break-all;"
                       >
                         <div
                           class="token-line"
@@ -1188,7 +1188,7 @@ exports[`Lesson Page Should render correctly with valid lesson route 1`] = `
                       </p>
                       <pre
                         class="prism-code language-"
-                        style="color: rgb(36, 41, 46); background-color: rgb(247, 246, 243); padding: 20px 20px 0px 20px; margin-bottom: 0px; font-size: 14px; border-radius: 4px; margin-block: 20px;"
+                        style="color: rgb(36, 41, 46); background-color: rgb(247, 246, 243); padding: 20px 20px 0px 20px; margin-bottom: 0px; font-size: 14px; border-radius: 4px; margin-block: 20px; word-break: break-all;"
                       >
                         <div
                           class="token-line"

--- a/components/mdx/CodeBlock.tsx
+++ b/components/mdx/CodeBlock.tsx
@@ -19,7 +19,8 @@ const CodeBlock: React.FC<Props> = ({ children, className }) => {
             marginBottom: 0,
             fontSize: 14,
             borderRadius: 4,
-            marginBlock: 20
+            marginBlock: 20,
+            wordBreak: 'break-all'
           }}
         >
           {tokens.map((line, i) => (


### PR DESCRIPTION
### Changes

- Apply the CSS property `word-break` to the `CodeBlock` component so it doesn't cause an overflow

### Related issues

- #3044 