### PR TITLE
Make the lesson TOC collapsable on mobile

### DIFF
--- a/__tests__/pages/curriculum/[lessonSlug]/[subLessonSlug].test.js
+++ b/__tests__/pages/curriculum/[lessonSlug]/[subLessonSlug].test.js
@@ -29,6 +29,7 @@ import { parseMDX } from '../../../../helpers/static/parseMDX'
 jest.mock('../../../../helpers/static/parseMDX')
 import dummyLessonsData from '../../../../__dummy__/lessonData'
 jest.mock('../../../../helpers/static/lessons')
+import userEvent from '@testing-library/user-event'
 
 describe('[subLessonSlug]', () => {
   const mockSlugs = [
@@ -210,6 +211,18 @@ describe('[subLessonSlug]', () => {
         'gridTemplateColumns: auto auto'
       )
       expect(screen.getByTestId('toc')).toHaveStyle('position: sticky')
+    })
+
+    test('should open accordion on mobile', async () => {
+      mockUseBreakpoint.mockReturnValueOnce(false)
+
+      render(<SubLessonPage {...props(false)} />)
+
+      const toggle = screen.getByTestId('accordion-toggle')
+      await userEvent.click(toggle)
+
+      const accordionCollapse = screen.getByTestId('accordion-collapse')
+      expect(accordionCollapse).toHaveClass('show')
     })
   })
 })

--- a/__tests__/pages/curriculum/[lessonSlug]/__snapshots__/[subLessonSlug].test.js.snap
+++ b/__tests__/pages/curriculum/[lessonSlug]/__snapshots__/[subLessonSlug].test.js.snap
@@ -12,40 +12,64 @@ exports[`[subLessonSlug] Page should match screenshot 1`] = `
       data-testid="toc"
       style="position: initial;"
     >
-      <ul
-        class="p-md-4 toc__container m-0 rounded"
+      <div
+        class="accordion"
       >
-        <li
-          style="padding-left: 0rem;"
+        <div
+          class="border-0 card"
         >
-          <a
-            class="MDX_a text-decoration-none"
-            href="#heading1"
+          <div
+            class="toc__header card-header"
           >
-            heading1
-          </a>
-        </li>
-        <li
-          style="padding-left: 1rem;"
-        >
-          <a
-            class="MDX_a text-decoration-none"
-            href="#heading2"
+            <button
+              class="toc__toggle"
+              data-testid="accordion-toggle"
+              type="button"
+            >
+              Table of Contents
+            </button>
+          </div>
+          <div
+            class="accordion-collapse collapse"
+            data-testid="accordion-collapse"
           >
-            heading2
-          </a>
-        </li>
-        <li
-          style="padding-left: 2rem;"
-        >
-          <a
-            class="MDX_a text-decoration-none"
-            href="#heading3"
-          >
-            heading3
-          </a>
-        </li>
-      </ul>
+            <div
+              class="toc__container card-body"
+            >
+              <li
+                style="padding-left: 0rem;"
+              >
+                <a
+                  class="MDX_a text-decoration-none"
+                  href="#heading1"
+                >
+                  heading1
+                </a>
+              </li>
+              <li
+                style="padding-left: 1rem;"
+              >
+                <a
+                  class="MDX_a text-decoration-none"
+                  href="#heading2"
+                >
+                  heading2
+                </a>
+              </li>
+              <li
+                style="padding-left: 2rem;"
+              >
+                <a
+                  class="MDX_a text-decoration-none"
+                  href="#heading3"
+                >
+                  heading3
+                </a>
+              </li>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <div
       class="card shadow-sm  d-block border-0 p-3 p-md-4 bg-white lesson-wrapper "

--- a/pages/curriculum/[lessonSlug]/[subLessonSlug].tsx
+++ b/pages/curriculum/[lessonSlug]/[subLessonSlug].tsx
@@ -96,7 +96,9 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({
     >
       <Accordion alwaysOpen={breakpoint} activeKey={activeKey}>
         <Card className="border-0">
-          <Card.Header className={styles.toc__header}>
+          <Card.Header
+            className={`${breakpoint ? '' : 'py-3'} ${styles.toc__header}`}
+          >
             <CustomToggle
               setToggle={setToggle}
               breakpoint={breakpoint}
@@ -106,7 +108,7 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({
             </CustomToggle>
           </Card.Header>
           <Accordion.Collapse eventKey="0" data-testid="accordion-collapse">
-            <Card.Body className={styles.toc__container}>
+            <Card.Body className={`rounded ${styles.toc__container}`}>
               {mapHeadingsToLi}
             </Card.Body>
           </Accordion.Collapse>

--- a/pages/curriculum/[lessonSlug]/[subLessonSlug].tsx
+++ b/pages/curriculum/[lessonSlug]/[subLessonSlug].tsx
@@ -147,7 +147,7 @@ const SubLessonPage: React.FC<Props> & WithLayout = ({
       }}
     >
       <TableOfContents
-        selectedSubLesson={selectedSubLesson as SubLesson}
+        selectedSubLesson={selectedSubLesson}
         breakpoint={breakpoint}
       />
       <div

--- a/scss/subLessonSlug.module.scss
+++ b/scss/subLessonSlug.module.scss
@@ -1,6 +1,8 @@
+@use './colors.module.scss';
+
 .sublesson__container {
   display: grid;
-  gap: 40px;
+  gap: 1rem;
   position: relative;
   padding: 0;
 }
@@ -8,12 +10,23 @@
 .sublesson__sidebar {
   top: 20px;
   height: fit-content;
-  width: fit-content;
 }
 
 .toc__container {
   list-style: none;
-  background: white;
-  width: fit-content;
+  background: colors.$fg-light;
   height: fit-content;
+}
+
+.toc__header {
+  background-color: colors.$bg-white;
+}
+
+.toc__toggle {
+  background: transparent;
+  border: 0;
+  font-family: Inter;
+  width: 100%;
+  text-align: left;
+  cursor: default;
 }

--- a/scss/subLessonSlug.module.scss
+++ b/scss/subLessonSlug.module.scss
@@ -28,5 +28,5 @@
   font-family: Inter;
   width: 100%;
   text-align: left;
-  cursor: default;
+  padding: 0;
 }


### PR DESCRIPTION
### Changes

- Instead of the TOC taking the full space on mobile, it's now closed by default
- Update the `subLesson` test file
- Update the `subLesson` style file

### UI screenshots

Always opened
 ![image](https://github.com/garageScript/c0d3-app/assets/35906419/7ec388c4-d3a1-4736-a484-bf80648309ad)
Closed 
![image](https://github.com/garageScript/c0d3-app/assets/35906419/c3a7690b-0f41-44f7-8d84-632a1a58fcf6)
Opened
 ![image](https://github.com/garageScript/c0d3-app/assets/35906419/b8b49a1c-8846-470e-a46a-d42b32c20560)

### Related PRs

- Closes #3092 
