### PR TITLE
Improve the lesson page spacing and elements

### DIFF
--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -31169,7 +31169,7 @@ exports[`Storyshots mdx/ChallengeBar Standart 1`] = `
   className="my-3 mt-5"
 >
   <div
-    className="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white px-4 py-4 border-0"
+    className="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white p-4 border-0"
   >
     <div>
       <span
@@ -31187,7 +31187,7 @@ exports[`Storyshots mdx/ChallengeBar Standart 1`] = `
       className="d-flex flex-column gap-2"
     >
       <a
-        className="btn btn-light text-primary py-3 px-3 noUnderline"
+        className="btn btn-light text-primary p-3 noUnderline"
         href="/"
         rel="noopener noreferrer"
         target="_blank"

--- a/__tests__/__snapshots__/storyshots.test.js.snap
+++ b/__tests__/__snapshots__/storyshots.test.js.snap
@@ -31166,39 +31166,45 @@ exports[`Storyshots mdx/BlockQuote Quote 1`] = `
 
 exports[`Storyshots mdx/ChallengeBar Standart 1`] = `
 <div
-  className="d-flex justify-content-center my-3"
+  className="my-3 mt-5"
 >
   <div
-    className="card shadow-sm bg-primary text-white px-4 py-2 border-0"
+    className="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white px-4 py-4 border-0"
   >
-    <h1
-      className="text-center fw-bold align-self-center"
-    >
-      Master your skill by solving challenges
-    </h1>
-    <a
-      className="text-white text-center  noUnderline"
-      href="/docs/setup#submitting-challenges"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      Submitting challenges
-    </a>
-    <p
-      className="px-2 m-0 text-center fw-bold"
-    >
-      Complete the first seven of JS0 challenges
-    </p>
+    <div>
+      <span
+        className="align-self-center fs-4"
+      >
+        Master your skill by solving challenges
+      </span>
+      <p
+        className="m-0"
+      >
+        Complete the first seven of JS0 challenges
+      </p>
+    </div>
     <div
-      className="text-center"
+      className="d-flex flex-column gap-2"
     >
       <a
-        className="btn btn-light mt-2 text-primary  noUnderline"
+        className="btn btn-light text-primary py-3 px-3 noUnderline"
         href="/"
         rel="noopener noreferrer"
         target="_blank"
       >
         View Challenges
+      </a>
+      <a
+        className="MDX_a"
+      >
+        <a
+          className="text-white d-block noUnderline"
+          href="/docs/setup#submitting-challenges"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          How to submit challenges?
+        </a>
       </a>
     </div>
   </div>

--- a/__tests__/pages/curriculum/[lessonSlug]/__snapshots__/[subLessonSlug].test.js.snap
+++ b/__tests__/pages/curriculum/[lessonSlug]/__snapshots__/[subLessonSlug].test.js.snap
@@ -72,59 +72,67 @@ exports[`[subLessonSlug] Page should match screenshot 1`] = `
       </div>
     </div>
     <div
-      class="card shadow-sm  d-block border-0 p-3 p-md-4 bg-white lesson-wrapper "
+      class="card shadow-sm d-flex flex-column gap-5 border-0 p-3 p-md-4 bg-white lesson-wrapper"
     >
-      <nav
-        aria-label="Sub-lesson Links"
-      >
-        <a
-          aria-current="page"
-          class="subtitle link-dark dark d-block"
-          href="/curriculum/js0/first_sub_lesson"
+      <div>
+        <nav
+          aria-label="Sub-lesson Links"
         >
-          Part 1: first sub lesson
-        </a>
-        <a
-          class="subtitle text-muted d-block"
-          href="/curriculum/js0/second_sub_lesson"
+          <a
+            aria-current="page"
+            class="subtitle link-dark dark d-block"
+            href="/curriculum/js0/first_sub_lesson"
+          >
+            Part 1: first sub lesson
+          </a>
+          <a
+            class="subtitle text-muted d-block"
+            href="/curriculum/js0/second_sub_lesson"
+          >
+            Part 2: second sub lesson
+          </a>
+          <a
+            class="subtitle text-muted d-block"
+            href="/curriculum/js0/third_sub_lesson"
+          >
+            Part 3: third sub lesson
+          </a>
+        </nav>
+        <h1
+          class="MDX_h1"
+          id="first"
         >
-          Part 2: second sub lesson
-        </a>
-        <a
-          class="subtitle text-muted d-block"
-          href="/curriculum/js0/third_sub_lesson"
+          first
+        </h1>
+        <p
+          class="MDX_p"
         >
-          Part 3: third sub lesson
-        </a>
-      </nav>
-      <h1
-        class="MDX_h1"
-        id="first"
-      >
-        first
-      </h1>
-      <p>
-        simple
-      </p>
-      <div
-        class="d-flex"
-      >
-        <a
-          class="lessonLink next"
-          href="/curriculum/js0/second_sub_lesson"
+          simple
+        </p>
+        <div
+          class="mt-5"
         >
-          Next part: 
-          <span>
-            second sub lesson
-          </span>
-        </a>
+          <div
+            class="d-flex"
+          >
+            <a
+              class="lessonLink next"
+              href="/curriculum/js0/second_sub_lesson"
+            >
+              Next part: 
+              <span>
+                second sub lesson
+              </span>
+            </a>
+          </div>
+        </div>
       </div>
       <a
         class="MDX_a edit"
         href="https://github.com/garageScript/c0d3-app/edit/master/some/fake/path"
         title="Edit this page on Github"
       >
-        Edit this page
+        Edit this page on Github
       </a>
     </div>
   </div>

--- a/__tests__/pages/docs/__snapshots__/[docSlug].test.js.snap
+++ b/__tests__/pages/docs/__snapshots__/[docSlug].test.js.snap
@@ -38,7 +38,7 @@ exports[`[docSlug] Page should match screenshot 1`] = `
       href="https://github.com/garageScript/c0d3-app/edit/master/some/fake/path"
       title="Edit this page on Github"
     >
-      Edit this page
+      Edit this page on Github
     </a>
   </div>
 </div>

--- a/components/EditPage/EditPage.tsx
+++ b/components/EditPage/EditPage.tsx
@@ -10,9 +10,9 @@ const EditPage: React.FC<Props> = ({ filePath }) => {
     <a
       href={`https://github.com/garageScript/c0d3-app/edit/master/${filePath}`}
       title="Edit this page on Github"
-      className={`${styles['MDX_a']} ${styles['edit']}`}
+      className={`${styles.MDX_a} ${styles.edit}`}
     >
-      Edit this page
+      Edit this page on Github
     </a>
   )
 }

--- a/components/mdx/ChallengBar.tsx
+++ b/components/mdx/ChallengBar.tsx
@@ -9,7 +9,7 @@ const ChallengeBar: React.FC<{
 }> = ({ href, description, title }) => {
   return (
     <div className="my-3 mt-5">
-      <div className="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white px-4 py-4 border-0">
+      <div className="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white p-4 border-0">
         <div>
           <span className="align-self-center fs-4">{title}</span>
           <p className="m-0">{description}</p>
@@ -17,7 +17,7 @@ const ChallengeBar: React.FC<{
         <div className="d-flex flex-column gap-2">
           <NavLink
             path={href}
-            className="btn btn-light text-primary py-3 px-3"
+            className="btn btn-light text-primary p-3"
             external
           >
             View Challenges

--- a/components/mdx/ChallengBar.tsx
+++ b/components/mdx/ChallengBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import NavLink from '../NavLink'
+import MDXcomponents from '../../helpers/mdxComponents'
 
 const ChallengeBar: React.FC<{
   href: string
@@ -7,26 +8,29 @@ const ChallengeBar: React.FC<{
   title: string
 }> = ({ href, description, title }) => {
   return (
-    <div className="d-flex justify-content-center my-3">
-      <div className="card shadow-sm bg-primary text-white px-4 py-2 border-0">
-        <h1 className="text-center fw-bold align-self-center">{title}</h1>
-        <NavLink
-          path="/docs/setup#submitting-challenges"
-          className="text-white text-center "
-          external
-        >
-          Submitting challenges
-        </NavLink>
-        <p className="px-2 m-0 text-center fw-bold">{description}</p>
-
-        <div className="text-center">
+    <div className="my-3 mt-5">
+      <div className="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white px-4 py-4 border-0">
+        <div>
+          <span className="align-self-center fs-4">{title}</span>
+          <p className="m-0">{description}</p>
+        </div>
+        <div className="d-flex flex-column gap-2">
           <NavLink
             path={href}
-            className={`btn btn-light mt-2 text-primary `}
+            className="btn btn-light text-primary py-3 px-3"
             external
           >
             View Challenges
           </NavLink>
+          <MDXcomponents.a>
+            <NavLink
+              path="/docs/setup#submitting-challenges"
+              className="text-white d-block"
+              external
+            >
+              How to submit challenges?
+            </NavLink>
+          </MDXcomponents.a>
         </div>
       </div>
     </div>

--- a/components/mdx/__snapshots__/ChallengeBar.test.js.snap
+++ b/components/mdx/__snapshots__/ChallengeBar.test.js.snap
@@ -3,28 +3,35 @@
 exports[`ChallengeBar component Should created redirect based on input 1`] = `
 <div>
   <div
-    class="d-flex justify-content-center my-3"
+    class="my-3 mt-5"
   >
     <div
-      class="card shadow-sm bg-primary text-white px-4 py-2 border-0"
+      class="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white px-4 py-4 border-0"
     >
-      <h1
-        class="text-center fw-bold align-self-center"
-      />
-      <a
-        class="text-white text-center  noUnderline"
-        href="/docs/setup#submitting-challenges"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Submitting challenges
-      </a>
-      <p
-        class="px-2 m-0 text-center fw-bold"
-      />
+      <div>
+        <span
+          class="align-self-center fs-4"
+        />
+        <p
+          class="m-0"
+        />
+      </div>
       <div
-        class="text-center"
-      />
+        class="d-flex flex-column gap-2"
+      >
+        <a
+          class="MDX_a"
+        >
+          <a
+            class="text-white d-block noUnderline"
+            href="/docs/setup#submitting-challenges"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            How to submit challenges?
+          </a>
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/components/mdx/__snapshots__/ChallengeBar.test.js.snap
+++ b/components/mdx/__snapshots__/ChallengeBar.test.js.snap
@@ -6,7 +6,7 @@ exports[`ChallengeBar component Should created redirect based on input 1`] = `
     class="my-3 mt-5"
   >
     <div
-      class="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white px-4 py-4 border-0"
+      class="d-flex flex-col flex-md-row gap-3 justify-content-between align-items-none align-items-md-center card shadow-sm bg-primary text-white p-4 border-0"
     >
       <div>
         <span

--- a/helpers/mdxComponents.tsx
+++ b/helpers/mdxComponents.tsx
@@ -28,6 +28,7 @@ const MDXcomponents = {
   ul: (props: any) => <ul className={`${styles['MDX_ul']}`} {...props} />,
   ol: (props: any) => <ol className={`${styles['MDX_ol']}`} {...props} />,
   a: (props: any) => <a className={`${styles['MDX_a']}`} {...props} />,
+  p: (props: any) => <p className={`${styles['MDX_p']}`} {...props} />,
   td: (props: any) => <td className={`${styles['MDX_td']}`} {...props} />,
   th: (props: any) => <th className={`${styles['MDX_th']}`} {...props} />
 }

--- a/pages/curriculum/[lessonSlug]/[subLessonSlug].tsx
+++ b/pages/curriculum/[lessonSlug]/[subLessonSlug].tsx
@@ -151,30 +151,36 @@ const SubLessonPage: React.FC<Props> & WithLayout = ({
         breakpoint={breakpoint}
       />
       <div
-        className={`card shadow-sm  d-block border-0 p-3 p-md-4 bg-white ${mdxStyles['lesson-wrapper']} `}
+        className={`card shadow-sm d-flex flex-column gap-5 border-0 p-3 p-md-4 bg-white ${mdxStyles['lesson-wrapper']}`}
       >
-        <Title
-          title={`${selectedSubLesson.frontMatter.title} | ${lessonSlug} | C0D3`}
-        />
-        <ScrollTopArrow />
-        {hasMultipleSubLessons && (
-          <SubLessonLinks
-            subLessons={subLessons}
-            lessonSlug={lessonSlug}
-            subLessonSlug={subLessonSlug}
+        <div>
+          <Title
+            title={`${selectedSubLesson.frontMatter.title} | ${lessonSlug} | C0D3`}
           />
-        )}
+          <ScrollTopArrow />
+          {hasMultipleSubLessons && (
+            <SubLessonLinks
+              subLessons={subLessons}
+              lessonSlug={lessonSlug}
+              subLessonSlug={subLessonSlug}
+            />
+          )}
 
-        <MDXRemote {...selectedSubLesson.source!} components={MDXcomponents} />
-
-        {hasMultipleSubLessons && (
-          <NextPreviousLessons
-            subLessons={subLessons}
-            subLessonSlug={subLessonSlug}
-            lessonSlug={lessonSlug}
+          <MDXRemote
+            {...selectedSubLesson.source!}
+            components={MDXcomponents}
           />
-        )}
 
+          {hasMultipleSubLessons && (
+            <div className="mt-5">
+              <NextPreviousLessons
+                subLessons={subLessons}
+                subLessonSlug={subLessonSlug}
+                lessonSlug={lessonSlug}
+              />
+            </div>
+          )}
+        </div>
         <EditPage filePath={githubFilePath} />
       </div>
     </div>

--- a/scss/_text.module.scss
+++ b/scss/_text.module.scss
@@ -17,7 +17,7 @@ h2 {
 
 h3 {
   @include rubik-bold;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 160%;
 }
 

--- a/scss/mdx.module.scss
+++ b/scss/mdx.module.scss
@@ -10,6 +10,12 @@
 .MDX_h3 {
   font-weight: 600;
   display: inline-block;
+  margin-top: 2em;
+  margin-bottom: 0.8em;
+}
+
+.MDX_p {
+  margin-bottom: 1.2em;
 }
 
 .MDX_ol > li::marker {
@@ -51,10 +57,6 @@
   display: flex;
   justify-content: center;
   text-decoration: none;
-  &::before {
-    content: '\270E';
-    transform: rotate(90deg);
-  }
   &:hover {
     text-decoration: none;
   }


### PR DESCRIPTION
### Changes

- Increase the h3 font size from 16px to 20px because when the text is short, it's hard to read it
- Add a top margin for every heading & paragraph element to make the content look less cramped
- Remove the pencil icon from the text "Edit this page" to simplify the look of it (the icon isn't compatible with the icons we use in the app)
- Add spacing between the lesson content elements: next/previous lesson, lesson text content, and challenge bar
- Redesign the ChallengeBar

### Screenshots

**Before & After headings:**

> before
![image](https://github.com/garageScript/c0d3-app/assets/35906419/309cb2e8-cd52-4965-8c7b-6b4b8ac852ed)

> after:
![image](https://github.com/garageScript/c0d3-app/assets/35906419/292f7487-0b67-4e33-9cc4-8d6efdd6ca75)

**pencil icon**

> before:
![image](https://github.com/garageScript/c0d3-app/assets/35906419/444e79f2-eff5-4a90-a3f1-036c16e57693)

> after:
![image](https://github.com/garageScript/c0d3-app/assets/35906419/8baa2df3-6528-4e10-b695-e08088339c20)

**Challenge bar**

> before:
![image](https://github.com/garageScript/c0d3-app/assets/35906419/eb62f487-c209-43c7-9306-45e22397706c)

> after:
![image](https://github.com/garageScript/c0d3-app/assets/35906419/72075bfa-1b8a-4fcf-9b39-86053980051e)

**Lesson content elements**

> before:
![image](https://github.com/garageScript/c0d3-app/assets/35906419/fe514c4c-3fa1-4d1f-b395-33798529231f)

> after:
![image](https://github.com/garageScript/c0d3-app/assets/35906419/b2046d1c-4827-4fb5-9e31-16b52a969ecd)


### Related PRs

#2321 
