### PR TITLE
Improve the lesson sidebar design

### DIFF
--- a/__tests__/pages/curriculum/[lessonSlug]/__snapshots__/[subLessonSlug].test.js.snap
+++ b/__tests__/pages/curriculum/[lessonSlug]/__snapshots__/[subLessonSlug].test.js.snap
@@ -3,60 +3,109 @@
 exports[`[subLessonSlug] Page should match screenshot 1`] = `
 <div>
   <div
-    class="lesson-wrapper card shadow-sm mt-3 d-block border-0 p-3 p-md-4 bg-white"
+    class="mt-3 sublesson__container"
+    data-testid="sublesson__container"
+    style="grid-template-columns: none;"
   >
-    <nav
-      aria-label="Sub-lesson Links"
-    >
-      <a
-        aria-current="page"
-        class="subtitle link-dark dark d-block"
-        href="/curriculum/js0/first_sub_lesson"
-      >
-        Part 1: first sub lesson
-      </a>
-      <a
-        class="subtitle text-muted d-block"
-        href="/curriculum/js0/second_sub_lesson"
-      >
-        Part 2: second sub lesson
-      </a>
-      <a
-        class="subtitle text-muted d-block"
-        href="/curriculum/js0/third_sub_lesson"
-      >
-        Part 3: third sub lesson
-      </a>
-    </nav>
-    <h1
-      class="MDX_h1"
-      id="first"
-    >
-      first
-    </h1>
-    <p>
-      simple
-    </p>
     <div
-      class="d-flex"
+      class="card shadow-sm border-0 sublesson__sidebar"
+      data-testid="toc"
+      style="position: initial;"
     >
-      <a
-        class="lessonLink next"
-        href="/curriculum/js0/second_sub_lesson"
+      <ul
+        class="p-md-4 toc__container"
       >
-        Next part: 
-        <span>
-          second sub lesson
-        </span>
+        <li
+          style="padding-left: 0rem;"
+        >
+          <a
+            class="MDX_a"
+            href="#heading1"
+            style="text-decoration: none;"
+          >
+            heading1
+          </a>
+        </li>
+        <li
+          style="padding-left: 1rem;"
+        >
+          <a
+            class="MDX_a"
+            href="#heading2"
+            style="text-decoration: none;"
+          >
+            heading2
+          </a>
+        </li>
+        <li
+          style="padding-left: 2rem;"
+        >
+          <a
+            class="MDX_a"
+            href="#heading3"
+            style="text-decoration: none;"
+          >
+            heading3
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="lesson-wrapper card shadow-sm  d-block border-0 p-3 p-md-4 bg-white"
+    >
+      <nav
+        aria-label="Sub-lesson Links"
+      >
+        <a
+          aria-current="page"
+          class="subtitle link-dark dark d-block"
+          href="/curriculum/js0/first_sub_lesson"
+        >
+          Part 1: first sub lesson
+        </a>
+        <a
+          class="subtitle text-muted d-block"
+          href="/curriculum/js0/second_sub_lesson"
+        >
+          Part 2: second sub lesson
+        </a>
+        <a
+          class="subtitle text-muted d-block"
+          href="/curriculum/js0/third_sub_lesson"
+        >
+          Part 3: third sub lesson
+        </a>
+      </nav>
+      <h1
+        class="MDX_h1"
+        id="first"
+      >
+        first
+      </h1>
+      <p>
+        simple
+      </p>
+      <div
+        class="d-flex"
+      >
+        <a
+          class="lessonLink next"
+          href="/curriculum/js0/second_sub_lesson"
+        >
+          Next part: 
+          <span>
+            second sub lesson
+          </span>
+        </a>
+      </div>
+      <a
+        class="MDX_a edit"
+        href="https://github.com/garageScript/c0d3-app/edit/master/some/fake/path"
+        title="Edit this page on Github"
+      >
+        Edit this page
       </a>
     </div>
-    <a
-      class="MDX_a edit"
-      href="https://github.com/garageScript/c0d3-app/edit/master/some/fake/path"
-      title="Edit this page on Github"
-    >
-      Edit this page
-    </a>
   </div>
 </div>
 `;

--- a/content/lessons/js0/sublesson/functions_and_execution_context.mdx
+++ b/content/lessons/js0/sublesson/functions_and_execution_context.mdx
@@ -3,8 +3,6 @@ title: Functions and execution context
 order: 2
 ---
 
-# Table of Contents
-
 # Functions
 
 Have you ever had to do the same thing (like making rice) over and over again

--- a/content/lessons/js0/sublesson/primitive_data_and_operators.mdx
+++ b/content/lessons/js0/sublesson/primitive_data_and_operators.mdx
@@ -3,8 +3,6 @@ title: Primitive data and operations
 order: 1
 ---
 
-# Table of Contents
-
 # Overview
 
 Why Learn JS? JavaScript is the only language that lets you build applications

--- a/content/lessons/js1/sublesson/hypertext_markup_language.mdx
+++ b/content/lessons/js1/sublesson/hypertext_markup_language.mdx
@@ -3,8 +3,6 @@ title: HyperText Markup Language
 order: 1
 ---
 
-# Table of Contents
-
 # Preflight
 
 This section contains a few questions for you to answer to make sure you

--- a/content/lessons/js1/sublesson/recursion_closure_and_async.mdx
+++ b/content/lessons/js1/sublesson/recursion_closure_and_async.mdx
@@ -3,8 +3,6 @@ title: Recursion, closure and async
 order: 2
 ---
 
-# Table of Contents
-
 # Interviewing
 
 During interviews for software engineering positions, your ability to write
@@ -901,9 +899,9 @@ problem.
 3. **Recursive case:** If the counter is still below 99, print 'The things I do
    for love', bring the counter one step closer to 99, and go again.
 
-   It might look strange to see `return love(counter + 1)` in the recursive case, but
-   only `return` in the base case. Shouldn't a function always either have a
-   return value or not?
+   It might look strange to see `return love(counter + 1)` in the recursive
+   case, but only `return` in the base case. Shouldn't a function always either
+   have a return value or not?
 
    Each of the 99 calls to `love` will pass its return value to the `love` that
    called it, and saying `return` is like saying `return undefined`. So the very

--- a/content/lessons/js2/sublesson/basic_array_functions.mdx
+++ b/content/lessons/js2/sublesson/basic_array_functions.mdx
@@ -3,8 +3,6 @@ title: Basic array functions
 order: 2
 ---
 
-# Table of Contents
-
 # Introduction
 
 So far, you have used variables to store singular values: a number, a boolean, a
@@ -1192,19 +1190,19 @@ removed = fruits2.splice(1)
      > to the end of an array. `Push()` returns the new length of the array.
 
    - Continue.
-  
+
 4. **Code**
 
-  ```jsx
-  const copyArray = (a, result=[]) => {
-    if (result.length === a.length) {
-      return result
-    }
-    result.push( a[result.length] )
-    return copyArray(a, result)
+```jsx
+const copyArray = (a, result = []) => {
+  if (result.length === a.length) {
+    return result
   }
-  ```
-  
+  result.push(a[result.length])
+  return copyArray(a, result)
+}
+```
+
 <Spoiler name = "Debrief">
     
 `push` was the most obvious choice for this task, because we could start out with an empty array and add all the elements to it. We could have also used `unshift` if we'd started from the end. In the next section, we'll learn a much easier way to copy arrays.

--- a/content/lessons/js2/sublesson/introduction_to_testing_inner_properties.mdx
+++ b/content/lessons/js2/sublesson/introduction_to_testing_inner_properties.mdx
@@ -3,8 +3,6 @@ title: Introduction to testing, inner Properties
 order: 1
 ---
 
-# Table of Contents
-
 <br />
 
 # Introduction to Testing

--- a/content/lessons/js2/sublesson/map_reduce_and_filter_functions.mdx
+++ b/content/lessons/js2/sublesson/map_reduce_and_filter_functions.mdx
@@ -3,8 +3,6 @@ title: Map, reduce, and filter functions
 order: 3
 ---
 
-# Table of Contents
-
 # Map
 
 Now that you know how to add and remove elements from arrays, we can now explore
@@ -1162,8 +1160,8 @@ understand how it works before moving on.
 
 </Spoiler>
 
-4. Write a function called matches that counts how many times a given
-   element occurs in an array.
+4. Write a function called matches that counts how many times a given element
+   occurs in an array.
 
    ```jsx
    matches(['Thor', 'Loki', 'Ant-Man', 'Loki'], 'Loki') // returns 2
@@ -1277,7 +1275,7 @@ understand how it works before moving on.
 4. **Code**
 
    ```jsx
-   const combineLess5 = (a) => {
+   const combineLess5 = a => {
      return a.reduce((acc, e) => {
        if (e.length >= 5) {
          return acc
@@ -1406,8 +1404,8 @@ When the function is running, `this` refers to the object that comes before `.`.
 ```jsx
 Array.prototype.last = function () {
   return this[this.length - 1]
-};
-[1, 2, 3].last() // When the last function is run, 'this' refers to [1,2,3]
+}
+;[1, 2, 3].last() // When the last function is run, 'this' refers to [1,2,3]
 const jackfruit = [1, 2, 3].last() // What is jackfruit?
 ```
 
@@ -1416,8 +1414,8 @@ const jackfruit = [1, 2, 3].last() // What is jackfruit?
 ```jsx
 Array.prototype.last = function () {
   return this[this.length - 1]
-};
-[1, 2, 3].last() // When the last function is run, this refers to [1,2,3]
+}
+;[1, 2, 3].last() // When the last function is run, this refers to [1,2,3]
 jackfruit = [1, 2, 3].last() // 3
 ```
 

--- a/content/lessons/js3/sublesson/objects.mdx
+++ b/content/lessons/js3/sublesson/objects.mdx
@@ -3,8 +3,6 @@ title: Objects
 order: 2
 ---
 
-# Table of Contents
-
 # Objects
 
 Objects are the most important concept in JavaScript. But wait, didn't we
@@ -1206,9 +1204,7 @@ environment.
 2. **Shape**
 
    ```jsx
-   const headers = () => {
-
-   }
+   const headers = () => {}
    ```
 
 3. **Explanation**
@@ -1937,8 +1933,7 @@ object `{}`, to store the results.
 
 ```jsx
 ;[9, 8, 7, 8, 7, 7, 7].getMostCommon()
-  // returns 7 because it is the most common element
-
+// returns 7 because it is the most common element
 ;['Batman', 8, 7, 'Batman', 'Robin'].getMostCommon()
 // returns "Batman" because it is the most common element
 ```
@@ -2493,8 +2488,8 @@ So your defined Array.prototype.push function will call `this.oldPush` which is
 also your defined `Array.prototype.push` function, so it just keeps calling
 itself forever.
 
-**This is an example of why it is considered bad practice to overwrite _built-in_
-Javascript prototypes and methods.**
+**This is an example of why it is considered bad practice to overwrite
+_built-in_ Javascript prototypes and methods.**
 
 </Spoiler>
 

--- a/content/lessons/js3/sublesson/preflight.mdx
+++ b/content/lessons/js3/sublesson/preflight.mdx
@@ -3,8 +3,6 @@ title: Preflight
 order: 1
 ---
 
-# Table of Contents
-
 # Preflight
 
 1. Write a function called mergeArrays that combines two arrays into one.

--- a/content/lessons/js3/sublesson/promises.mdx
+++ b/content/lessons/js3/sublesson/promises.mdx
@@ -3,8 +3,6 @@ title: Promises
 order: 3
 ---
 
-# Table of Contents
-
 # Function vs. Fat Arrow
 
 So far, you've learned two ways to write a function:
@@ -272,8 +270,8 @@ keyword provided by nodeJS. You've seen it used to export solution files to a
 test file.
 
 > Some modules are dropping support for commonJS. You may have to use `import`
-> instead of `require` and write `"type": "module"` into your `package.json` file.
-> Read more
+> instead of `require` and write `"type": "module"` into your `package.json`
+> file. Read more
 > [ESM modules](https://www.digitalocean.com/community/tutorials/js-modules-es6)
 
 ```jsx

--- a/content/lessons/js4/sublesson/classes.mdx
+++ b/content/lessons/js4/sublesson/classes.mdx
@@ -3,8 +3,6 @@ title: Classes
 order: 3
 ---
 
-# Table of Contents
-
 # Class Objects
 
 Now that we've learned some fundamentals of CSS and HTML layout, we'll turn our

--- a/content/lessons/js4/sublesson/css.mdx
+++ b/content/lessons/js4/sublesson/css.mdx
@@ -3,8 +3,6 @@ title: CSS
 order: 2
 ---
 
-# Table of Contents
-
 # CSS
 
 So far, we have learned that HTML is a collection of tags, which are

--- a/content/lessons/js4/sublesson/interactive_elements.mdx
+++ b/content/lessons/js4/sublesson/interactive_elements.mdx
@@ -3,8 +3,6 @@ title: Interactive Elements
 order: 1
 ---
 
-# Table of Contents
-
 # Test Driven Development (TDD)
 
 Usually the first section contains a few questions for you to answer to make
@@ -1809,7 +1807,8 @@ It helps to look at the [documentation](https://github.com/markedjs/marked)
 
 2. Add a keyup event listener to the input tag that grabs the input value.
 
-- Set the innerHTML to a function call of the input tag’s value: `marked.parse(value)`
+- Set the innerHTML to a function call of the input tag’s value:
+  `marked.parse(value)`
 
 </Spoiler>
 

--- a/content/lessons/js5/sublesson/request_and_response.mdx
+++ b/content/lessons/js5/sublesson/request_and_response.mdx
@@ -3,8 +3,6 @@ title: Request and response
 order: 1
 ---
 
-# Table of Contents
-
 # Intro
 
 In this section, you will be writing code that runs on the computer using
@@ -580,19 +578,19 @@ will be no verification needed.
 
   <Spoiler>
 
-  ```jsx
-  const startApp = () => {
-    fetch('https://js5.c0d3.com/auth/api/sessions')
-      .then(r => {
-        return r.json()
-      })
-      .then(body => {
-        if (body.error) {
-          return setupLogin()
-        }
-      })
-  }
-  ```
+```jsx
+const startApp = () => {
+  fetch('https://js5.c0d3.com/auth/api/sessions')
+    .then(r => {
+      return r.json()
+    })
+    .then(body => {
+      if (body.error) {
+        return setupLogin()
+      }
+    })
+}
+```
 
   </Spoiler>
 

--- a/content/lessons/js5/sublesson/server.mdx
+++ b/content/lessons/js5/sublesson/server.mdx
@@ -3,8 +3,6 @@ title: Server
 order: 2
 ---
 
-# Table of Contents
-
 # Setting up a project
 
 This section will teach you the steps you need to setup a project and review

--- a/content/lessons/js5/sublesson/systems_(optional).mdx
+++ b/content/lessons/js5/sublesson/systems_(optional).mdx
@@ -3,8 +3,6 @@ title: Systems (optional)
 order: 3
 ---
 
-# Table of Contents
-
 # Production Systems
 
 If your website is going to have 1000s of requests every minute, you will need

--- a/helpers/static/lessons.ts
+++ b/helpers/static/lessons.ts
@@ -21,6 +21,7 @@ export type SubLesson = {
   }
   source?: MDXRemoteSerializeResult
   subLessonSlug: string
+  headings: { text: string; depth: number }[]
 }
 
 const isURIEncodedOrThrow = (errorPrefix: string, slug: string) => {

--- a/helpers/static/parseMDX.ts
+++ b/helpers/static/parseMDX.ts
@@ -1,7 +1,6 @@
 import { serialize } from 'next-mdx-remote/serialize'
 import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import matter from 'gray-matter'
-import toc from 'remark-toc'
 import gfm from 'remark-gfm'
 import slug from 'remark-slug'
 import autolink from 'rehype-autolink-headings'
@@ -16,7 +15,7 @@ type ParsedMDX = {
 const getSource = (content: string) =>
   serialize(content, {
     mdxOptions: {
-      remarkPlugins: [slug, [toc, { maxDepth: 2 }], gfm],
+      remarkPlugins: [slug, gfm],
       rehypePlugins: [autolink]
     }
   })

--- a/scss/subLessonSlug.module.scss
+++ b/scss/subLessonSlug.module.scss
@@ -1,0 +1,19 @@
+.sublesson__container {
+  display: grid;
+  gap: 40px;
+  position: relative;
+  padding: 0;
+}
+
+.sublesson__sidebar {
+  top: 20px;
+  height: fit-content;
+  width: fit-content;
+}
+
+.toc__container {
+  list-style: none;
+  background: white;
+  width: fit-content;
+  height: fit-content;
+}


### PR DESCRIPTION
### Overview

This PR polishes and redesign the lesson sidebar by putting it inside a container to differentiate it from other elements, making it sticky so the student can easily navigate the lesson sections, and finally removing the `remark-toc` as it's now replaced with an in-house solution.

### Changes

- Extract the headings from an mdx source using `gray-matter`
- Update the sidebar UI
- Add new tests cases to the `subLesson` test file to cover the new changes
- Remove the text "Table of Contents" from all mdx files so it doesn't show in the compiled source
- Update snapshots

### Images

#### Before

![image](https://github.com/garageScript/c0d3-app/assets/35906419/0dab9337-2f60-4717-8c0d-868cf112c3e8)

#### After

![image](https://github.com/garageScript/c0d3-app/assets/35906419/ad972098-e9b4-4cba-8cfc-b529956b7de8)

#### On mobile

![image](https://github.com/garageScript/c0d3-app/assets/35906419/5d495329-820c-45c5-87d5-40deeece3f28)

### Subsequent changes

- Remove the package `remark-toc`
- Redesign the mobile view to make it collapsable
- Highlight the currently viewed section in the sidebar

### Related issues

- #2321 