### PR TITLE
fix(husky): grep throws premature termination

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -15,9 +15,9 @@ changedFiles="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
 # changedFiles="$changedFiles"$'\n'"yarn.lock"
 # changedFiles="$changedFiles"$'\n'"package-lock.json"
 
-depsChanged=$(echo "$changedFiles" | grep -e "package-lock.json" -e "yarn.lock")
+depsChanged=$(echo "$changedFiles" | git grep -e "package-lock.json" -e "yarn.lock")
 
-prismaChanged=$(echo "$changedFiles" | grep -e "schema.prisma")
+prismaChanged=$(echo "$changedFiles" | git grep -e "schema.prisma")
 
 # Define update msg variable
 upgradeMsg=$(cat <<-DOC


### PR DESCRIPTION
### Problem

The current issue arises when the grep command fails to find a pattern in a text, resulting in an error code 1. This error is considered an error condition in the `husky.sh` file, leading to the premature termination of the script.

### Solution

To address this problem, my chosen solution is to replace the `grep` command with `git grep`. Unlike `grep`, `git grep` does not return an exit code of 1 when a pattern is not found. This change ensures that the error condition is no longer triggered, allowing the script to continue execution without premature termination.

While there are alternative approaches to handle this issue, such as using [the OR operator to return `true` when `grep -e` exits with a code >= 1](https://unix.stackexchange.com/a/330662), or [specifically suppressing the error by checking if `grep -e` returns an exit code of 1](https://unix.stackexchange.com/a/427598), I have opted for the simplicity of using `git grep` to effectively suppress the error.

### Changes

- Update the variables `depsChanged` & `prismaChanged` to use `git grep` to find the pattern

### Related issues

- Closes #3053 